### PR TITLE
Add Apple HIG compliance: accessibility, reduce motion, Dynamic Type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,3 +50,26 @@ Open `ios/SnapGrid/SnapGrid.xcodeproj` in Xcode 15.4+. Bundle ID: `com.snapgrid.
 Native SwiftUI + SwiftData rewrite. Uses XcodeGen (`SnapGrid/project.yml`).
 
 Open `SnapGrid/SnapGrid.xcodeproj` in Xcode. Bundle ID: `com.snapgrid.app`.
+
+## Apple HIG Compliance (Mac & iOS)
+
+All native SwiftUI code must follow Apple's Human Interface Guidelines. When writing or modifying views:
+
+**Accessibility (non-negotiable):**
+- Every interactive element needs `.accessibilityLabel()` — buttons, grid items, tabs, badges
+- Icon-only buttons always need a label (the icon is not enough for VoiceOver)
+- Status elements (toasts, badges, progress) need `.accessibilityAddTraits(.isStatusElement)`
+- Check `@Environment(\.accessibilityReduceMotion)` before applying spring animations, staggered reveals, or continuous animations (shimmer). Use `.easeInOut(duration: 0.15)` or `.identity` as fallback
+- Use semantic text styles (`.headline`, `.body`, `.caption`) instead of `.system(size: N)` so text scales with Dynamic Type
+
+**Colors & system integration:**
+- Use `Color.accentColor` for selection indicators and interactive highlights — never hardcode `Color.blue`
+- When defining custom adaptive colors, add Increase Contrast variants by checking `NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast`
+- Custom background colors are acceptable for media apps, but interactive/text colors should respect system accessibility settings
+
+**macOS-specific patterns:**
+- Settings must use `Settings {}` scene with `TabView` and `.formStyle(.grouped)`
+- Provide comprehensive menu bar commands with standard keyboard shortcuts
+- Support `Cmd+Click` toggle, `Shift+Click` range, and rubber band selection
+- Windows should have a title (even if title bar is hidden) for Mission Control/Window menu
+- Persist view state (`@AppStorage`/`@SceneStorage`) so the app restores on relaunch

--- a/SnapGrid/SnapGrid/App/AppState.swift
+++ b/SnapGrid/SnapGrid/App/AppState.swift
@@ -6,9 +6,22 @@ import SwiftUI
 final class AppState {
     var selectedIds: Set<String> = []
     var anchorId: String?
-    var activeSpaceId: String?
+
+    init() {
+        // Restore persisted state
+        if let saved = UserDefaults.standard.string(forKey: "thumbnailSize"),
+           let size = ThumbnailSize(rawValue: saved) {
+            thumbnailSize = size
+        }
+        activeSpaceId = UserDefaults.standard.string(forKey: "lastActiveSpaceId")
+    }
+    var activeSpaceId: String? {
+        didSet { UserDefaults.standard.set(activeSpaceId, forKey: "lastActiveSpaceId") }
+    }
     var searchText: String = ""
-    var thumbnailSize: ThumbnailSize = .medium
+    var thumbnailSize: ThumbnailSize = .medium {
+        didSet { UserDefaults.standard.set(thumbnailSize.rawValue, forKey: "thumbnailSize") }
+    }
     var detailItem: String? = nil  // MediaItem id
     var detailSourceFrame: CGRect? = nil  // Global frame of tapped thumbnail for hero animation
     var detailSwipeProgress: CGFloat = 0  // 0 = viewing current item, 1 = fully swiped to next

--- a/SnapGrid/SnapGrid/App/SnapGridApp.swift
+++ b/SnapGrid/SnapGrid/App/SnapGridApp.swift
@@ -28,7 +28,7 @@ struct SnapGridApp: App {
     }
 
     var body: some Scene {
-        WindowGroup {
+        WindowGroup("SnapGrid") {
             ContentView()
                 .task { KeySyncService.syncToiCloud() }
         }
@@ -99,6 +99,12 @@ struct SnapGridApp: App {
                     NotificationCenter.default.post(name: .undoDelete, object: nil)
                 }
                 .keyboardShortcut("z")
+
+                Button("Redo") {}
+                    .keyboardShortcut("z", modifiers: [.command, .shift])
+                    .disabled(true)
+
+                Divider()
 
                 Button("Delete") {
                     NotificationCenter.default.post(name: .deleteSelected, object: nil)

--- a/SnapGrid/SnapGrid/Extensions/Color+Theme.swift
+++ b/SnapGrid/SnapGrid/Extensions/Color+Theme.swift
@@ -2,42 +2,81 @@ import SwiftUI
 import AppKit
 
 extension Color {
-    // Adaptive colors — respond to light/dark appearance automatically
+    // Adaptive colors — respond to light/dark appearance and Increase Contrast automatically.
+    // Increase Contrast variants boost text/border contrast for accessibility compliance.
+
+    private static let highContrast = NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast
 
     static let snapBackground = Color(nsColor: NSColor(name: nil) { appearance in
-        appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-            ? NSColor(red: 0.078, green: 0.078, blue: 0.078, alpha: 1.0)  // #141414
-            : NSColor(red: 0.941, green: 0.961, blue: 0.984, alpha: 1.0)  // #f0f5fb
+        let dark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        if dark {
+            return highContrast
+                ? NSColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0)        // #000000
+                : NSColor(red: 0.078, green: 0.078, blue: 0.078, alpha: 1.0)  // #141414
+        } else {
+            return highContrast
+                ? NSColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)        // #FFFFFF
+                : NSColor(red: 0.941, green: 0.961, blue: 0.984, alpha: 1.0)  // #f0f5fb
+        }
     })
 
     static let snapForeground = Color(nsColor: NSColor(name: nil) { appearance in
-        appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-            ? NSColor(red: 0.98, green: 0.98, blue: 0.98, alpha: 1.0)     // #FAFAFA
-            : NSColor(red: 0.008, green: 0.031, blue: 0.09, alpha: 1.0)   // #020817
+        let dark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        if dark {
+            return NSColor(red: 0.98, green: 0.98, blue: 0.98, alpha: 1.0)    // #FAFAFA
+        } else {
+            return NSColor(red: 0.008, green: 0.031, blue: 0.09, alpha: 1.0)  // #020817
+        }
     })
 
     static let snapCard = Color(nsColor: NSColor(name: nil) { appearance in
-        appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-            ? NSColor(red: 0.122, green: 0.122, blue: 0.122, alpha: 1.0)  // #1F1F1F
-            : NSColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)       // #FFFFFF
+        let dark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        if dark {
+            return highContrast
+                ? NSColor(red: 0.098, green: 0.098, blue: 0.098, alpha: 1.0)  // #191919
+                : NSColor(red: 0.122, green: 0.122, blue: 0.122, alpha: 1.0)  // #1F1F1F
+        } else {
+            return NSColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)       // #FFFFFF
+        }
     })
 
     static let snapMuted = Color(nsColor: NSColor(name: nil) { appearance in
-        appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-            ? NSColor(red: 0.176, green: 0.176, blue: 0.176, alpha: 1.0)  // #2D2D2D
-            : NSColor(red: 0.945, green: 0.961, blue: 0.976, alpha: 1.0)  // #f1f5f9
+        let dark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        if dark {
+            return highContrast
+                ? NSColor(red: 0.2, green: 0.2, blue: 0.2, alpha: 1.0)        // #333333
+                : NSColor(red: 0.176, green: 0.176, blue: 0.176, alpha: 1.0)  // #2D2D2D
+        } else {
+            return highContrast
+                ? NSColor(red: 0.918, green: 0.929, blue: 0.945, alpha: 1.0)  // #eaedF1
+                : NSColor(red: 0.945, green: 0.961, blue: 0.976, alpha: 1.0)  // #f1f5f9
+        }
     })
 
     static let snapMutedForeground = Color(nsColor: NSColor(name: nil) { appearance in
-        appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-            ? NSColor(red: 0.651, green: 0.651, blue: 0.651, alpha: 1.0)  // #A6A6A6
-            : NSColor(red: 0.392, green: 0.455, blue: 0.545, alpha: 1.0)  // #64748b
+        let dark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        if dark {
+            return highContrast
+                ? NSColor(red: 0.78, green: 0.78, blue: 0.78, alpha: 1.0)     // #C7C7C7
+                : NSColor(red: 0.651, green: 0.651, blue: 0.651, alpha: 1.0)  // #A6A6A6
+        } else {
+            return highContrast
+                ? NSColor(red: 0.29, green: 0.33, blue: 0.40, alpha: 1.0)     // #4A5466
+                : NSColor(red: 0.392, green: 0.455, blue: 0.545, alpha: 1.0)  // #64748b
+        }
     })
 
     static let snapBorder = Color(nsColor: NSColor(name: nil) { appearance in
-        appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-            ? NSColor(red: 0.122, green: 0.122, blue: 0.122, alpha: 1.0)  // #1F1F1F
-            : NSColor(red: 0.886, green: 0.910, blue: 0.941, alpha: 1.0)  // #e2e8f0
+        let dark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        if dark {
+            return highContrast
+                ? NSColor(red: 0.25, green: 0.25, blue: 0.25, alpha: 1.0)     // #404040
+                : NSColor(red: 0.122, green: 0.122, blue: 0.122, alpha: 1.0)  // #1F1F1F
+        } else {
+            return highContrast
+                ? NSColor(red: 0.78, green: 0.80, blue: 0.83, alpha: 1.0)     // #C7CCD4
+                : NSColor(red: 0.886, green: 0.910, blue: 0.941, alpha: 1.0)  // #e2e8f0
+        }
     })
 
     static let snapAccent = Color(nsColor: NSColor(name: nil) { appearance in

--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -19,6 +19,7 @@ struct ContentView: View {
     /// Pre-computed search scores keyed by item ID. Empty = no active search.
     @State private var searchScores: [String: Double] = [:]
     @State private var isSearchActive = false
+    @State private var isSearchFieldPresented = false
 
     private func itemsForSpace(_ spaceId: String?) -> [MediaItem] {
         var items = allItems
@@ -158,7 +159,7 @@ struct ContentView: View {
             }
         }
         .frame(minWidth: 540, minHeight: 400)
-        .searchable(text: $appState.searchText, placement: .toolbar, prompt: "Search patterns, descriptions...")
+        .searchable(text: $appState.searchText, isPresented: $isSearchFieldPresented, placement: .toolbar, prompt: "Search patterns, descriptions...")
         .toolbar {
             ToolbarItem(placement: .principal) {
                 Spacer()
@@ -182,14 +183,7 @@ struct ContentView: View {
             },
             onCreateNewSpace: { createSpace() },
             onFocusSearch: {
-                // Search from the theme frame (contentView's superview) to reach
-                // toolbar views — .searchable places NSSearchField in the toolbar,
-                // which is outside contentView's hierarchy
-                if let window = NSApp.keyWindow,
-                   let rootView = window.contentView?.superview,
-                   let searchField = findSearchField(in: rootView) {
-                    window.makeFirstResponder(searchField)
-                }
+                isSearchFieldPresented = true
             },
             onSelectAll: { appState.selectAll(activeFilteredItems.map(\.id)) },
             onSwitchToSpace: { digit in
@@ -727,15 +721,6 @@ struct ContentView: View {
         Task {
             await importService.analyzeItem(item, context: modelContext)
         }
-    }
-
-    private func findSearchField(in view: NSView?) -> NSSearchField? {
-        guard let view else { return nil }
-        if let searchField = view as? NSSearchField { return searchField }
-        for subview in view.subviews {
-            if let found = findSearchField(in: subview) { return found }
-        }
-        return nil
     }
 
 }

--- a/SnapGrid/SnapGrid/Views/Detail/HeroDetailOverlay.swift
+++ b/SnapGrid/SnapGrid/Views/Detail/HeroDetailOverlay.swift
@@ -51,6 +51,7 @@ struct HeroDetailOverlay: View {
 
     @Environment(VideoPreviewManager.self) private var videoPreview
     @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// Captured at open time — stays stable even when parent re-filters.
     @State private var items: [MediaItem]
     @State private var currentIndex: Int
@@ -243,7 +244,7 @@ struct HeroDetailOverlay: View {
             guard heroComplete && !isClosing && !isNavigating && items.count > 1 else {
                 if phase == .ended {
                     trackpadScroll.reset()
-                    withAnimation(SnapSpring.standard) { swipeOffset = 0 }
+                    withAnimation(SnapSpring.standard(reduced: reduceMotion)) { swipeOffset = 0 }
                 }
                 return
             }
@@ -272,7 +273,7 @@ struct HeroDetailOverlay: View {
         } else if offset > threshold && currentIndex > 0 {
             navigateTo(currentIndex - 1)
         } else {
-            withAnimation(SnapSpring.standard) {
+            withAnimation(SnapSpring.standard(reduced: reduceMotion)) {
                 swipeOffset = 0
             }
         }
@@ -282,7 +283,7 @@ struct HeroDetailOverlay: View {
 
     private func navigateTo(_ newIndex: Int) {
         guard newIndex >= 0, newIndex < items.count, newIndex != currentIndex else {
-            withAnimation(SnapSpring.standard) { swipeOffset = 0 }
+            withAnimation(SnapSpring.standard(reduced: reduceMotion)) { swipeOffset = 0 }
             return
         }
         isNavigating = true
@@ -295,7 +296,7 @@ struct HeroDetailOverlay: View {
         }
 
         // Slide current image out, adjacent image slides in
-        withAnimation(SnapSpring.standard) {
+        withAnimation(SnapSpring.standard(reduced: reduceMotion)) {
             swipeOffset = direction * lastWindowWidth
         } completion: {
             // Swap to new item without animation
@@ -351,7 +352,7 @@ struct HeroDetailOverlay: View {
             let suggestedName = item.analysisResult?.patterns.first?.name
 
             if hasHoverPreview {
-                withAnimation(SnapSpring.hero) {
+                withAnimation(SnapSpring.hero(reduced: reduceMotion)) {
                     isExpanded = true
                     videoPreview.transitionToDetail(
                         itemId: item.id, url: url, finalFrame: finalFrame, suggestedName: suggestedName
@@ -364,7 +365,7 @@ struct HeroDetailOverlay: View {
                 videoPreview.transitionToDetail(
                     itemId: item.id, url: url, finalFrame: finalFrame, suggestedName: suggestedName
                 )
-                withAnimation(SnapSpring.hero) {
+                withAnimation(SnapSpring.hero(reduced: reduceMotion)) {
                     isExpanded = true
                 } completion: {
                     heroComplete = true
@@ -380,7 +381,7 @@ struct HeroDetailOverlay: View {
             if !FileManager.default.fileExists(atPath: mediaURL.path) {
                 isLoadingFullRes = true
             }
-            withAnimation(SnapSpring.hero) {
+            withAnimation(SnapSpring.hero(reduced: reduceMotion)) {
                 isExpanded = true
             } completion: {
                 heroComplete = true
@@ -498,6 +499,13 @@ struct HeroDetailOverlay: View {
 
     private func startMetadataReveal() {
         revealTask?.cancel()
+
+        // Skip staggered reveal when reduce motion is enabled — show everything at once
+        if reduceMotion {
+            withAnimation(.easeInOut(duration: 0.15)) { metadataStage = 4 }
+            return
+        }
+
         revealTask = Task { @MainActor in
             try? await Task.sleep(for: MetadataReveal.titleDelay)
             guard !Task.isCancelled, heroComplete else { return }
@@ -646,7 +654,7 @@ struct HeroDetailOverlay: View {
             }
         }
 
-        withAnimation(SnapSpring.hero) {
+        withAnimation(SnapSpring.hero(reduced: reduceMotion)) {
             isExpanded = false
             if currentItem.isVideo && !hasNavigated {
                 videoPreview.transitionToGrid()
@@ -738,24 +746,24 @@ private struct DetailMetadataSection: View {
                         .controlSize(.small)
                         .tint(.white)
                     Text("Analyzing...")
-                        .font(.system(size: 13))
+                        .font(.callout)
                         .foregroundStyle(.white.opacity(0.6))
                 }
                 .stageReveal(stage: stage, threshold: 1)
             } else if item.analysisError != nil {
                 HStack(spacing: 6) {
                     Image(systemName: "exclamationmark.triangle")
-                        .font(.system(size: 12))
+                        .font(.caption)
                         .foregroundStyle(.red.opacity(0.8))
                     Text("Analysis failed")
-                        .font(.system(size: 13))
+                        .font(.callout)
                         .foregroundStyle(.white.opacity(0.6))
                 }
                 .stageReveal(stage: stage, threshold: 1)
             } else if let result = item.analysisResult {
                 if !result.imageSummary.isEmpty {
                     Text(result.imageSummary)
-                        .font(.system(size: 14, weight: .semibold))
+                        .font(.body.weight(.semibold))
                         .foregroundStyle(.white.opacity(0.85))
                         .lineLimit(2)
                         .stageReveal(stage: stage, threshold: 1)
@@ -765,7 +773,7 @@ private struct DetailMetadataSection: View {
                 if !result.patterns.isEmpty {
                     FlowLayout(spacing: 6) {
                         ForEach(Array(result.patterns.enumerated()), id: \.element.name) { index, pattern in
-                            PatternPill(name: pattern.name, size: 12)
+                            PatternPill(name: pattern.name, large: true)
                                 .onTapGesture { onSearchPattern?(pattern.name) }
                                 .opacity(stage >= 2 ? 1 : 0)
                                 .offset(y: stage >= 2 ? 0 : MetadataReveal.slideDistance)
@@ -783,8 +791,8 @@ private struct DetailMetadataSection: View {
                     ExpandableText(
                         text: result.imageContext,
                         lineLimit: 3,
-                        font: .system(size: 12),
-                        platformFont: .systemFont(ofSize: 12),
+                        font: .caption,
+                        platformFont: .systemFont(ofSize: NSFont.systemFontSize(for: .small)),
                         lineSpacing: 2,
                         textColor: .white.opacity(0.4),
                         animation: MetadataReveal.spring,
@@ -806,7 +814,7 @@ private struct DetailMetadataSection: View {
                     Text(formatDuration(duration))
                 }
             }
-            .font(.system(size: 11, design: .monospaced))
+            .font(.caption.monospaced())
             .foregroundStyle(.white.opacity(0.25))
             .stageReveal(stage: stage, threshold: 4)
             .padding(.top, 12)

--- a/SnapGrid/SnapGrid/Views/Grid/EmptyStateView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/EmptyStateView.swift
@@ -44,16 +44,16 @@ struct EmptyStateView: View {
                 // Onboarding card centered on top
                 VStack(spacing: 24) {
                     Image(systemName: mode == .appLevel ? "photo.on.rectangle.angled" : "rectangle.stack.badge.plus")
-                        .font(.system(size: 56, weight: .light))
+                        .font(.system(size: 56, weight: .light))  // Decorative icon — fixed size intentional
                         .foregroundStyle(Color.snapMutedForeground.opacity(0.5))
 
                     VStack(spacing: 8) {
                         Text(mode == .appLevel ? "Drop screenshots here" : "No items in this space")
-                            .font(.system(size: 20, weight: .semibold))
+                            .font(.title3.weight(.semibold))
                             .foregroundStyle(Color.snapForeground)
 
                         Text(mode == .appLevel ? "Or use File \u{2192} Import (\u{2318}O) to get started" : "Drop images here or move items from All")
-                            .font(.system(size: 14))
+                            .font(.body)
                             .foregroundStyle(Color.snapMutedForeground)
                     }
 
@@ -76,7 +76,7 @@ struct EmptyStateView: View {
                                 .frame(width: 160)
 
                             Text("Add an AI API key in Settings (\u{2318},) to enable automatic image analysis")
-                                .font(.system(size: 13))
+                                .font(.callout)
                                 .foregroundStyle(Color.snapMutedForeground.opacity(0.7))
                                 .multilineTextAlignment(.center)
                                 .frame(maxWidth: 300)
@@ -92,6 +92,7 @@ struct EmptyStateView: View {
                                 .stroke(isDragTargeted ? Color.snapAccent : Color.snapBorder, lineWidth: isDragTargeted ? 2 : 1)
                         )
                 )
+                .accessibilityElement(children: .combine)
             }
         }
     }

--- a/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -20,6 +20,7 @@ struct GridItemView: View {
 
     @Environment(VideoPreviewManager.self) private var videoPreview
     @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isHovered = false
     @State private var thumbnail: NSImage?
     @State private var globalFrame: CGRect = .zero
@@ -45,6 +46,18 @@ struct GridItemView: View {
 
     private var height: CGFloat {
         width / item.aspectRatio
+    }
+
+    private var accessibilityDescription: String {
+        var parts: [String] = []
+        if item.isVideo { parts.append("Video") } else { parts.append("Image") }
+        if let summary = item.analysisResult?.imageSummary, !summary.isEmpty {
+            parts.append(summary)
+        }
+        parts.append("\(item.width) by \(item.height)")
+        if item.isAnalyzing { parts.append("Analyzing") }
+        if item.analysisError != nil { parts.append("Analysis failed") }
+        return parts.joined(separator: ", ")
     }
 
     /// Continuous opacity driven by fullscreen swipe progress.
@@ -127,7 +140,7 @@ struct GridItemView: View {
                         HStack {
                             Spacer()
                             Image(systemName: "play.fill")
-                                .font(.system(size: 10))
+                                .font(.caption2)
                                 .foregroundStyle(.white)
                                 .padding(6)
                                 .background(.black.opacity(0.5))
@@ -136,6 +149,7 @@ struct GridItemView: View {
                         }
                     }
                     .frame(width: width, height: height)
+                    .accessibilityHidden(true)
                 }
 
                 // Bottom overlay: analyzing shimmer or hover-only pattern tags
@@ -175,18 +189,19 @@ struct GridItemView: View {
                                 endPoint: .init(x: 0.5, y: 0.55)
                             )
                             .opacity(showHoverGradient ? 1 : 0)
-                            .offset(y: effectiveHover ? 0 : 20)
-                            .animation(SnapSpring.standard, value: effectiveHover)
+                            .offset(y: effectiveHover ? 0 : (reduceMotion ? 0 : 20))
+                            .animation(SnapSpring.standard(reduced: reduceMotion), value: effectiveHover)
 
                             HStack {
                                 FlowLayout(spacing: 5) {
                                     ForEach(Array(patterns.prefix(5).enumerated()), id: \.element.name) { index, pattern in
                                         PatternPill(name: pattern.name)
                                             .opacity(effectiveHover ? 1 : 0)
-                                            .offset(y: effectiveHover ? 0 : 8)
+                                            .offset(y: effectiveHover ? 0 : (reduceMotion ? 0 : 8))
                                             .animation(
-                                                SnapSpring.fast
-                                                    .delay(Double(index) * 0.025),
+                                                reduceMotion
+                                                    ? .easeInOut(duration: 0.1)
+                                                    : SnapSpring.fast.delay(Double(index) * 0.025),
                                                 value: effectiveHover
                                             )
                                     }
@@ -198,7 +213,7 @@ struct GridItemView: View {
                     }
                 }
                 .frame(width: width, height: height, alignment: .bottomLeading)
-                .animation(SnapSpring.standard, value: item.isAnalyzing)
+                .animation(SnapSpring.standard(reduced: reduceMotion), value: item.isAnalyzing)
             }
             .allowsHitTesting(false)
         }
@@ -217,6 +232,7 @@ struct GridItemView: View {
                 .buttonStyle(.plain)
                 .padding(8)
                 .transition(.opacity.combined(with: .scale(scale: 0.8)))
+                .accessibilityLabel("Delete")
             }
         }
         .overlay(alignment: .topLeading) {
@@ -232,6 +248,7 @@ struct GridItemView: View {
                 .buttonStyle(.plain)
                 .padding(8)
                 .transition(.opacity.combined(with: .scale(scale: 0.8)))
+                .accessibilityLabel("Remove from space")
             }
         }
         .overlay(alignment: .bottomLeading) {
@@ -239,9 +256,9 @@ struct GridItemView: View {
                 Button(action: onRetryAnalysis) {
                     HStack(spacing: 4) {
                         Image(systemName: "arrow.clockwise")
-                            .font(.system(size: 10))
+                            .font(.caption2)
                         Text("Retry")
-                            .font(.system(size: 11, weight: .medium))
+                            .font(.caption.weight(.medium))
                     }
                     .foregroundStyle(.white)
                     .padding(.horizontal, 8)
@@ -252,20 +269,24 @@ struct GridItemView: View {
                 .buttonStyle(.plain)
                 .padding(8)
                 .transition(.opacity.combined(with: .scale(scale: 0.8)))
+                .accessibilityLabel("Retry analysis")
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .overlay(
             RoundedRectangle(cornerRadius: 12)
-                .strokeBorder(isSelected ? Color.blue : Color.clear, lineWidth: 2)
+                .strokeBorder(isSelected ? Color.accentColor : Color.clear, lineWidth: 2)
         )
-        .shadow(  // ImageCard.tsx:96 — shadow-sm / hover:shadow-md
+        .shadow(
             color: .black.opacity(effectiveHover ? 0.1 : 0.05),
             radius: effectiveHover ? 6 : 2,
             x: 0,
             y: effectiveHover ? 4 : 1
         )
-        .animation(SnapSpring.fast, value: effectiveHover)
+        .animation(SnapSpring.fast(reduced: reduceMotion), value: effectiveHover)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityDescription)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
         .onHover { hovering in
             isHovered = hovering
             hoverTask?.cancel()
@@ -325,7 +346,7 @@ struct GridItemView: View {
                 }
                 if isBulk {
                     Text("\(selectedCount)")
-                        .font(.system(size: 11, weight: .bold))
+                        .font(.caption.bold())
                         .foregroundStyle(.white)
                         .frame(width: 20, height: 20)
                         .background(Color.snapAccent)
@@ -432,32 +453,39 @@ private enum ShimmerConfig {
 
 struct ShimmerText: View {
     let text: String
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     init(_ text: String) {
         self.text = text
     }
 
     var body: some View {
-        TimelineView(.animation) { timeline in
-            let t = timeline.date.timeIntervalSinceReferenceDate
-                .truncatingRemainder(dividingBy: ShimmerConfig.cycle)
-                / ShimmerConfig.cycle
-            let phase = t * (ShimmerConfig.rangeEnd - ShimmerConfig.rangeStart)
-                + ShimmerConfig.rangeStart
-
+        if reduceMotion {
             Text(text)
-                .font(.system(size: 11))
-                .foregroundStyle(
-                    .linearGradient(
-                        colors: [
-                            .white.opacity(ShimmerConfig.baseBrightness),
-                            .white.opacity(ShimmerConfig.peakBrightness),
-                            .white.opacity(ShimmerConfig.baseBrightness),
-                        ],
-                        startPoint: .init(x: phase - ShimmerConfig.bandHalf, y: 0.5),
-                        endPoint: .init(x: phase + ShimmerConfig.bandHalf, y: 0.5)
+                .font(.caption)
+                .foregroundStyle(.white.opacity(ShimmerConfig.peakBrightness))
+        } else {
+            TimelineView(.animation) { timeline in
+                let t = timeline.date.timeIntervalSinceReferenceDate
+                    .truncatingRemainder(dividingBy: ShimmerConfig.cycle)
+                    / ShimmerConfig.cycle
+                let phase = t * (ShimmerConfig.rangeEnd - ShimmerConfig.rangeStart)
+                    + ShimmerConfig.rangeStart
+
+                Text(text)
+                    .font(.caption)
+                    .foregroundStyle(
+                        .linearGradient(
+                            colors: [
+                                .white.opacity(ShimmerConfig.baseBrightness),
+                                .white.opacity(ShimmerConfig.peakBrightness),
+                                .white.opacity(ShimmerConfig.baseBrightness),
+                            ],
+                            startPoint: .init(x: phase - ShimmerConfig.bandHalf, y: 0.5),
+                            endPoint: .init(x: phase + ShimmerConfig.bandHalf, y: 0.5)
+                        )
                     )
-                )
+            }
         }
     }
 }

--- a/SnapGrid/SnapGrid/Views/Grid/MasonryGridView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/MasonryGridView.swift
@@ -127,13 +127,13 @@ struct MasonryGridView: View {
                     .padding(.top, 24)
                     .padding(.bottom, 24)
 
-                    // Rubber band visual — ImageGrid.tsx:715: border-blue-400 bg-blue-400/10
+                    // Rubber band visual
                     if let rect = rubberBandRect {
                         Rectangle()
-                            .fill(Color.blue.opacity(0.10))
+                            .fill(Color.accentColor.opacity(0.10))
                             .overlay(
                                 Rectangle()
-                                    .stroke(Color.blue.opacity(0.6), lineWidth: 1)
+                                    .stroke(Color.accentColor.opacity(0.6), lineWidth: 1)
                             )
                             .frame(width: rect.width, height: rect.height)
                             .offset(x: rect.minX, y: rect.minY)

--- a/SnapGrid/SnapGrid/Views/Grid/SelectionBadge.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/SelectionBadge.swift
@@ -5,12 +5,14 @@ struct SelectionBadge: View {
 
     var body: some View {
         Text("\(count) selected")
-            .font(.system(size: 13, weight: .medium))
+            .font(.callout.weight(.medium))
             .foregroundStyle(.white)
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
-            .background(Color.blue)  // ImageGrid.tsx:728 — bg-blue-500 (always blue, not adaptive accent)
+            .background(Color.accentColor)
             .clipShape(Capsule())
             .shadow(color: .black.opacity(0.3), radius: 8, y: 4)
+            .accessibilityLabel("\(count) items selected")
+            .accessibilityAddTraits(.updatesFrequently)
     }
 }

--- a/SnapGrid/SnapGrid/Views/Settings/PromptsSettingsTab.swift
+++ b/SnapGrid/SnapGrid/Views/Settings/PromptsSettingsTab.swift
@@ -193,7 +193,7 @@ private struct PromptEditorSheet: View {
             Divider()
 
             TextEditor(text: $draft)
-                .font(.system(size: 11, design: .monospaced))
+                .font(.caption.monospaced())
                 .scrollContentBackground(.hidden)
                 .padding(12)
 

--- a/SnapGrid/SnapGrid/Views/Settings/StorageSettingsTab.swift
+++ b/SnapGrid/SnapGrid/Views/Settings/StorageSettingsTab.swift
@@ -15,7 +15,7 @@ struct StorageSettingsTab: View {
                 LabeledContent("Path") {
                     HStack {
                         Text(MediaStorageService.shared.baseURL.path)
-                            .font(.system(size: 11, design: .monospaced))
+                            .font(.caption.monospaced())
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                             .truncationMode(.middle)

--- a/SnapGrid/SnapGrid/Views/Shared/AnimationTokens.swift
+++ b/SnapGrid/SnapGrid/Views/Shared/AnimationTokens.swift
@@ -6,9 +6,31 @@ import SwiftUI
 ///  - **fast**     — micro-interactions: hover shadows, button reveals, small state toggles
 ///  - **standard** — UI transitions: tab switches, toasts, selection badges, carousel slides
 ///  - **hero**     — page-level: detail overlay expand/collapse
+///
+/// All presets have reduced-motion variants that use short ease curves instead of springs.
+/// Views should read `@Environment(\.accessibilityReduceMotion)` and pass it to
+/// the `reduced:` overloads, or use the static lets when reduce-motion is handled elsewhere.
 enum SnapSpring {
     static let fast     = Animation.spring(response: 0.2, dampingFraction: 0.85)
     static let standard = Animation.spring(response: 0.3, dampingFraction: 0.8)
     static let hero     = Animation.spring(response: 0.36, dampingFraction: 0.87)
     static let metadata = Animation.spring(response: 0.4, dampingFraction: 0.85)
+
+    // MARK: - Reduce Motion Variants
+
+    static func fast(reduced: Bool) -> Animation {
+        reduced ? .easeInOut(duration: 0.1) : fast
+    }
+
+    static func standard(reduced: Bool) -> Animation {
+        reduced ? .easeInOut(duration: 0.15) : standard
+    }
+
+    static func hero(reduced: Bool) -> Animation {
+        reduced ? .easeInOut(duration: 0.2) : hero
+    }
+
+    static func metadata(reduced: Bool) -> Animation {
+        reduced ? .easeInOut(duration: 0.15) : metadata
+    }
 }

--- a/SnapGrid/SnapGrid/Views/Shared/FloatingVideoLayer.swift
+++ b/SnapGrid/SnapGrid/Views/Shared/FloatingVideoLayer.swift
@@ -132,7 +132,7 @@ struct FloatingVideoLayer: View {
                     return provider
                 } preview: {
                     Image(systemName: "video.fill")
-                        .font(.system(size: 24))
+                        .font(.title2)
                         .foregroundStyle(.white)
                         .frame(width: 96, height: 64)
                         .background(Color.gray.opacity(0.5))
@@ -191,20 +191,21 @@ struct VideoControlsOverlay: View {
         // Center play/pause button
         Button(action: togglePlayback) {
             Image(systemName: isPlaying ? "pause.fill" : "play.fill")
-                .font(.system(size: 20, weight: .semibold))
+                .font(.title3.weight(.semibold))
                 .foregroundStyle(.white)
                 .frame(width: 44, height: 44)
                 .background(.black.opacity(0.5))
                 .clipShape(Circle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(isPlaying ? "Pause" : "Play")
 
         // Bottom time bar
         VStack {
             Spacer()
             HStack {
                 Text("\(formatTime(currentTime)) / \(formatTime(duration))")
-                    .font(.system(size: 11, weight: .medium).monospacedDigit())
+                    .font(.caption.weight(.medium).monospacedDigit())
                     .foregroundStyle(.white.opacity(0.8))
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)

--- a/SnapGrid/SnapGrid/Views/Shared/PatternPill.swift
+++ b/SnapGrid/SnapGrid/Views/Shared/PatternPill.swift
@@ -4,15 +4,15 @@ import SwiftUI
 /// Uses `.ultraThinMaterial` so it composites correctly above NSView-backed video content.
 struct PatternPill: View {
     let name: String
-    var size: CGFloat = 11
+    var large: Bool = false
 
     var body: some View {
         Text(name)
-            .font(.system(size: size))
+            .font(large ? .subheadline : .callout)
             .foregroundStyle(.white.opacity(0.9))
-            .padding(.horizontal, size <= 11 ? 8 : 10)
-            .padding(.vertical, size <= 11 ? 3 : 5)
-            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: size <= 11 ? 10 : 12))
+            .padding(.horizontal, large ? 10 : 8)
+            .padding(.vertical, large ? 5 : 3)
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: large ? 12 : 10))
             .environment(\.colorScheme, .dark)
     }
 }

--- a/SnapGrid/SnapGrid/Views/Shared/ToastView.swift
+++ b/SnapGrid/SnapGrid/Views/Shared/ToastView.swift
@@ -8,14 +8,17 @@ struct ToastOverlay: View {
             Spacer()
             ForEach(toasts) { toast in
                 Text(toast.message)
-                    .font(.system(size: 13, weight: .medium))
+                    .font(.callout.weight(.medium))
                     .foregroundStyle(.white)
                     .padding(.horizontal, 16)
                     .padding(.vertical, 10)
-                    .background(.black.opacity(0.75))
+                    .background(.ultraThinMaterial.opacity(0.9))
+                    .background(.black.opacity(0.6))
                     .clipShape(Capsule())
                     .shadow(color: .black.opacity(0.2), radius: 8, y: 4)
                     .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .accessibilityLabel(toast.message)
+                    .accessibilityAddTraits(.updatesFrequently)
             }
         }
         .padding(.bottom, 24)

--- a/SnapGrid/SnapGrid/Views/Spaces/SpaceTabBar.swift
+++ b/SnapGrid/SnapGrid/Views/Spaces/SpaceTabBar.swift
@@ -58,12 +58,13 @@ struct SpaceTabBar: View {
                 // Add button
                 Button(action: onCreateSpace) {
                     Image(systemName: "plus")
-                        .font(.system(size: 12, weight: .medium))
+                        .font(.caption.weight(.medium))
                         .foregroundStyle(Color.snapMutedForeground)
                         .padding(12)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Add space")
             }
             .padding(.horizontal, 24)
             .padding(.top, 6)
@@ -113,7 +114,7 @@ struct SpaceTabBar: View {
             })
             .focused($isEditingFocused)
             .textFieldStyle(.plain)
-            .font(.system(size: 13, weight: .medium))
+            .font(.body.weight(.medium))
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
             .background(Color.snapMuted)
@@ -233,6 +234,8 @@ struct SpaceTabBar: View {
 
     // MARK: - Tab View
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     @ViewBuilder
     private func tabView(id: String?, title: String, isActive: Bool) -> some View {
         let isDropTarget = (id == nil && dropTargetId == "ALL") || (id != nil && dropTargetId == id)
@@ -243,7 +246,7 @@ struct SpaceTabBar: View {
         } label: {
             VStack(spacing: 0) {
                 Text(title)
-                    .font(.system(size: 13, weight: isActive ? .medium : .regular))
+                    .font(.body.weight(isActive ? .medium : .regular))
                     .foregroundStyle(
                         isActive ? Color.snapForeground :
                         isDropTarget ? Color.snapForeground.opacity(0.7) :
@@ -277,7 +280,9 @@ struct SpaceTabBar: View {
             }
         }
         .buttonStyle(.plain)
-        .animation(SnapSpring.standard, value: activeSpaceId)
+        .accessibilityLabel("\(title)\(isActive ? ", selected" : "")")
+        .accessibilityAddTraits(isActive ? [.isButton, .isSelected] : .isButton)
+        .animation(SnapSpring.standard(reduced: reduceMotion), value: activeSpaceId)
     }
 
     // MARK: - Drop Helpers


### PR DESCRIPTION
### Why?

The native Mac app was audited against Apple's Human Interface Guidelines and found to be missing core accessibility support — no VoiceOver labels, no reduce motion handling, hardcoded font sizes that don't scale with Dynamic Type, and hardcoded `Color.blue` instead of system accent color.

### How?

Systematic pass across all 17 view files to add VoiceOver labels, `SnapSpring.reduced:` animation variants that respect `accessibilityReduceMotion`, semantic text styles replacing ~30 hardcoded `.system(size:)` calls, `Color.accentColor` for selection indicators, Increase Contrast variants in `Color+Theme`, and small platform fixes (window title, Redo menu, state restoration, `.searchable(isPresented:)` replacing an NSView hierarchy walk).

<sub>Generated with Claude Code</sub>