### PR TITLE
Separate AI guidance from master prompt and polish settings

### DIFF
--- a/SnapGrid/SnapGrid/Services/AIAnalysisService.swift
+++ b/SnapGrid/SnapGrid/Services/AIAnalysisService.swift
@@ -34,7 +34,7 @@ enum AIProvider: String, CaseIterable, Codable, Sendable {
 final class AIAnalysisService: Sendable {
     static let shared = AIAnalysisService()
 
-    private let systemPrompt = """
+    private let masterSystemPrompt = """
     You are an expert AI in analyzing images. Your task is to analyze the content of images and provide appropriate descriptions.
 
     Provide your response in the following JSON format:
@@ -59,15 +59,18 @@ final class AIAnalysisService: Sendable {
       7. List patterns in order of confidence/importance
       8. Ensure that the patterns are unique and not duplicates of each other and imageSummary
       9. Provide exactly 6 patterns, ordered by confidence
+      10. Respond with a strict, valid JSON object — do not include markdown formatting, explanations, or code block symbols
+      11. Use title case for pattern/object names
+      12. Provide up to 6 patterns, ordered by confidence
     """
 
-    static let defaultPromptDescription = "Analyze this image and provide a detailed breakdown of its content. If it's a UI screenshot, focus on UI patterns and components. If it's a general scene, focus on objects and subjects. Respond with a strict, valid JSON object in the format specified in the system prompt. Do not include markdown formatting, explanations, or code block symbols. Use title case for pattern/object names. Provide up to 6 patterns/objects, ordered by confidence."
+    static let defaultGuidance = "If it's a UI screenshot, focus on UI patterns and components. If it's a general scene, focus on objects and subjects."
 
-    private var userText: String { Self.defaultPromptDescription }
+    private let userText = "Analyze this image."
 
     private let maxRetries = 2
 
-    func analyze(image: NSImage, provider: AIProvider, model: String, spacePrompt: String? = nil) async throws -> AnalysisResult {
+    func analyze(image: NSImage, provider: AIProvider, model: String, guidance: String? = nil, spaceContext: String? = nil) async throws -> AnalysisResult {
         guard let apiKey = try KeychainService.get(service: provider.keychainService) else {
             throw AnalysisError.noAPIKey
         }
@@ -76,7 +79,7 @@ final class AIAnalysisService: Sendable {
             throw AnalysisError.imageConversionFailed
         }
 
-        let prompt = buildPrompt(spacePrompt: spacePrompt)
+        let prompt = buildPrompt(guidance: guidance, spaceContext: spaceContext)
 
         var lastError: Error?
         for attempt in 0...maxRetries {
@@ -114,14 +117,14 @@ final class AIAnalysisService: Sendable {
         return false
     }
 
-    func analyzeVideo(frames: [NSImage], provider: AIProvider, model: String, spacePrompt: String? = nil) async throws -> AnalysisResult {
+    func analyzeVideo(frames: [NSImage], provider: AIProvider, model: String, guidance: String? = nil, spaceContext: String? = nil) async throws -> AnalysisResult {
         // Analyze each frame and merge results
         var allPatterns: [String: [Double]] = [:]
         var contexts: [String] = []
         var summaries: [String] = []
 
         for frame in frames {
-            let result = try await analyze(image: frame, provider: provider, model: model, spacePrompt: spacePrompt)
+            let result = try await analyze(image: frame, provider: provider, model: model, guidance: guidance, spaceContext: spaceContext)
             contexts.append(result.imageContext)
             summaries.append(result.imageSummary)
 
@@ -284,11 +287,13 @@ final class AIAnalysisService: Sendable {
 
     // MARK: - Helpers
 
-    private func buildPrompt(spacePrompt: String?) -> String {
-        guard let spacePrompt, !spacePrompt.isEmpty else {
-            return systemPrompt
+    private func buildPrompt(guidance: String? = nil, spaceContext: String? = nil) -> String {
+        let effectiveGuidance = (guidance?.isEmpty == false ? guidance : nil) ?? Self.defaultGuidance
+        var result = masterSystemPrompt + "\n\nGuidance:\n" + effectiveGuidance
+        if let spaceContext, !spaceContext.isEmpty {
+            result += "\n" + spaceContext
         }
-        return systemPrompt + "\n\nAdditional instructions:\n" + spacePrompt
+        return result
     }
 
     /// Max dimension recommended by Anthropic — larger images are resized server-side anyway.

--- a/SnapGrid/SnapGrid/Services/ImportService.swift
+++ b/SnapGrid/SnapGrid/Services/ImportService.swift
@@ -161,25 +161,31 @@ final class ImportService {
             let result: AnalysisResult
             let storage = self.storage
 
-            // Build space prompt (applies to both images and videos)
-            var spacePrompt: String?
-            if let space = item.space, space.useCustomPrompt, let prompt = space.customPrompt {
-                spacePrompt = "This item belongs to a collection called \"\(space.name)\". \(prompt)"
-            } else if UserDefaults.standard.bool(forKey: "useAllSpacePrompt") {
-                let allPrompt = UserDefaults.standard.string(forKey: "allSpacePrompt") ?? ""
-                if !allPrompt.isEmpty {
-                    spacePrompt = allPrompt
+            // Resolve guidance and space context separately
+            var guidance: String?
+            var spaceContext: String?
+
+            if let space = item.space {
+                spaceContext = "This image belongs to a collection called \"\(space.name)\". Use this as context to inform your analysis."
+                if space.useCustomPrompt, let custom = space.customPrompt, !custom.isEmpty {
+                    guidance = custom
+                }
+            }
+            if guidance == nil, UserDefaults.standard.bool(forKey: "useAllSpacePrompt") {
+                let allGuidance = UserDefaults.standard.string(forKey: "allSpacePrompt") ?? ""
+                if !allGuidance.isEmpty {
+                    guidance = allGuidance
                 }
             }
 
             if item.isVideo {
                 let frames = try await VideoFrameExtractor.extractAnalysisFrames(from: storage.mediaURL(filename: item.filename))
-                result = try await analysisService.analyzeVideo(frames: frames, provider: provider, model: model, spacePrompt: spacePrompt)
+                result = try await analysisService.analyzeVideo(frames: frames, provider: provider, model: model, guidance: guidance, spaceContext: spaceContext)
             } else {
                 guard let image = NSImage(contentsOf: storage.mediaURL(filename: item.filename)) else {
                     throw ImportError.cannotReadDimensions
                 }
-                result = try await analysisService.analyze(image: image, provider: provider, model: model, spacePrompt: spacePrompt)
+                result = try await analysisService.analyze(image: image, provider: provider, model: model, guidance: guidance, spaceContext: spaceContext)
             }
 
             print("[Analysis] Success for \(item.id): \(result.patterns.count) patterns")

--- a/SnapGrid/SnapGrid/Views/Settings/AISettingsTab.swift
+++ b/SnapGrid/SnapGrid/Views/Settings/AISettingsTab.swift
@@ -9,7 +9,6 @@ struct AISettingsTab: View {
 
     @State private var apiKeyInput: String = ""
     @State private var hasKey: Bool = false
-@State private var showSaved: Bool = false
     @State private var saveError: String?
     @State private var keyWarning: String?
     @State private var discoveredModels: [DiscoveredModel] = []
@@ -19,51 +18,35 @@ struct AISettingsTab: View {
         AIProvider(rawValue: selectedProvider) ?? .openai
     }
 
+    private var keyPlaceholder: String {
+        switch provider {
+        case .openai: return "sk-..."
+        case .anthropic: return "sk-ant-..."
+        case .gemini: return "AIza..."
+        case .openrouter: return "sk-or-..."
+        }
+    }
+
+    private var keyGenerationURL: URL {
+        switch provider {
+        case .openai: return URL(string: "https://platform.openai.com/api-keys")!
+        case .anthropic: return URL(string: "https://console.anthropic.com/settings/keys")!
+        case .gemini: return URL(string: "https://aistudio.google.com/apikey")!
+        case .openrouter: return URL(string: "https://openrouter.ai/keys")!
+        }
+    }
+
     var body: some View {
         Form {
-            Section("AI Provider For Image Analysis") {
+            Section {
                 Picker("Provider", selection: $selectedProvider) {
                     ForEach(AIProvider.allCases, id: \.rawValue) { p in
                         Text(p.displayName).tag(p.rawValue)
                     }
                 }
-            }
-
-            Section("API Key") {
-                HStack {
-                    SecureField("Enter your \(provider.displayName) API key", text: $apiKeyInput)
-                        .textFieldStyle(.roundedBorder)
-                    Button("Save") {
-                        saveApiKey()
-                    }
-                    .disabled(apiKeyInput.isEmpty)
-                }
-
-                if let keyWarning {
-                    Text(keyWarning)
-                        .font(.caption)
-                        .foregroundStyle(.orange)
-                }
-
-                if showSaved {
-                    Text("API key saved")
-                        .font(.caption)
-                        .foregroundStyle(.green)
-                }
-
-                if let saveError {
-                    Text(saveError)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                }
 
                 if hasKey {
-                    HStack {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundStyle(.green)
-                        Text("Key configured")
-                            .foregroundStyle(.secondary)
-                        Spacer()
+                    LabeledContent("API Key") {
                         Button("Remove", role: .destructive) {
                             try? KeychainService.delete(service: provider.keychainService)
                             hasKey = false
@@ -72,6 +55,30 @@ struct AISettingsTab: View {
                             KeySyncService.syncToiCloud()
                         }
                     }
+                } else {
+                    HStack {
+                        SecureField("API Key", text: $apiKeyInput, prompt: Text(keyPlaceholder))
+                            .textFieldStyle(.roundedBorder)
+                        Button("Save") {
+                            saveApiKey()
+                        }
+                        .disabled(apiKeyInput.isEmpty)
+                    }
+
+                    Link("Get \(provider.displayName) API key", destination: keyGenerationURL)
+                        .font(.caption)
+                }
+
+                if let keyWarning {
+                    Text(keyWarning)
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+
+                if let saveError {
+                    Text(saveError)
+                        .font(.caption)
+                        .foregroundStyle(.red)
                 }
             }
 
@@ -103,13 +110,13 @@ struct AISettingsTab: View {
         let binding = modelBinding(for: provider)
 
         if !hasKey {
-            Text("Configure an API key above to select a model.")
+            Text("Add an API key to choose a model.")
                 .foregroundStyle(.secondary)
         } else if isLoadingModels {
             HStack {
                 ProgressView()
                     .controlSize(.small)
-                Text("Discovering available models…")
+                Text("Loading models…")
                     .foregroundStyle(.secondary)
             }
         } else if !discoveredModels.isEmpty {
@@ -148,8 +155,6 @@ struct AISettingsTab: View {
             hasKey = true
             apiKeyInput = ""
             saveError = nil
-            showSaved = true
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) { showSaved = false }
             ModelDiscoveryService.shared.clearCache(for: provider)
             Task { await loadModels() }
             NotificationCenter.default.post(name: .apiKeySaved, object: nil)

--- a/SnapGrid/SnapGrid/Views/Settings/DeveloperSettingsTab.swift
+++ b/SnapGrid/SnapGrid/Views/Settings/DeveloperSettingsTab.swift
@@ -45,7 +45,7 @@ struct DeveloperSettingsTab: View {
                         resetAllData()
                     }
                 } message: {
-                    Text("This will delete all imported media, analysis results, and spaces. The app will restart. This cannot be undone.")
+                    Text("This will delete all media, analysis results, and spaces. This cannot be undone. The app will restart.")
                 }
             }
         }

--- a/SnapGrid/SnapGrid/Views/Settings/PromptsSettingsTab.swift
+++ b/SnapGrid/SnapGrid/Views/Settings/PromptsSettingsTab.swift
@@ -1,14 +1,14 @@
 import SwiftUI
 import SwiftData
 
-struct PromptsSettingsTab: View {
+struct GuidanceSettingsTab: View {
     @Query(sort: \Space.order) private var spaces: [Space]
     @Environment(\.modelContext) private var modelContext
 
-    @AppStorage("allSpacePrompt") private var allSpacePrompt: String = ""
-    @AppStorage("useAllSpacePrompt") private var useAllSpacePrompt: Bool = false
+    @AppStorage("allSpacePrompt") private var allSpaceGuidance: String = ""
+    @AppStorage("useAllSpacePrompt") private var useAllSpaceGuidance: Bool = false
 
-    @State private var editingPrompt: PromptEditTarget?
+    @State private var editingTarget: GuidanceEditTarget?
     @State private var selectedOverrideId: String?
 
     private var spacesWithOverrides: [Space] {
@@ -26,27 +26,27 @@ struct PromptsSettingsTab: View {
 
     var body: some View {
         Form {
-            // MARK: - Default Prompt
+            // MARK: - Default Guidance
 
-            Section("Default Prompt") {
-                Toggle("Override default prompt", isOn: $useAllSpacePrompt)
-                    .onChange(of: useAllSpacePrompt) { _, isOn in
-                        if isOn && allSpacePrompt.isEmpty {
-                            allSpacePrompt = AIAnalysisService.defaultPromptDescription
+            Section("Analysis Guidance") {
+                Toggle("Use custom guidance", isOn: $useAllSpaceGuidance)
+                    .onChange(of: useAllSpaceGuidance) { _, isOn in
+                        if isOn && allSpaceGuidance.isEmpty {
+                            allSpaceGuidance = AIAnalysisService.defaultGuidance
                         }
                         if !isOn {
-                            allSpacePrompt = ""
+                            allSpaceGuidance = ""
                         }
                     }
 
                 VStack(alignment: .leading, spacing: 8) {
-                    Text(useAllSpacePrompt ? allSpacePrompt : AIAnalysisService.defaultPromptDescription)
+                    Text(useAllSpaceGuidance ? allSpaceGuidance : AIAnalysisService.defaultGuidance)
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
-                    if useAllSpacePrompt {
+                    if useAllSpaceGuidance {
                         Button("Edit") {
-                            editingPrompt = .defaultPrompt(allSpacePrompt)
+                            editingTarget = .defaultGuidance(allSpaceGuidance)
                         }
                     }
                 }
@@ -55,8 +55,8 @@ struct PromptsSettingsTab: View {
             // MARK: - Space Overrides
 
             if !spaces.isEmpty {
-                Section("Space Overrides") {
-                    Text("Additional instructions appended to the default prompt for specific spaces.")
+                Section("Per-Space Guidance") {
+                    Text("When set, replaces the default for that space.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
@@ -64,8 +64,8 @@ struct PromptsSettingsTab: View {
                         ForEach(spacesWithOverrides) { space in
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(space.name)
-                                if let prompt = space.customPrompt, !prompt.isEmpty {
-                                    Text(prompt)
+                                if let guidance = space.customPrompt, !guidance.isEmpty {
+                                    Text(guidance)
                                         .font(.caption)
                                         .foregroundStyle(.secondary)
                                         .lineLimit(1)
@@ -76,6 +76,10 @@ struct PromptsSettingsTab: View {
                     }
                     .listStyle(.bordered)
                     .frame(height: max(72, CGFloat(spacesWithOverrides.count) * 40))
+                    .onDoubleClick(handler: {
+                        guard let space = selectedSpace else { return }
+                        editingTarget = .spaceGuidance(space.id, space.name, space.customPrompt ?? "")
+                    })
 
                     HStack(spacing: 8) {
                         Menu("Add...") {
@@ -85,7 +89,7 @@ struct PromptsSettingsTab: View {
                                     if space.customPrompt == nil { space.customPrompt = "" }
                                     try? modelContext.save()
                                     selectedOverrideId = space.id
-                                    editingPrompt = .spacePrompt(space.id, space.name, "")
+                                    editingTarget = .spaceGuidance(space.id, space.name, "")
                                 }
                             }
                         }
@@ -103,7 +107,7 @@ struct PromptsSettingsTab: View {
 
                         Button("Edit") {
                             guard let space = selectedSpace else { return }
-                            editingPrompt = .spacePrompt(space.id, space.name, space.customPrompt ?? "")
+                            editingTarget = .spaceGuidance(space.id, space.name, space.customPrompt ?? "")
                         }
                         .disabled(selectedSpace == nil)
 
@@ -115,8 +119,8 @@ struct PromptsSettingsTab: View {
         }
         .formStyle(.grouped)
         .textSelection(.enabled)
-        .sheet(item: $editingPrompt) { target in
-            PromptEditorSheet(target: target) { newText in
+        .sheet(item: $editingTarget) { target in
+            GuidanceEditorSheet(target: target) { newText in
                 applyEdit(target: target, text: newText)
             }
         }
@@ -124,12 +128,12 @@ struct PromptsSettingsTab: View {
 
     // MARK: - Apply Edit
 
-    private func applyEdit(target: PromptEditTarget, text: String) {
+    private func applyEdit(target: GuidanceEditTarget, text: String) {
         switch target {
-        case .defaultPrompt:
-            allSpacePrompt = text
-            useAllSpacePrompt = !text.isEmpty
-        case .spacePrompt(let spaceId, _, _):
+        case .defaultGuidance:
+            allSpaceGuidance = text
+            useAllSpaceGuidance = !text.isEmpty
+        case .spaceGuidance(let spaceId, _, _):
             guard let space = spaces.first(where: { $0.id == spaceId }) else { return }
             space.customPrompt = text
             space.useCustomPrompt = !text.isEmpty
@@ -140,42 +144,107 @@ struct PromptsSettingsTab: View {
 
 // MARK: - Edit Target
 
-private enum PromptEditTarget: Identifiable {
-    case defaultPrompt(String)
-    case spacePrompt(String, String, String) // id, name, text
+private enum GuidanceEditTarget: Identifiable {
+    case defaultGuidance(String)
+    case spaceGuidance(String, String, String) // id, name, text
 
     var id: String {
         switch self {
-        case .defaultPrompt: return "default"
-        case .spacePrompt(let spaceId, _, _): return spaceId
+        case .defaultGuidance: return "default"
+        case .spaceGuidance(let spaceId, _, _): return spaceId
         }
     }
 
     var title: String {
         switch self {
-        case .defaultPrompt: return "Default Prompt"
-        case .spacePrompt(_, let name, _): return name
+        case .defaultGuidance: return "Default Guidance"
+        case .spaceGuidance(_, let name, _): return name
         }
     }
 
     var text: String {
         switch self {
-        case .defaultPrompt(let text): return text
-        case .spacePrompt(_, _, let text): return text
+        case .defaultGuidance(let text): return text
+        case .spaceGuidance(_, _, let text): return text
         }
     }
 }
 
-// MARK: - Prompt Editor Sheet
+// MARK: - NSTextView wrapper (TextEditor in sheets breaks Cmd+C/V)
 
-private struct PromptEditorSheet: View {
-    let target: PromptEditTarget
+private struct NativeTextEditor: NSViewRepresentable {
+    @Binding var text: String
+    var placeholder: String
+    var font: NSFont
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSTextView.scrollableTextView()
+        let textView = scrollView.documentView as! NSTextView
+        textView.font = font
+        textView.isRichText = false
+        textView.allowsUndo = true
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.backgroundColor = .clear
+        textView.textContainerInset = NSSize(width: 8, height: 8)
+        textView.delegate = context.coordinator
+        textView.string = text
+        scrollView.hasVerticalScroller = true
+        scrollView.drawsBackground = false
+
+        // Add placeholder label
+        let label = NSTextField(labelWithString: placeholder)
+        label.font = font
+        label.textColor = .tertiaryLabelColor
+        label.tag = 999
+        label.translatesAutoresizingMaskIntoConstraints = false
+        textView.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: textView.topAnchor, constant: 8),
+            label.leadingAnchor.constraint(equalTo: textView.leadingAnchor, constant: 12),
+        ])
+        label.isHidden = !text.isEmpty
+
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        let textView = scrollView.documentView as! NSTextView
+        if textView.string != text {
+            textView.string = text
+        }
+        textView.subviews.first(where: { $0.tag == 999 })?.isHidden = !text.isEmpty
+
+        // Make text view first responder so Edit menu (Cmd+C/V/X) works
+        if !context.coordinator.hasFocused, let window = textView.window {
+            window.makeFirstResponder(textView)
+            context.coordinator.hasFocused = true
+        }
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        let parent: NativeTextEditor
+        var hasFocused = false
+        init(_ parent: NativeTextEditor) { self.parent = parent }
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            parent.text = textView.string
+        }
+    }
+}
+
+// MARK: - Guidance Editor Sheet
+
+private struct GuidanceEditorSheet: View {
+    let target: GuidanceEditTarget
     let onSave: (String) -> Void
 
     @Environment(\.dismiss) private var dismiss
     @State private var draft: String
 
-    init(target: PromptEditTarget, onSave: @escaping (String) -> Void) {
+    init(target: GuidanceEditTarget, onSave: @escaping (String) -> Void) {
         self.target = target
         self.onSave = onSave
         self._draft = State(initialValue: target.text)
@@ -184,7 +253,7 @@ private struct PromptEditorSheet: View {
     var body: some View {
         VStack(spacing: 0) {
             HStack {
-                Text("Edit Prompt — \(target.title)")
+                Text("Edit Guidance — \(target.title)")
                     .font(.headline)
                 Spacer()
             }
@@ -192,10 +261,11 @@ private struct PromptEditorSheet: View {
 
             Divider()
 
-            TextEditor(text: $draft)
-                .font(.caption.monospaced())
-                .scrollContentBackground(.hidden)
-                .padding(12)
+            NativeTextEditor(
+                text: $draft,
+                placeholder: "e.g., Focus on typography, color palettes, and layout patterns",
+                font: .monospacedSystemFont(ofSize: 11, weight: .regular)
+            )
 
             Divider()
 

--- a/SnapGrid/SnapGrid/Views/Settings/SettingsView.swift
+++ b/SnapGrid/SnapGrid/Views/Settings/SettingsView.swift
@@ -8,9 +8,9 @@ struct SettingsView: View {
                     Label("AI", systemImage: "brain")
                 }
 
-            PromptsSettingsTab()
+            GuidanceSettingsTab()
                 .tabItem {
-                    Label("Prompts", systemImage: "text.quote")
+                    Label("Guidance", systemImage: "text.quote")
                 }
 
             StorageSettingsTab()

--- a/SnapGrid/SnapGrid/Views/Settings/StorageSettingsTab.swift
+++ b/SnapGrid/SnapGrid/Views/Settings/StorageSettingsTab.swift
@@ -47,7 +47,7 @@ struct StorageSettingsTab: View {
         let manager = iCloudDownloadManager.shared
 
         Section("iCloud") {
-            Toggle("Keep all files downloaded locally", isOn: $keepFilesLocal)
+            Toggle("Keep files downloaded", isOn: $keepFilesLocal)
                 .onChange(of: keepFilesLocal) { _, enabled in
                     if enabled {
                         manager.downloadAll()
@@ -79,7 +79,7 @@ struct StorageSettingsTab: View {
                     }
                 } else {
                     HStack(spacing: 4) {
-                        Text("\(evicted) files waiting to download")
+                        Text("\(evicted) files in iCloud only")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                         Button("Download Now") {

--- a/ios/SnapGrid/SnapGrid/Services/AIAnalysisService.swift
+++ b/ios/SnapGrid/SnapGrid/Services/AIAnalysisService.swift
@@ -29,7 +29,7 @@ enum AIProvider: String, CaseIterable, Codable, Sendable {
 final class AIAnalysisService: Sendable {
     static let shared = AIAnalysisService()
 
-    private let systemPrompt = """
+    private let masterSystemPrompt = """
     You are an expert AI in analyzing images. Your task is to analyze the content of images and provide appropriate descriptions.
 
     Provide your response in the following JSON format:
@@ -54,18 +54,23 @@ final class AIAnalysisService: Sendable {
       7. List patterns in order of confidence/importance
       8. Ensure that the patterns are unique and not duplicates of each other and imageSummary
       9. Provide exactly 6 patterns, ordered by confidence
+      10. Respond with a strict, valid JSON object — do not include markdown formatting, explanations, or code block symbols
+      11. Use title case for pattern/object names
+      12. Provide up to 6 patterns, ordered by confidence
     """
 
-    private let userText = "Analyze this image and provide a detailed breakdown of its content. If it's a UI screenshot, focus on UI patterns and components. If it's a general scene, focus on objects and subjects. Respond with a strict, valid JSON object in the format specified in the system prompt. Do not include markdown formatting, explanations, or code block symbols. Use title case for pattern/object names. Provide up to 6 patterns/objects, ordered by confidence."
+    static let defaultGuidance = "If it's a UI screenshot, focus on UI patterns and components. If it's a general scene, focus on objects and subjects."
+
+    private let userText = "Analyze this image."
 
     private let maxRetries = 2
 
-    func analyze(image: UIImage, provider: AIProvider, model: String, apiKey: String, spacePrompt: String? = nil) async throws -> AnalysisResult {
+    func analyze(image: UIImage, provider: AIProvider, model: String, apiKey: String, guidance: String? = nil, spaceContext: String? = nil) async throws -> AnalysisResult {
         guard let base64 = imageToBase64(image) else {
             throw AnalysisError.imageConversionFailed
         }
 
-        let prompt = buildPrompt(spacePrompt: spacePrompt)
+        let prompt = buildPrompt(guidance: guidance, spaceContext: spaceContext)
 
         var lastError: Error?
         for attempt in 0...maxRetries {
@@ -236,11 +241,13 @@ final class AIAnalysisService: Sendable {
 
     // MARK: - Helpers
 
-    private func buildPrompt(spacePrompt: String?) -> String {
-        guard let spacePrompt, !spacePrompt.isEmpty else {
-            return systemPrompt
+    private func buildPrompt(guidance: String? = nil, spaceContext: String? = nil) -> String {
+        let effectiveGuidance = (guidance?.isEmpty == false ? guidance : nil) ?? Self.defaultGuidance
+        var result = masterSystemPrompt + "\n\nGuidance:\n" + effectiveGuidance
+        if let spaceContext, !spaceContext.isEmpty {
+            result += "\n" + spaceContext
         }
-        return systemPrompt + "\n\nAdditional instructions:\n" + spacePrompt
+        return result
     }
 
     private let maxImageDimension: CGFloat = 1568

--- a/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
@@ -511,11 +511,24 @@ struct MainView: View {
                 item.isAnalyzing = true
                 do {
                     let image = try loadImage(for: item, rootURL: rootURL)
+
+                    // Resolve guidance and space context
+                    var guidance: String?
+                    var spaceContext: String?
+                    if let space = item.space {
+                        spaceContext = "This image belongs to a collection called \"\(space.name)\". Use this as context to inform your analysis."
+                        if space.useCustomPrompt, let custom = space.customPrompt, !custom.isEmpty {
+                            guidance = custom
+                        }
+                    }
+
                     let result = try await AIAnalysisService.shared.analyze(
                         image: image,
                         provider: provider,
                         model: resolvedModel,
-                        apiKey: apiKey
+                        apiKey: apiKey,
+                        guidance: guidance,
+                        spaceContext: spaceContext
                     )
                     item.analysisResult = result
                     item.isAnalyzing = false

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -50,8 +50,8 @@ interface SettingsPanelProps {
   onCreateSpace: (name: string) => Promise<Space>;
   onRenameSpace: (id: string, name: string) => Promise<void>;
   onDeleteSpace: (id: string) => Promise<void>;
-  onUpdateSpacePrompt: (id: string, customPrompt: string | undefined, useCustomPrompt: boolean) => Promise<void>;
-  onUpdateAllSpacePrompt: (customPrompt: string | undefined, useCustomPrompt: boolean) => Promise<void>;
+  onUpdateSpaceGuidance: (id: string, customPrompt: string | undefined, useCustomPrompt: boolean) => Promise<void>;
+  onUpdateAllSpaceGuidance: (customPrompt: string | undefined, useCustomPrompt: boolean) => Promise<void>;
   onReorderSpaces?: (fromIndex: number, toIndex: number) => void;
   onShuffleImages?: () => void;
 }
@@ -65,8 +65,8 @@ export function SettingsPanel({
   onCreateSpace,
   onRenameSpace,
   onDeleteSpace,
-  onUpdateSpacePrompt,
-  onUpdateAllSpacePrompt,
+  onUpdateSpaceGuidance,
+  onUpdateAllSpaceGuidance,
   onReorderSpaces,
   onShuffleImages,
 }: SettingsPanelProps) {
@@ -174,8 +174,8 @@ export function SettingsPanel({
                     onCreateSpace={onCreateSpace}
                     onRenameSpace={onRenameSpace}
                     onDeleteSpace={onDeleteSpace}
-                    onUpdateSpacePrompt={onUpdateSpacePrompt}
-                    onUpdateAllSpacePrompt={onUpdateAllSpacePrompt}
+                    onUpdateSpaceGuidance={onUpdateSpaceGuidance}
+                    onUpdateAllSpaceGuidance={onUpdateAllSpaceGuidance}
                     onReorderSpaces={onReorderSpaces}
                   />
                 </motion.div>
@@ -845,8 +845,8 @@ interface SpacesTabProps {
   onCreateSpace: (name: string) => Promise<Space>;
   onRenameSpace: (id: string, name: string) => Promise<void>;
   onDeleteSpace: (id: string) => Promise<void>;
-  onUpdateSpacePrompt: (id: string, customPrompt: string | undefined, useCustomPrompt: boolean) => Promise<void>;
-  onUpdateAllSpacePrompt: (customPrompt: string | undefined, useCustomPrompt: boolean) => Promise<void>;
+  onUpdateSpaceGuidance: (id: string, customPrompt: string | undefined, useCustomPrompt: boolean) => Promise<void>;
+  onUpdateAllSpaceGuidance: (customPrompt: string | undefined, useCustomPrompt: boolean) => Promise<void>;
   onReorderSpaces?: (fromIndex: number, toIndex: number) => void;
 }
 
@@ -857,8 +857,8 @@ const SpacesTab = ({
   onCreateSpace,
   onRenameSpace,
   onDeleteSpace,
-  onUpdateSpacePrompt,
-  onUpdateAllSpacePrompt,
+  onUpdateSpaceGuidance,
+  onUpdateAllSpaceGuidance,
   onReorderSpaces,
 }: SpacesTabProps) => {
   // Which space is selected for editing (null = "All")
@@ -897,9 +897,9 @@ const SpacesTab = ({
 
   const handleToggleCustomPrompt = (checked: boolean) => {
     if (selectedSpaceId === null) {
-      onUpdateAllSpacePrompt(currentPromptText || undefined, checked);
+      onUpdateAllSpaceGuidance(currentPromptText || undefined, checked);
     } else {
-      onUpdateSpacePrompt(selectedSpaceId, currentPromptText || undefined, checked);
+      onUpdateSpaceGuidance(selectedSpaceId, currentPromptText || undefined, checked);
     }
   };
 
@@ -909,12 +909,12 @@ const SpacesTab = ({
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
       if (selectedSpaceId === null) {
-        onUpdateAllSpacePrompt(text, true);
+        onUpdateAllSpaceGuidance(text, true);
       } else {
-        onUpdateSpacePrompt(selectedSpaceId, text, true);
+        onUpdateSpaceGuidance(selectedSpaceId, text, true);
       }
     }, 500);
-  }, [selectedSpaceId, onUpdateAllSpacePrompt, onUpdateSpacePrompt]);
+  }, [selectedSpaceId, onUpdateAllSpaceGuidance, onUpdateSpaceGuidance]);
 
   // Clean up debounce on unmount
   useEffect(() => {
@@ -1117,7 +1117,7 @@ const SpacesTab = ({
                 )}
                 {item.hasCustomPrompt && (
                   <span className="flex-shrink-0 text-[10px] px-1.5 py-0.5 rounded bg-gray-200 dark:bg-zinc-700 text-gray-500 dark:text-gray-400 select-none">
-                    custom instructions
+                    custom guidance
                   </span>
                 )}
               </div>
@@ -1193,15 +1193,15 @@ const SpacesTab = ({
         </button>
       </div>
 
-      {/* Prompt section */}
+      {/* Guidance section */}
       <div className="pt-4 border-t border-gray-100 dark:border-zinc-800/50 space-y-3">
         <h3 className="text-[11px] font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 select-none">
-          Analysis Instructions
+          Analysis Guidance
           {selectedSpaceId === null ? " — All" : ` — ${selectedSpace?.name ?? ""}`}
         </h3>
 
         <div className="flex items-center justify-between">
-          <span className="text-sm text-gray-700 dark:text-gray-300 select-none">Custom instructions</span>
+          <span className="text-sm text-gray-700 dark:text-gray-300 select-none">Custom guidance</span>
           <Switch
             checked={isCustom}
             onCheckedChange={handleToggleCustomPrompt}
@@ -1220,7 +1220,7 @@ const SpacesTab = ({
           </div>
         ) : (
           <p className="text-xs text-gray-500 dark:text-gray-500 select-none">
-            Using the built-in prompt. App updates will automatically improve analysis.
+            Using default guidance. App updates will automatically improve analysis.
           </p>
         )}
       </div>

--- a/src/hooks/useImageAnalysis.tsx
+++ b/src/hooks/useImageAnalysis.tsx
@@ -5,8 +5,8 @@ import { captureVideoFrames } from '../lib/videoUtils';
 import { ImageItem, PatternTag } from "./useImageStore";
 
 export interface UseImageAnalysisReturn {
-  analyzeAndUpdateImage: (media: ImageItem, dataUrl: string, savedFilePath?: string, systemPrompt?: string) => Promise<ImageItem>;
-  retryAnalysis: (imageId: string, images: ImageItem[], updateImageFn: (id: string, updater: (img: ImageItem) => ImageItem) => void, systemPrompt?: string) => Promise<void>;
+  analyzeAndUpdateImage: (media: ImageItem, dataUrl: string, savedFilePath?: string, guidance?: string) => Promise<ImageItem>;
+  retryAnalysis: (imageId: string, images: ImageItem[], updateImageFn: (id: string, updater: (img: ImageItem) => ImageItem) => void, guidance?: string) => Promise<void>;
 }
 
 export function useImageAnalysis(): UseImageAnalysisReturn {
@@ -14,7 +14,7 @@ export function useImageAnalysis(): UseImageAnalysisReturn {
     media: ImageItem,
     dataUrl: string,
     savedFilePath?: string,
-    systemPrompt?: string
+    guidance?: string
   ): Promise<ImageItem> => {
     // Early return if no API key available
     const hasKey = await hasApiKey();
@@ -27,7 +27,7 @@ export function useImageAnalysis(): UseImageAnalysisReturn {
       // Handle different media types
       if (media.type === "image") {
         // For images, use the standard analysis
-        analysis = await analyzeImage(dataUrl, systemPrompt);
+        analysis = await analyzeImage(dataUrl, guidance);
       } else if (media.type === "video") {
         // For videos, capture frames and analyze them
         isAnalyzingVideo = true;
@@ -35,7 +35,7 @@ export function useImageAnalysis(): UseImageAnalysisReturn {
           // Capture frames at 33% and 66% of the video duration
           const frames = await captureVideoFrames(dataUrl);
           // Analyze the captured frames
-          analysis = await analyzeVideoFrames(frames, systemPrompt);
+          analysis = await analyzeVideoFrames(frames, guidance);
         } catch (frameError) {
           console.error("Failed to capture or analyze video frames:", frameError);
           throw new Error("Failed to analyze video: " + (frameError instanceof Error ? frameError.message : 'Unknown error'));
@@ -44,17 +44,17 @@ export function useImageAnalysis(): UseImageAnalysisReturn {
         // Unsupported media type
         return media;
       }
-      
+
       // Extract the imageContext from the first pattern (should be the same for all patterns)
       const imageContext = analysis[0]?.imageContext || '';
-      
+
       const patternTags = analysis
         .map(pattern => {
           const name = pattern.pattern || pattern.name;
           if (!name) return null;
-          
-          return { 
-            name, 
+
+          return {
+            name,
             confidence: pattern.confidence,
             imageContext: pattern.imageContext,
             imageSummary: pattern.imageSummary
@@ -62,9 +62,9 @@ export function useImageAnalysis(): UseImageAnalysisReturn {
         })
         .filter((tag): tag is PatternTag => tag !== null);
 
-      const updatedMedia = { 
-        ...media, 
-        patterns: patternTags, 
+      const updatedMedia = {
+        ...media,
+        patterns: patternTags,
         isAnalyzing: false,
         imageContext: imageContext // Set imageContext at the image level
       };
@@ -108,7 +108,7 @@ export function useImageAnalysis(): UseImageAnalysisReturn {
           console.error("Failed to update error state metadata:", metadataError);
         }
       }
-      
+
       return updatedMedia;
     }
   }, []);
@@ -117,7 +117,7 @@ export function useImageAnalysis(): UseImageAnalysisReturn {
     imageId: string,
     images: ImageItem[],
     updateImageFn: (id: string, updater: (img: ImageItem) => ImageItem) => void,
-    systemPrompt?: string
+    guidance?: string
   ) => {
     // Find the media
     const mediaToAnalyze = images.find(img => img.id === imageId);
@@ -139,7 +139,7 @@ export function useImageAnalysis(): UseImageAnalysisReturn {
     try {
       // Get the data URL for analysis
       let dataUrl;
-      
+
       if (mediaToAnalyze.actualFilePath) {
         if (mediaToAnalyze.type === "image") {
           // If we have a file path, convert image to base64
@@ -154,9 +154,9 @@ export function useImageAnalysis(): UseImageAnalysisReturn {
       } else {
         throw new Error("No media data available for analysis");
       }
-      
+
       // Perform analysis
-      const analyzedMedia = await analyzeAndUpdateImage(mediaToAnalyze, dataUrl, mediaToAnalyze.actualFilePath, systemPrompt);
+      const analyzedMedia = await analyzeAndUpdateImage(mediaToAnalyze, dataUrl, mediaToAnalyze.actualFilePath, guidance);
 
       // Merge analysis results into the current image state (preserves concurrent updates like spaceId)
       updateImageFn(imageId, (img) => ({
@@ -171,7 +171,7 @@ export function useImageAnalysis(): UseImageAnalysisReturn {
 
       // Update error state in UI (merge into current state to preserve concurrent updates)
       updateImageFn(imageId, (img) => ({ ...img, isAnalyzing: false, error: 'Analysis failed' }));
-      
+
       // Persist error state to disk
       if (window.electron && mediaToAnalyze.actualFilePath) {
         try {

--- a/src/hooks/useImageStore.tsx
+++ b/src/hooks/useImageStore.tsx
@@ -66,8 +66,8 @@ export function useImageStore() {
     });
   }, [collection.setImages]);
 
-  // Assign multiple images to a space (bulk), then re-analyze each with the target space's prompt
-  const assignImagesToSpace = useCallback(async (imageIds: string[], spaceId: string | null, systemPrompt?: string) => {
+  // Assign multiple images to a space (bulk), then re-analyze each with the target space's guidance
+  const assignImagesToSpace = useCallback(async (imageIds: string[], spaceId: string | null, guidance?: string) => {
     // Update all in state immediately
     for (const imageId of imageIds) {
       updateImage(imageId, (img) => ({ ...img, spaceId: spaceId ?? undefined }));
@@ -81,12 +81,12 @@ export function useImageStore() {
       const { url, isAnalyzing, error, ...metadataToSave } = updatedImage;
       await window.electron.updateMetadata({ id: imageId, metadata: { ...metadataToSave, spaceId: spaceId } });
       updateImage(imageId, (img) => ({ ...img, isAnalyzing: true, error: undefined }));
-      await analysis.retryAnalysis(imageId, collection.images, updateImage, systemPrompt);
+      await analysis.retryAnalysis(imageId, collection.images, updateImage, guidance);
     }));
   }, [collection.images, updateImage, analysis]);
 
   // Assign an image to a space (or remove from space with null), then re-analyze with the target space's prompt
-  const assignImageToSpace = useCallback(async (imageId: string, spaceId: string | null, systemPrompt?: string) => {
+  const assignImageToSpace = useCallback(async (imageId: string, spaceId: string | null, guidance?: string) => {
     const image = collection.images.find(img => img.id === imageId);
     if (!image) return;
 
@@ -99,17 +99,17 @@ export function useImageStore() {
 
     // Re-analyze with the target space's prompt
     updateImage(imageId, (img) => ({ ...img, isAnalyzing: true, error: undefined }));
-    await analysis.retryAnalysis(imageId, collection.images, updateImage, systemPrompt);
+    await analysis.retryAnalysis(imageId, collection.images, updateImage, guidance);
   }, [collection.images, updateImage, analysis]);
 
   // Enhanced addImage that uses the new hooks
-  const addImage = useCallback(async (file: File, spaceId?: string, systemPrompt?: string) => {
+  const addImage = useCallback(async (file: File, spaceId?: string, guidance?: string) => {
     await fileSystem.addImageFromFile(
       file,
       addToCollection,
       async (media, dataUrl, savedFilePath) => {
         const analyzingMedia = { ...media, isAnalyzing: true };
-        const analyzedMedia = await analysis.analyzeAndUpdateImage(analyzingMedia, dataUrl, savedFilePath, systemPrompt);
+        const analyzedMedia = await analysis.analyzeAndUpdateImage(analyzingMedia, dataUrl, savedFilePath, guidance);
         return analyzedMedia;
       },
       spaceId
@@ -117,13 +117,13 @@ export function useImageStore() {
   }, [fileSystem, analysis, addToCollection]);
 
   // Enhanced importFromFilePath that uses the new hooks
-  const importFromFilePath = useCallback(async (filePath: string, spaceId?: string, systemPrompt?: string) => {
+  const importFromFilePath = useCallback(async (filePath: string, spaceId?: string, guidance?: string) => {
     await fileSystem.importFromFilePath(
       filePath,
       addToCollection,
       async (media, dataUrl, savedFilePath) => {
         const analyzingMedia = { ...media, isAnalyzing: true };
-        const analyzedMedia = await analysis.analyzeAndUpdateImage(analyzingMedia, dataUrl, savedFilePath, systemPrompt);
+        const analyzedMedia = await analysis.analyzeAndUpdateImage(analyzingMedia, dataUrl, savedFilePath, guidance);
         return analyzedMedia;
       },
       spaceId
@@ -131,8 +131,8 @@ export function useImageStore() {
   }, [fileSystem, analysis, addToCollection]);
 
   // Enhanced retryAnalysis that uses the new hooks
-  const retryAnalysis = useCallback(async (imageId: string, systemPrompt?: string) => {
-    await analysis.retryAnalysis(imageId, collection.images, updateImage, systemPrompt);
+  const retryAnalysis = useCallback(async (imageId: string, guidance?: string) => {
+    await analysis.retryAnalysis(imageId, collection.images, updateImage, guidance);
   }, [analysis, collection.images, updateImage]);
 
   // Set up queue management

--- a/src/hooks/useSpaces.ts
+++ b/src/hooks/useSpaces.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from "react";
-import { DEFAULT_SYSTEM_PROMPT } from "@/services/aiAnalysisService";
+import { DEFAULT_GUIDANCE } from "@/services/aiAnalysisService";
 
 export interface Space {
   id: string;
@@ -23,47 +23,43 @@ export interface UseSpacesReturn {
   createSpace: (name: string) => Promise<Space>;
   renameSpace: (id: string, name: string) => Promise<void>;
   deleteSpace: (id: string) => Promise<void>;
-  updateSpacePrompt: (id: string, customPrompt: string | undefined, useCustomPrompt: boolean) => Promise<void>;
+  updateSpaceGuidance: (id: string, customPrompt: string | undefined, useCustomPrompt: boolean) => Promise<void>;
   allSpacePromptConfig: AllSpacePromptConfig;
   reorderSpaces: (fromIndex: number, toIndex: number) => Promise<void>;
-  updateAllSpacePrompt: (customPrompt: string | undefined, useCustomPrompt: boolean) => Promise<void>;
+  updateAllSpaceGuidance: (customPrompt: string | undefined, useCustomPrompt: boolean) => Promise<void>;
   isLoading: boolean;
 }
 
-export function resolvePromptForSpace(
+export function resolveGuidanceForSpace(
   spaceId: string | null | undefined,
   spaces: Space[],
   allSpacePromptConfig: AllSpacePromptConfig
 ): string | undefined {
-  let spaceName: string | undefined;
-  let customInstructions: string | undefined;
-
+  // Global guidance override (applies when viewing "All")
   if (spaceId === null || spaceId === undefined) {
     if (allSpacePromptConfig.useCustomPrompt && allSpacePromptConfig.customPrompt) {
-      customInstructions = allSpacePromptConfig.customPrompt;
+      return allSpacePromptConfig.customPrompt;
     }
+    return undefined;
+  }
+
+  // Space-specific guidance
+  const space = spaces.find(s => s.id === spaceId);
+  if (!space) return undefined;
+
+  const parts: string[] = [];
+
+  // Space name context
+  parts.push(`This image belongs to a collection called "${space.name}". Use this as context to inform your analysis.`);
+
+  // Custom guidance replaces default; if no custom guidance, include default
+  if (space.useCustomPrompt && space.customPrompt) {
+    parts.push(space.customPrompt);
   } else {
-    const space = spaces.find(s => s.id === spaceId);
-    if (space) {
-      spaceName = space.name;
-      if (space.useCustomPrompt && space.customPrompt) {
-        customInstructions = space.customPrompt;
-      }
-    }
+    parts.push(DEFAULT_GUIDANCE);
   }
 
-  const additions: string[] = [];
-  if (spaceName) {
-    additions.push(`This image belongs to a collection called "${spaceName}". Use this as context to inform your analysis — pay attention to aspects relevant to this theme.`);
-  }
-  if (customInstructions) {
-    additions.push(customInstructions);
-  }
-
-  if (additions.length > 0) {
-    return `${DEFAULT_SYSTEM_PROMPT}\n\nAdditional instructions:\n${additions.join('\n')}`;
-  }
-  return undefined;
+  return parts.join(' ');
 }
 
 function generateId(): string {
@@ -162,7 +158,7 @@ export function useSpaces(): UseSpacesReturn {
     await persistSpaces(updated);
   }, [spaces, persistSpaces]);
 
-  const updateSpacePrompt = useCallback(async (
+  const updateSpaceGuidance = useCallback(async (
     id: string,
     customPrompt: string | undefined,
     useCustomPrompt: boolean
@@ -174,7 +170,7 @@ export function useSpaces(): UseSpacesReturn {
     await persistSpaces(updated);
   }, [spaces, persistSpaces]);
 
-  const updateAllSpacePrompt = useCallback(async (
+  const updateAllSpaceGuidance = useCallback(async (
     customPrompt: string | undefined,
     useCustomPrompt: boolean
   ) => {
@@ -194,9 +190,9 @@ export function useSpaces(): UseSpacesReturn {
     renameSpace,
     deleteSpace,
     reorderSpaces,
-    updateSpacePrompt,
+    updateSpaceGuidance,
     allSpacePromptConfig,
-    updateAllSpacePrompt,
+    updateAllSpaceGuidance,
     isLoading,
   };
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useImageStore, ImageItem } from "@/hooks/useImageStore";
-import { useSpaces, resolvePromptForSpace } from "@/hooks/useSpaces";
+import { useSpaces, resolveGuidanceForSpace } from "@/hooks/useSpaces";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import UploadZone from "@/components/UploadZone";
 import ImageGrid, { ImageGridHandle } from "@/components/ImageGrid";
@@ -39,9 +39,9 @@ const Index = () => {
     renameSpace,
     deleteSpace,
     reorderSpaces,
-    updateSpacePrompt,
+    updateSpaceGuidance,
     allSpacePromptConfig,
-    updateAllSpacePrompt,
+    updateAllSpaceGuidance,
   } = useSpaces();
 
   const [searchQuery, setSearchQuery] = useState("");
@@ -84,17 +84,17 @@ const Index = () => {
   const allSpacePromptConfigRef = useRef(allSpacePromptConfig);
   allSpacePromptConfigRef.current = allSpacePromptConfig;
 
-  // Wrap addImage to auto-assign to active space with prompt resolution
+  // Wrap addImage to auto-assign to active space with guidance resolution
   const addImageToActiveSpace = useCallback(async (file: File) => {
     const spaceId = activeSpaceIdRef.current ?? undefined;
-    const prompt = resolvePromptForSpace(activeSpaceIdRef.current, spacesRef.current, allSpacePromptConfigRef.current);
-    await addImage(file, spaceId, prompt);
+    const guidance = resolveGuidanceForSpace(activeSpaceIdRef.current, spacesRef.current, allSpacePromptConfigRef.current);
+    await addImage(file, spaceId, guidance);
   }, [addImage]);
 
   const importToActiveSpace = useCallback(async (filePath: string) => {
     const spaceId = activeSpaceIdRef.current ?? undefined;
-    const prompt = resolvePromptForSpace(activeSpaceIdRef.current, spacesRef.current, allSpacePromptConfigRef.current);
-    await importFromFilePath(filePath, spaceId, prompt);
+    const guidance = resolveGuidanceForSpace(activeSpaceIdRef.current, spacesRef.current, allSpacePromptConfigRef.current);
+    await importFromFilePath(filePath, spaceId, guidance);
   }, [importFromFilePath]);
 
   // Load saved preferences on mount
@@ -313,24 +313,24 @@ const Index = () => {
   }, [removeImages]);
 
   const handleAssignImageToSpace = useCallback(async (imageId: string, spaceId: string | null) => {
-    const prompt = resolvePromptForSpace(spaceId, spaces, allSpacePromptConfig);
-    await assignImageToSpace(imageId, spaceId, prompt);
+    const guidance = resolveGuidanceForSpace(spaceId, spaces, allSpacePromptConfig);
+    await assignImageToSpace(imageId, spaceId, guidance);
   }, [assignImageToSpace, spaces, allSpacePromptConfig]);
 
   const handleAssignImagesToSpace = useCallback(async (imageIds: string[], spaceId: string | null) => {
-    const prompt = resolvePromptForSpace(spaceId, spaces, allSpacePromptConfig);
-    await assignImagesToSpace(imageIds, spaceId, prompt);
+    const guidance = resolveGuidanceForSpace(spaceId, spaces, allSpacePromptConfig);
+    await assignImagesToSpace(imageIds, spaceId, guidance);
   }, [assignImagesToSpace, spaces, allSpacePromptConfig]);
 
   const handleRemoveFromSpace = useCallback(async (id: string) => {
-    const prompt = resolvePromptForSpace(null, spaces, allSpacePromptConfig);
-    await assignImageToSpace(id, null, prompt);
+    const guidance = resolveGuidanceForSpace(null, spaces, allSpacePromptConfig);
+    await assignImageToSpace(id, null, guidance);
   }, [assignImageToSpace, spaces, allSpacePromptConfig]);
 
   const handleRetryAnalysis = useCallback(async (imageId: string) => {
     const image = images.find(img => img.id === imageId);
-    const prompt = resolvePromptForSpace(image?.spaceId ?? null, spaces, allSpacePromptConfig);
-    await retryAnalysis(imageId, prompt);
+    const guidance = resolveGuidanceForSpace(image?.spaceId ?? null, spaces, allSpacePromptConfig);
+    await retryAnalysis(imageId, guidance);
   }, [images, spaces, allSpacePromptConfig, retryAnalysis]);
 
   // Determine if we're in empty state - consider both actual emptiness and simulated empty state
@@ -478,8 +478,8 @@ const Index = () => {
           onCreateSpace={createSpace}
           onRenameSpace={renameSpace}
           onDeleteSpace={deleteSpace}
-          onUpdateSpacePrompt={updateSpacePrompt}
-          onUpdateAllSpacePrompt={updateAllSpacePrompt}
+          onUpdateSpaceGuidance={updateSpaceGuidance}
+          onUpdateAllSpaceGuidance={updateAllSpaceGuidance}
           onReorderSpaces={reorderSpaces}
           onShuffleImages={shuffleImages}
         />

--- a/src/services/aiAnalysisService.ts
+++ b/src/services/aiAnalysisService.ts
@@ -135,7 +135,8 @@ export async function deleteApiKey(provider?: AIProvider): Promise<boolean> {
 
 // ── Shared prompt ──────────────────────────────────────────────────
 
-export const DEFAULT_SYSTEM_PROMPT = `You are an expert AI in analyzing images. Your task is to analyze the content of images and provide appropriate descriptions.
+// System prompt: structural instructions for response format (not user-visible)
+const SYSTEM_PROMPT = `You are an expert AI in analyzing images. Your task is to analyze the content of images and provide appropriate descriptions.
 
     Provide your response in the following JSON format:
     {
@@ -158,9 +159,20 @@ export const DEFAULT_SYSTEM_PROMPT = `You are an expert AI in analyzing images. 
       6. Include confidence scores between 0.8 and 1.0
       7. List patterns in order of confidence/importance
       8. Ensure that the patterns are unique and not duplicates of each other and imageSummary
-      9. Provide exactly 6 patterns, ordered by confidence`;
+      9. Provide exactly 6 patterns, ordered by confidence
+      10. Respond with a strict, valid JSON object — do not include markdown formatting, explanations, or code block symbols
+      11. Use title case for pattern/object names
+      12. Provide up to 6 patterns, ordered by confidence`;
 
-const USER_TEXT = "Analyze this image and provide a detailed breakdown of its content. If it's a UI screenshot, focus on UI patterns and components. If it's a general scene, focus on objects and subjects. Respond with a strict, valid JSON object in the format specified in the system prompt. Do not include markdown formatting, explanations, or code block symbols. Use title case for pattern/object names. Provide up to 6 patterns/objects, ordered by confidence.";
+// Master instructions in the user message (not user-visible)
+const MASTER_USER_TEXT = "Analyze this image.";
+
+// Default guidance: user-visible, tells the AI what to focus on
+export const DEFAULT_GUIDANCE = "If it's a UI screenshot, focus on UI patterns and components. If it's a general scene, focus on objects and subjects.";
+
+function buildUserText(guidance?: string): string {
+  return `${MASTER_USER_TEXT} ${guidance ?? DEFAULT_GUIDANCE}`;
+}
 
 // ── Response parsing (shared by both providers) ────────────────────
 
@@ -231,7 +243,7 @@ function extractBase64(dataUrl: string): { data: string; mediaType: string } {
 
 // ── OpenAI analysis ────────────────────────────────────────────────
 
-async function analyzeImageWithOpenAI(imageUrl: string, modelId: string, systemPrompt: string): Promise<PatternMatch[]> {
+async function analyzeImageWithOpenAI(imageUrl: string, modelId: string, systemPrompt: string, userText: string): Promise<PatternMatch[]> {
   const payload = {
     model: modelId,
     messages: [
@@ -242,7 +254,7 @@ async function analyzeImageWithOpenAI(imageUrl: string, modelId: string, systemP
       {
         role: "user",
         content: [
-          { type: "text", text: USER_TEXT },
+          { type: "text", text: userText },
           { type: "image_url", image_url: { url: imageUrl } }
         ]
       }
@@ -281,7 +293,7 @@ async function analyzeImageWithOpenAI(imageUrl: string, modelId: string, systemP
 
 // ── Claude analysis ────────────────────────────────────────────────
 
-async function analyzeImageWithClaude(imageUrl: string, modelId: string, systemPrompt: string): Promise<PatternMatch[]> {
+async function analyzeImageWithClaude(imageUrl: string, modelId: string, systemPrompt: string, userText: string): Promise<PatternMatch[]> {
   const { data: base64Data, mediaType } = extractBase64(imageUrl);
 
   const payload = {
@@ -300,7 +312,7 @@ async function analyzeImageWithClaude(imageUrl: string, modelId: string, systemP
               data: base64Data
             }
           },
-          { type: "text", text: USER_TEXT }
+          { type: "text", text: userText }
         ]
       }
     ]
@@ -338,7 +350,7 @@ async function analyzeImageWithClaude(imageUrl: string, modelId: string, systemP
 
 // ── Gemini analysis ───────────────────────────────────────────────
 
-async function analyzeImageWithGemini(imageUrl: string, modelId: string, systemPrompt: string): Promise<PatternMatch[]> {
+async function analyzeImageWithGemini(imageUrl: string, modelId: string, systemPrompt: string, userText: string): Promise<PatternMatch[]> {
   const { data: base64Data, mediaType } = extractBase64(imageUrl);
 
   const payload = {
@@ -346,7 +358,7 @@ async function analyzeImageWithGemini(imageUrl: string, modelId: string, systemP
     contents: [
       {
         parts: [
-          { text: USER_TEXT },
+          { text: userText },
           {
             inlineData: {
               mimeType: mediaType,
@@ -395,7 +407,7 @@ async function analyzeImageWithGemini(imageUrl: string, modelId: string, systemP
 
 // ── OpenRouter analysis ──────────────────────────────────────────
 
-async function analyzeImageWithOpenRouter(imageUrl: string, modelId: string, systemPrompt: string): Promise<PatternMatch[]> {
+async function analyzeImageWithOpenRouter(imageUrl: string, modelId: string, systemPrompt: string, userText: string): Promise<PatternMatch[]> {
   const payload = {
     model: modelId,
     messages: [
@@ -406,7 +418,7 @@ async function analyzeImageWithOpenRouter(imageUrl: string, modelId: string, sys
       {
         role: "user",
         content: [
-          { type: "text", text: USER_TEXT },
+          { type: "text", text: userText },
           { type: "image_url", image_url: { url: imageUrl } }
         ]
       }
@@ -466,28 +478,28 @@ const PROVIDER_NAMES: Record<string, string> = {
   openrouter: "OpenRouter",
 };
 
-export async function analyzeImage(imageUrl: string, systemPrompt?: string): Promise<PatternMatch[]> {
+export async function analyzeImage(imageUrl: string, guidance?: string): Promise<PatternMatch[]> {
   const provider = await getActiveProvider();
   const hasKey = await hasApiKey(provider);
   if (!hasKey) {
     throw new Error(`${PROVIDER_NAMES[provider] || provider} API key not set. Please set an API key to use image analysis.`);
   }
 
-  const prompt = systemPrompt ?? DEFAULT_SYSTEM_PROMPT;
+  const userText = buildUserText(guidance);
 
   try {
     const modelId = await resolveModel();
 
     if (provider === 'anthropic') {
-      return await analyzeImageWithClaude(imageUrl, modelId, prompt);
+      return await analyzeImageWithClaude(imageUrl, modelId, SYSTEM_PROMPT, userText);
     }
     if (provider === 'gemini') {
-      return await analyzeImageWithGemini(imageUrl, modelId, prompt);
+      return await analyzeImageWithGemini(imageUrl, modelId, SYSTEM_PROMPT, userText);
     }
     if (provider === 'openrouter') {
-      return await analyzeImageWithOpenRouter(imageUrl, modelId, prompt);
+      return await analyzeImageWithOpenRouter(imageUrl, modelId, SYSTEM_PROMPT, userText);
     }
-    return await analyzeImageWithOpenAI(imageUrl, modelId, prompt);
+    return await analyzeImageWithOpenAI(imageUrl, modelId, SYSTEM_PROMPT, userText);
   } catch (error) {
     console.error(`Error analyzing image with ${provider}:`, error);
     throw error;
@@ -497,7 +509,7 @@ export async function analyzeImage(imageUrl: string, systemPrompt?: string): Pro
 /**
  * Analyzes multiple frames from a video and combines the results
  */
-export async function analyzeVideoFrames(frameUrls: string[], systemPrompt?: string): Promise<PatternMatch[]> {
+export async function analyzeVideoFrames(frameUrls: string[], guidance?: string): Promise<PatternMatch[]> {
   if (!frameUrls || frameUrls.length === 0) {
     throw new Error("No frames provided for analysis");
   }
@@ -508,7 +520,7 @@ export async function analyzeVideoFrames(frameUrls: string[], systemPrompt?: str
   }
 
   try {
-    const frameAnalysisPromises = frameUrls.map(frameUrl => analyzeImage(frameUrl, systemPrompt));
+    const frameAnalysisPromises = frameUrls.map(frameUrl => analyzeImage(frameUrl, guidance));
     const frameResults = await Promise.all(frameAnalysisPromises);
 
     const allPatterns: PatternMatch[] = [];


### PR DESCRIPTION
### Why?

The AI analysis prompt mixed functional instructions (JSON format, title case, pattern count) with content guidance (what to focus on) in a single user-exposed string. Users editing their "prompt" could accidentally break the response format. Space-specific prompts were also appended rather than replacing the default, leading to conflicting instructions. The settings UI had redundant labels, missing affordances, and broken Cmd+C in the editor sheet.

### How?

Split the prompt into a hidden master prompt (structural/format rules) and user-visible "guidance" (what to pay attention to), renamed consistently across all three apps (Electron, Mac, iOS). Space guidance now replaces the default rather than appending. Polished the Mac settings UI — merged provider/key into one section, added API key format placeholders and generation links, replaced TextEditor with NSTextView wrapper for working clipboard shortcuts, and tightened copy across all tabs.

<sub>Generated with Claude Code</sub>