### PR TITLE
Support bulk retry analysis for multi-selected items

### DIFF
--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -714,12 +714,17 @@ struct ContentView: View {
         appState.activeSpaceId = nil
     }
 
-    private func retryAnalysis(_ item: MediaItem) {
-        item.analysisError = nil
-        item.analysisResult = nil
+    private func retryAnalysis(_ ids: Set<String>) {
+        let items = allItems.filter { ids.contains($0.id) }
+        for item in items {
+            item.analysisError = nil
+            item.analysisResult = nil
+        }
         try? modelContext.save()
-        Task {
-            await importService.analyzeItem(item, context: modelContext)
+        for item in items {
+            Task {
+                await importService.analyzeItem(item, context: modelContext)
+            }
         }
     }
 

--- a/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -404,7 +404,7 @@ struct GridItemView: View {
 
             Divider()
 
-            Button("Retry Analysis") {
+            Button(isBulk ? "Retry Analysis for \(selectedCount) Items" : "Retry Analysis") {
                 onRetryAnalysis()
             }
 

--- a/SnapGrid/SnapGrid/Views/Grid/MasonryGridView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/MasonryGridView.swift
@@ -12,7 +12,7 @@ struct MasonryGridView: View {
     let onShiftSelect: (String) -> Void
     let onDelete: (Set<String>) -> Void
     let onAssignToSpace: (Set<String>, String?) -> Void
-    let onRetryAnalysis: (MediaItem) -> Void
+    let onRetryAnalysis: (Set<String>) -> Void
     let onSetSelection: (Set<String>) -> Void
     var coordinateSpaceName: String = "gridContent"
 
@@ -109,7 +109,7 @@ struct MasonryGridView: View {
                                         onShiftSelect: { onShiftSelect(item.id) },
                                         onDelete: { onDelete(effectiveIds) },
                                         onAssignToSpace: { spaceId in onAssignToSpace(effectiveIds, spaceId) },
-                                        onRetryAnalysis: { onRetryAnalysis(item) }
+                                        onRetryAnalysis: { onRetryAnalysis(effectiveIds) }
                                     )
                                     .background(
                                         GeometryReader { geo in


### PR DESCRIPTION
## Summary
- Aligns "Retry Analysis" context menu action with existing bulk operation patterns (delete, move to space) so it operates on all selected items, not just the right-clicked one
- `retryAnalysis` now accepts a `Set<String>` of item IDs and clears errors / dispatches analysis for each
- Context menu label updates dynamically to show "Retry Analysis for N Items" when multiple items are selected

## Test plan
- [ ] Multi-select items (Cmd+Click or rubber band), right-click → verify "Retry Analysis for N Items" label
- [ ] Click it → all selected items should show analysis spinner
- [ ] Single item right-click → verify singular "Retry Analysis" label still works
- [ ] Inline retry button on error overlay still works for individual items

🤖 Generated with [Claude Code](https://claude.com/claude-code)