### PR TITLE
Improve iOS accessibility: Dynamic Type, Reduce Motion, and VoiceOver

### DIFF
--- a/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
@@ -71,7 +71,7 @@ private extension View {
         self
             .opacity(stage >= threshold ? 1 : 0)
             .offset(y: stage >= threshold ? 0 : 4)
-            .animation(MetadataReveal.spring, value: stage)
+            .animation(SnapSpring.resolvedMetadata, value: stage)
     }
 }
 
@@ -313,7 +313,7 @@ struct FullScreenImageOverlay: View {
             loadFullImage()
             prepareVideoIfNeeded()
             preloadAdjacentImages()
-            withAnimation(SnapSpring.hero) {
+            withAnimation(SnapSpring.resolvedHero) {
                 isExpanded = true
             } completion: {
                 heroComplete = true
@@ -471,7 +471,7 @@ struct FullScreenImageOverlay: View {
                         prepareShareItem()
                     } label: {
                         Image(systemName: "square.and.arrow.up")
-                            .font(.system(size: 18, weight: .medium))
+                            .font(.body.weight(.medium))
                             .frame(width: 56, height: 50)
                     }
 
@@ -483,7 +483,7 @@ struct FullScreenImageOverlay: View {
                         showDeleteConfirmation = true
                     } label: {
                         Image(systemName: "trash")
-                            .font(.system(size: 18, weight: .medium))
+                            .font(.body.weight(.medium))
                             .frame(width: 56, height: 50)
                     }
                 }
@@ -495,7 +495,7 @@ struct FullScreenImageOverlay: View {
                     prepareShareItem()
                 } label: {
                     Image(systemName: "square.and.arrow.up")
-                        .font(.system(size: 18, weight: .medium))
+                        .font(.body.weight(.medium))
                         .foregroundStyle(.white.opacity(0.9))
                         .frame(width: 56, height: 50)
                 }
@@ -508,7 +508,7 @@ struct FullScreenImageOverlay: View {
                     showDeleteConfirmation = true
                 } label: {
                     Image(systemName: "trash")
-                        .font(.system(size: 18, weight: .medium))
+                        .font(.body.weight(.medium))
                         .foregroundStyle(.white.opacity(0.9))
                         .frame(width: 56, height: 50)
                 }
@@ -585,6 +585,10 @@ struct FullScreenImageOverlay: View {
     // MARK: - Metadata Reveal
 
     private func startMetadataReveal() {
+        if UIAccessibility.isReduceMotionEnabled {
+            metadataStage = 4
+            return
+        }
         revealTask?.cancel()
         revealTask = Task { @MainActor in
             try? await Task.sleep(for: MetadataReveal.titleDelay)
@@ -698,7 +702,7 @@ struct FullScreenImageOverlay: View {
                     if newIndex != currentIndex {
                         navigateTo(newIndex)
                     } else {
-                        withAnimation(SnapSpring.standard) {
+                        withAnimation(SnapSpring.resolvedStandard) {
                             swipeOffset = 0
                         }
                     }
@@ -707,7 +711,7 @@ struct FullScreenImageOverlay: View {
                     if dismissOffset > 100 || value.predictedEndTranslation.height > 300 {
                         close()
                     } else {
-                        withAnimation(SnapSpring.standard) {
+                        withAnimation(SnapSpring.resolvedStandard) {
                             dismissOffset = 0
                         }
                     }
@@ -721,7 +725,7 @@ struct FullScreenImageOverlay: View {
                     } else {
                         snapTarget = 0
                     }
-                    withAnimation(SnapSpring.standard) {
+                    withAnimation(SnapSpring.resolvedStandard) {
                         contentOffset = snapTarget
                     }
                     contentOffsetAtGestureStart = snapTarget
@@ -743,7 +747,7 @@ struct FullScreenImageOverlay: View {
             }
             .onEnded { _ in
                 let clamped = min(max(zoomScale, minZoomScale), maxZoomScale)
-                withAnimation(SnapSpring.standard) {
+                withAnimation(SnapSpring.resolvedStandard) {
                     zoomScale = clamped
                     if clamped <= minZoomScale {
                         zoomPanOffset = .zero
@@ -758,7 +762,7 @@ struct FullScreenImageOverlay: View {
 
     private func handleDoubleTap(at location: CGPoint) {
         let viewCenter = CGPoint(x: screenSize.width / 2, y: screenSize.height / 2)
-        withAnimation(SnapSpring.standard) {
+        withAnimation(SnapSpring.resolvedStandard) {
             if zoomScale > minZoomScale {
                 zoomScale = minZoomScale
                 zoomLastScale = minZoomScale
@@ -793,7 +797,7 @@ struct FullScreenImageOverlay: View {
     private func navigateTo(_ newIndex: Int) {
         guard newIndex >= 0, newIndex < items.count,
               newIndex != currentIndex, !isNavigating, !isClosing else {
-            withAnimation(SnapSpring.standard) { swipeOffset = 0 }
+            withAnimation(SnapSpring.resolvedStandard) { swipeOffset = 0 }
             return
         }
         isNavigating = true
@@ -803,7 +807,7 @@ struct FullScreenImageOverlay: View {
         player = nil
         impactFeedback.impactOccurred()
 
-        withAnimation(SnapSpring.standard) {
+        withAnimation(SnapSpring.resolvedStandard) {
             swipeOffset = direction * screenSize.width
         } completion: {
             // Swap without animation
@@ -869,20 +873,29 @@ struct FullScreenImageOverlay: View {
         let deletedItem = items[deletedIndex]
         let isLastItem = deletedIndex == items.count - 1
 
-        // Stage 1 — height crushes inward
-        withAnimation(DeleteAnimation.heightCrush) {
-            deleteStage = 1
+        if UIAccessibility.isReduceMotionEnabled {
+            // Simple fade when Reduce Motion is on
+            withAnimation(.easeOut(duration: 0.2)) {
+                deleteStage = 2
+            }
+        } else {
+            // Stage 1 — height crushes inward
+            withAnimation(DeleteAnimation.heightCrush) {
+                deleteStage = 1
+            }
         }
 
         Task { @MainActor in
-            // Stage 2 — width collapses + fade out
-            try? await Task.sleep(for: DeleteAnimation.widthDelay)
-            withAnimation(DeleteAnimation.widthCrush) {
-                deleteStage = 2
+            if !UIAccessibility.isReduceMotionEnabled {
+                // Stage 2 — width collapses + fade out
+                try? await Task.sleep(for: DeleteAnimation.widthDelay)
+                withAnimation(DeleteAnimation.widthCrush) {
+                    deleteStage = 2
+                }
             }
 
             // Stage 3 — crush complete, commit deletion + slide in replacement
-            try? await Task.sleep(for: DeleteAnimation.completeDelay)
+            try? await Task.sleep(for: UIAccessibility.isReduceMotionEnabled ? .milliseconds(250) : DeleteAnimation.completeDelay)
 
             // Notify parent to handle file move + SwiftData deletion
             onDelete?(deletedItem)
@@ -913,7 +926,7 @@ struct FullScreenImageOverlay: View {
             metadataStage = 0
 
             // Animate the slide-in
-            withAnimation(SnapSpring.standard) {
+            withAnimation(SnapSpring.resolvedStandard) {
                 swipeOffset = 0
             }
 
@@ -985,7 +998,7 @@ struct FullScreenImageOverlay: View {
             onDismissing?(currentItemId)
             closeTargetFrame = correctedRect
 
-            withAnimation(SnapSpring.hero) {
+            withAnimation(SnapSpring.resolvedHero) {
                 isExpanded = false
                 dismissOffset = 0
             } completion: {
@@ -1093,24 +1106,24 @@ private struct DetailMetadataSection: View {
                     ProgressView()
                         .tint(.white)
                     Text("Analyzing...")
-                        .font(.system(size: 14))
+                        .font(.subheadline)
                         .foregroundStyle(.white.opacity(0.6))
                 }
                 .stageReveal(stage: stage, threshold: 1)
             } else if item.analysisError != nil {
                 HStack(spacing: 6) {
                     Image(systemName: "exclamationmark.triangle")
-                        .font(.system(size: 13))
+                        .font(.footnote)
                         .foregroundStyle(.red.opacity(0.8))
                     Text("Analysis failed")
-                        .font(.system(size: 14))
+                        .font(.subheadline)
                         .foregroundStyle(.white.opacity(0.6))
                 }
                 .stageReveal(stage: stage, threshold: 1)
             } else if let result = item.analysisResult {
                 if !result.imageSummary.isEmpty {
                     Text(result.imageSummary)
-                        .font(.system(size: 16, weight: .semibold))
+                        .font(.title3.weight(.semibold))
                         .foregroundStyle(.white.opacity(0.9))
                         .lineLimit(2)
                         .stageReveal(stage: stage, threshold: 1)
@@ -1118,16 +1131,17 @@ private struct DetailMetadataSection: View {
                 }
 
                 if !result.patterns.isEmpty {
-                    FlowLayout(spacing: 6) {
+                    FlowLayout(spacing: 8) {
                         ForEach(Array(result.patterns.enumerated()), id: \.element.name) { index, pattern in
                             Text(pattern.name)
-                                .font(.system(size: 13, weight: .medium))
+                                .font(.caption)
                                 .foregroundStyle(.white.opacity(0.9))
-                                .padding(.horizontal, 10)
-                                .padding(.vertical, 5)
-                                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+                                .padding(.horizontal, 14)
+                                .padding(.vertical, 10)
+                                .background(.ultraThinMaterial, in: Capsule())
                                 .environment(\.colorScheme, .dark)
                                 .contentShape(Rectangle())
+                                .accessibilityHint("Double tap to search for this pattern")
                                 .onTapGesture {
                                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                                     onSearchPattern?(pattern.name)
@@ -1135,7 +1149,9 @@ private struct DetailMetadataSection: View {
                                 .opacity(stage >= 2 ? 1 : 0)
                                 .offset(y: stage >= 2 ? 0 : MetadataReveal.slideDistance)
                                 .animation(
-                                    MetadataReveal.spring.delay(Double(index) * MetadataReveal.tagStagger),
+                                    UIAccessibility.isReduceMotionEnabled
+                                        ? SnapSpring.resolvedMetadata
+                                        : MetadataReveal.spring.delay(Double(index) * MetadataReveal.tagStagger),
                                     value: stage
                                 )
                         }
@@ -1147,8 +1163,8 @@ private struct DetailMetadataSection: View {
                     ExpandableText(
                         text: result.imageContext,
                         lineLimit: 3,
-                        font: .system(size: 14),
-                        platformFont: .systemFont(ofSize: 14),
+                        font: .subheadline,
+                        platformFont: .preferredFont(forTextStyle: .subheadline),
                         lineSpacing: 3,
                         textColor: .white.opacity(0.5),
                         animation: MetadataReveal.spring,
@@ -1170,7 +1186,7 @@ private struct DetailMetadataSection: View {
                     Text(formatDuration(duration))
                 }
             }
-            .font(.system(size: 12, design: .monospaced))
+            .font(.caption.monospaced())
             .foregroundStyle(.white.opacity(0.3))
             .stageReveal(stage: stage, threshold: 4)
             .padding(.top, 14)

--- a/ios/SnapGrid/SnapGrid/Views/Detail/ImageDetailView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/ImageDetailView.swift
@@ -44,7 +44,7 @@ struct ImageDetailView: View {
                                         .font(.system(size: 28))
                                         .foregroundStyle(.white.opacity(0.4))
                                     Text("Couldn't download from iCloud")
-                                        .font(.system(size: 14))
+                                        .font(.subheadline)
                                         .foregroundStyle(.white.opacity(0.4))
                                     Button("Retry") {
                                         loadFailed = false
@@ -122,7 +122,7 @@ struct MetadataPanel: View {
             if let patterns = item.analysisResult?.patterns, !patterns.isEmpty {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Patterns")
-                        .font(.system(size: 12, weight: .semibold))
+                        .font(.caption.weight(.semibold))
                         .foregroundStyle(.white.opacity(0.4))
                         .textCase(.uppercase)
 
@@ -130,9 +130,9 @@ struct MetadataPanel: View {
                         ForEach(patterns, id: \.name) { pattern in
                             HStack(spacing: 4) {
                                 Text(pattern.name)
-                                    .font(.system(size: 13, weight: .medium))
+                                    .font(.footnote.weight(.medium))
                                 Text("\(Int(pattern.confidence * 100))%")
-                                    .font(.system(size: 11))
+                                    .font(.caption2)
                                     .foregroundStyle(.white.opacity(0.4))
                             }
                             .foregroundStyle(.white.opacity(0.8))
@@ -149,12 +149,12 @@ struct MetadataPanel: View {
             if let context = item.analysisResult?.imageContext, !context.isEmpty {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("AI Analysis")
-                        .font(.system(size: 12, weight: .semibold))
+                        .font(.caption.weight(.semibold))
                         .foregroundStyle(.white.opacity(0.4))
                         .textCase(.uppercase)
 
                     Text(context)
-                        .font(.system(size: 14))
+                        .font(.subheadline)
                         .foregroundStyle(.white.opacity(0.7))
                         .lineSpacing(4)
                 }
@@ -163,7 +163,7 @@ struct MetadataPanel: View {
             // Technical details
             VStack(alignment: .leading, spacing: 8) {
                 Text("Details")
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(.caption.weight(.semibold))
                     .foregroundStyle(.white.opacity(0.4))
                     .textCase(.uppercase)
 
@@ -193,10 +193,10 @@ private struct DetailChip: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(label)
-                .font(.system(size: 11))
+                .font(.caption2)
                 .foregroundStyle(.white.opacity(0.3))
             Text(value)
-                .font(.system(size: 13, weight: .medium))
+                .font(.footnote.weight(.medium))
                 .foregroundStyle(.white.opacity(0.7))
         }
     }

--- a/ios/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -48,10 +48,10 @@ struct GridItemView: View {
                     .overlay {
                         VStack(spacing: 6) {
                             Image(systemName: "icloud.and.arrow.down")
-                                .font(.system(size: 20))
+                                .font(.body)
                                 .foregroundStyle(.white.opacity(0.3))
                             Text("Tap to retry")
-                                .font(.system(size: 11))
+                                .font(.caption2)
                                 .foregroundStyle(.white.opacity(0.3))
                         }
                     }
@@ -70,7 +70,7 @@ struct GridItemView: View {
                 HStack {
                     Spacer()
                     Image(systemName: "play.fill")
-                        .font(.system(size: 10))
+                        .font(.caption2)
                         .foregroundStyle(.white)
                         .padding(6)
                         .background(.black.opacity(0.5))
@@ -78,6 +78,7 @@ struct GridItemView: View {
                         .padding(8)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+                .accessibilityHidden(true)
             }
 
             // Analysis state overlay
@@ -112,15 +113,17 @@ struct GridItemView: View {
                 } label: {
                     HStack(spacing: 4) {
                         Image(systemName: "arrow.clockwise")
-                            .font(.system(size: 10))
+                            .font(.caption2)
                         Text("Retry")
-                            .font(.system(size: 11, weight: .medium))
+                            .font(.caption2.weight(.medium))
                     }
                     .foregroundStyle(.white)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
                     .background(.red.opacity(0.7))
                     .clipShape(RoundedRectangle(cornerRadius: 6))
+                    .frame(minWidth: 44, minHeight: 44)
+                    .contentShape(Rectangle())
                 }
                 .padding(8)
                 .frame(width: width, height: height, alignment: .bottomLeading)
@@ -128,7 +131,7 @@ struct GridItemView: View {
             }
         }
         .frame(width: width, height: height)
-        .animation(SnapSpring.standard, value: item.isAnalyzing)
+        .animation(SnapSpring.resolvedStandard, value: item.isAnalyzing)
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .accessibilityLabel(item.isVideo ? "Video" : "Image")
         .accessibilityHint("Double tap to view full screen")
@@ -210,26 +213,32 @@ struct ShimmerText: View {
     }
 
     var body: some View {
-        TimelineView(.animation) { timeline in
-            let t = timeline.date.timeIntervalSinceReferenceDate
-                .truncatingRemainder(dividingBy: ShimmerConfig.cycle)
-                / ShimmerConfig.cycle
-            let phase = t * (ShimmerConfig.rangeEnd - ShimmerConfig.rangeStart)
-                + ShimmerConfig.rangeStart
-
+        if UIAccessibility.isReduceMotionEnabled {
             Text(text)
-                .font(.system(size: 11))
-                .foregroundStyle(
-                    .linearGradient(
-                        colors: [
-                            .white.opacity(ShimmerConfig.baseBrightness),
-                            .white.opacity(ShimmerConfig.peakBrightness),
-                            .white.opacity(ShimmerConfig.baseBrightness),
-                        ],
-                        startPoint: .init(x: phase - ShimmerConfig.bandHalf, y: 0.5),
-                        endPoint: .init(x: phase + ShimmerConfig.bandHalf, y: 0.5)
+                .font(.caption2)
+                .foregroundStyle(.white.opacity(0.7))
+        } else {
+            TimelineView(.animation) { timeline in
+                let t = timeline.date.timeIntervalSinceReferenceDate
+                    .truncatingRemainder(dividingBy: ShimmerConfig.cycle)
+                    / ShimmerConfig.cycle
+                let phase = t * (ShimmerConfig.rangeEnd - ShimmerConfig.rangeStart)
+                    + ShimmerConfig.rangeStart
+
+                Text(text)
+                    .font(.caption2)
+                    .foregroundStyle(
+                        .linearGradient(
+                            colors: [
+                                .white.opacity(ShimmerConfig.baseBrightness),
+                                .white.opacity(ShimmerConfig.peakBrightness),
+                                .white.opacity(ShimmerConfig.baseBrightness),
+                            ],
+                            startPoint: .init(x: phase - ShimmerConfig.bandHalf, y: 0.5),
+                            endPoint: .init(x: phase + ShimmerConfig.bandHalf, y: 0.5)
+                        )
                     )
-                )
+            }
         }
     }
 }

--- a/ios/SnapGrid/SnapGrid/Views/Grid/PatternPills.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Grid/PatternPills.swift
@@ -7,7 +7,7 @@ struct PatternPills: View {
         FlowLayout(spacing: 4) {
             ForEach(patterns, id: \.name) { pattern in
                 Text(pattern.name)
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.caption2.weight(.medium))
                     .foregroundStyle(.white.opacity(0.9))
                     .padding(.horizontal, 8)
                     .padding(.vertical, 3)

--- a/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
@@ -342,7 +342,7 @@ struct MainView: View {
         .onChange(of: activeSpaceId) { _, _ in
             let target = activeIndex
             if currentPage != target {
-                withAnimation(SnapSpring.standard) {
+                withAnimation(SnapSpring.resolvedStandard) {
                     currentPage = target
                 }
             }

--- a/ios/SnapGrid/SnapGrid/Views/Main/SpaceTabBar.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/SpaceTabBar.swift
@@ -14,14 +14,14 @@ struct SpaceTabBar: View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 4) {
                 TabButton(title: "All", index: 0, isActive: activeSpaceId == nil) {
-                    withAnimation(SnapSpring.standard) {
+                    withAnimation(SnapSpring.resolvedStandard) {
                         activeSpaceId = nil
                     }
                 }
 
                 ForEach(Array(spaces.enumerated()), id: \.element.id) { index, space in
                     TabButton(title: space.name, index: index + 1, isActive: activeSpaceId == space.id) {
-                        withAnimation(SnapSpring.standard) {
+                        withAnimation(SnapSpring.resolvedStandard) {
                             activeSpaceId = space.id
                         }
                     }
@@ -90,11 +90,11 @@ private struct TabButton: View {
             action()
         } label: {
             Text(title)
-                .font(.system(size: 15, weight: .medium))
+                .font(.subheadline.weight(.medium))
                 .hidden()
                 .overlay {
                     Text(title)
-                        .font(.system(size: 15, weight: isActive ? .medium : .regular))
+                        .font(.subheadline.weight(isActive ? .medium : .regular))
                         .foregroundStyle(isActive ? .white : .white.opacity(0.5))
                 }
                 .padding(.horizontal, 10)

--- a/ios/SnapGrid/SnapGrid/Views/Onboarding/OnboardingView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Onboarding/OnboardingView.swift
@@ -17,11 +17,11 @@ struct OnboardingView: View {
                         .foregroundStyle(.white.opacity(0.9))
 
                     Text("SnapGrid")
-                        .font(.system(size: 34, weight: .bold, design: .default))
+                        .font(.largeTitle.bold())
                         .foregroundStyle(.white)
 
                     Text("Sign in to iCloud to sync\nyour SnapGrid library")
-                        .font(.system(size: 17, weight: .regular))
+                        .font(.body)
                         .foregroundStyle(.white.opacity(0.6))
                         .multilineTextAlignment(.center)
                 }
@@ -36,9 +36,9 @@ struct OnboardingView: View {
                     } label: {
                         HStack(spacing: 10) {
                             Image(systemName: "gear")
-                                .font(.system(size: 17, weight: .medium))
+                                .font(.body.weight(.medium))
                             Text("Open Settings")
-                                .font(.system(size: 17, weight: .semibold))
+                                .font(.body.weight(.semibold))
                         }
                         .foregroundStyle(.black)
                         .frame(maxWidth: .infinity)
@@ -52,7 +52,7 @@ struct OnboardingView: View {
                         fileSystem.restoreAccess()
                     } label: {
                         Text("Try Again")
-                            .font(.system(size: 17, weight: .medium))
+                            .font(.body.weight(.medium))
                             .foregroundStyle(.white.opacity(0.6))
                             .frame(maxWidth: .infinity)
                             .frame(height: 44)
@@ -61,7 +61,7 @@ struct OnboardingView: View {
 
                     if let error = fileSystem.error {
                         Text(error)
-                            .font(.system(size: 13))
+                            .font(.footnote)
                             .foregroundStyle(.red.opacity(0.8))
                             .multilineTextAlignment(.center)
                             .padding(.horizontal, 24)

--- a/ios/SnapGrid/SnapGrid/Views/Shared/AnimationTokens.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Shared/AnimationTokens.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// Named animation presets for consistent motion across the app.
 ///
@@ -11,4 +12,17 @@ enum SnapSpring {
     static let standard = Animation.spring(response: 0.3, dampingFraction: 0.8)
     static let hero     = Animation.spring(response: 0.36, dampingFraction: 0.87)
     static let metadata = Animation.spring(response: 0.4, dampingFraction: 0.85)
+
+    /// Brief ease-out used when Reduce Motion is enabled.
+    private static let reduced = Animation.easeOut(duration: 0.2)
+
+    /// Returns a brief ease-out when Reduce Motion is on, otherwise the given spring.
+    static func resolved(_ spring: Animation) -> Animation {
+        UIAccessibility.isReduceMotionEnabled ? reduced : spring
+    }
+
+    static var resolvedFast: Animation     { resolved(fast) }
+    static var resolvedStandard: Animation { resolved(standard) }
+    static var resolvedHero: Animation     { resolved(hero) }
+    static var resolvedMetadata: Animation { resolved(metadata) }
 }

--- a/ios/SnapGrid/SnapGrid/Views/Shared/EmptyStateView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Shared/EmptyStateView.swift
@@ -8,11 +8,11 @@ struct EmptyStateView: View {
                 .foregroundStyle(.white.opacity(0.3))
 
             Text("No images yet")
-                .font(.system(size: 20, weight: .semibold))
+                .font(.title3.weight(.semibold))
                 .foregroundStyle(.white.opacity(0.7))
 
-            Text("Add images to your SnapGrid library\non your Mac to see them here")
-                .font(.system(size: 15))
+            Text("Tap + to add images, or add them\nfrom your Mac to see them here")
+                .font(.subheadline)
                 .foregroundStyle(.white.opacity(0.4))
                 .multilineTextAlignment(.center)
         }
@@ -27,7 +27,7 @@ struct SearchEmptyStateView: View {
                 .foregroundStyle(.white.opacity(0.3))
 
             Text("No results found")
-                .font(.system(size: 18, weight: .semibold))
+                .font(.headline)
                 .foregroundStyle(.white.opacity(0.7))
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -45,18 +45,18 @@ struct ErrorStateView: View {
                 .foregroundStyle(.white.opacity(0.3))
 
             Text("Something went wrong")
-                .font(.system(size: 18, weight: .semibold))
+                .font(.headline)
                 .foregroundStyle(.white.opacity(0.7))
 
             Text(message)
-                .font(.system(size: 14))
+                .font(.subheadline)
                 .foregroundStyle(.white.opacity(0.4))
                 .multilineTextAlignment(.center)
 
             Button("Try Again") {
                 Task { await retry() }
             }
-            .font(.system(size: 15, weight: .medium))
+            .font(.subheadline.weight(.medium))
             .foregroundStyle(.white)
             .padding(.horizontal, 20)
             .padding(.vertical, 10)


### PR DESCRIPTION
### Why?

The iOS app had zero support for core Apple accessibility features — all font sizes were hardcoded (ignoring Dynamic Type), animations played regardless of Reduce Motion, tap targets on pattern pills were well under 44pt, and VoiceOver was missing hints on interactive elements.

### How?

Migrated all hardcoded `.font(.system(size: X))` calls across 8 views to semantic text styles, added `SnapSpring.resolved*` animation helpers that return brief ease-out when Reduce Motion is on (gating shimmer, staggered reveals, and delete animations), expanded tap targets to meet HIG minimums, and added VoiceOver hints/hiding where needed. Also redesigned detail view pattern pills (fully-rounded capsule shape, `.title3` summary) and updated empty state copy.

<details>
<summary>Implementation Plan</summary>

# Fix HIG Issues in SnapGrid iOS App

## Context

HIG audit of the iOS app found 12 issues. The biggest gaps are accessibility: no Dynamic Type, small tap targets, no Reduce Motion support, and missing VoiceOver hints. The forced dark mode is a conscious design choice for a photo viewer (matches Photos, Lightroom, Halide) — we keep it but fix everything else.

4 commits, each independently shippable.

---

## Commit 1: Dynamic Type — migrate hardcoded fonts to semantic text styles

Every view uses `.font(.system(size: X))` which ignores user text size preferences.

**Rule:** Decorative icons (48pt+) keep fixed sizes. All reading text gets semantic styles.

### OnboardingView.swift

- `.system(size: 34, weight: .bold)` → `.largeTitle.bold()`
- `.system(size: 17, weight: .regular)` → `.body`
- `.system(size: 17, weight: .medium)` → `.body.weight(.medium)`
- `.system(size: 17, weight: .semibold)` → `.body.weight(.semibold)`
- `.system(size: 13)` → `.footnote`

### SpaceTabBar.swift

- `.system(size: 15, weight: .medium)` → `.subheadline.weight(.medium)`
- `.system(size: 15, weight: isActive ? .medium : .regular)` → `.subheadline.weight(isActive ? .medium : .regular)`

### GridItemView.swift

- `.system(size: 20)` (iCloud icon) → `.body`
- `.system(size: 11)` → `.caption2`
- `.system(size: 10)` → `.caption2`
- `.system(size: 11, weight: .medium)` → `.caption2.weight(.medium)`

### PatternPills.swift

- `.system(size: 11, weight: .medium)` → `.caption2.weight(.medium)`

### EmptyStateView.swift

- `.system(size: 20, weight: .semibold)` → `.title3.weight(.semibold)`
- `.system(size: 15)` → `.subheadline`
- `.system(size: 18, weight: .semibold)` → `.headline`
- `.system(size: 14)` → `.subheadline`
- `.system(size: 15, weight: .medium)` → `.subheadline.weight(.medium)`

### FullScreenImageOverlay.swift (DetailMetadataSection)

- `.system(size: 16, weight: .semibold)` → `.headline`
- `.system(size: 13, weight: .medium)` → `.footnote.weight(.medium)`
- `.system(size: 14)` → `.subheadline`
- `.system(size: 12, design: .monospaced)` → `.caption.monospaced()`
- `.system(size: 18, weight: .medium)` (toolbar icons) → `.body.weight(.medium)`
- `.system(size: 13)` → `.footnote`
- ExpandableText: `font: .system(size: 14)` → `.subheadline`, `platformFont: .systemFont(ofSize: 14)` → `.preferredFont(forTextStyle: .subheadline)`

### ImageDetailView.swift

- `.system(size: 14)` → `.subheadline`
- `.system(size: 12, weight: .semibold)` → `.caption.weight(.semibold)`
- `.system(size: 13, weight: .medium)` → `.footnote.weight(.medium)`
- `.system(size: 11)` → `.caption2`

---

## Commit 2: Tap targets — expand hit areas to 44pt minimum

### FullScreenImageOverlay.swift — detail pattern pills

Redesigned pills with larger padding and Capsule shape for natural 44pt hit area.

### GridItemView.swift — retry button

Add `.frame(minWidth: 44, minHeight: 44).contentShape(Rectangle())` to the button label.

---

## Commit 3: Reduce Motion — respect `accessibilityReduceMotion`

### AnimationTokens.swift — add resolved helpers

```swift
extension SnapSpring {
    static func resolved(_ spring: Animation) -> Animation {
        UIAccessibility.isReduceMotionEnabled ? .easeOut(duration: 0.2) : spring
    }
    static var resolvedFast: Animation { resolved(fast) }
    static var resolvedStandard: Animation { resolved(standard) }
    static var resolvedHero: Animation { resolved(hero) }
    static var resolvedMetadata: Animation { resolved(metadata) }
}
```

### GridItemView.swift — ShimmerText

When Reduce Motion is on, show static text instead of animated shimmer.

### FullScreenImageOverlay.swift

- Hero open/close: `SnapSpring.hero` → `SnapSpring.resolvedHero`
- Staggered metadata reveal: skip to final state immediately
- Tag stagger animation: remove `.delay()`
- Delete animation: simple fade instead of wallet crush
- Navigation swipe/dismiss: `SnapSpring.standard` → `SnapSpring.resolvedStandard`

### SpaceTabBar.swift + MainView.swift

- All `SnapSpring.standard` → `SnapSpring.resolvedStandard`

---

## Commit 4: VoiceOver and empty state copy

- Pattern pills: add `.accessibilityHint("Double tap to search for this pattern")`
- Video indicator: `.accessibilityHidden(true)` (parent already labels "Video")
- Empty state: updated copy to mention the + import button

</details>

<sub>Generated with Claude Code</sub>