### PR TITLE
Add Liquid Glass effects to Mac app (macOS 26+)

### DIFF
--- a/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -165,11 +165,7 @@ struct GridItemView: View {
                             )
 
                             HStack {
-                                ShimmerText("Analyzing...")
-                                    .padding(.horizontal, 8)
-                                    .padding(.vertical, 3)
-                                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10))
-                                    .environment(\.colorScheme, .dark)
+                                shimmerBadge
                                 Spacer()
                             }
                             .padding(8)
@@ -222,12 +218,7 @@ struct GridItemView: View {
         .overlay(alignment: .topTrailing) {
             if effectiveHover {
                 Button(action: onDelete) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 10, weight: .bold))
-                        .foregroundStyle(.white)
-                        .frame(width: 24, height: 24)
-                        .background(.black.opacity(0.6))
-                        .clipShape(Circle())
+                    hoverButtonIcon("xmark", size: 10)
                 }
                 .buttonStyle(.plain)
                 .padding(8)
@@ -238,12 +229,7 @@ struct GridItemView: View {
         .overlay(alignment: .topLeading) {
             if effectiveHover && activeSpaceId != nil {
                 Button { onAssignToSpace(nil) } label: {
-                    Image(systemName: "arrow.uturn.backward")
-                        .font(.system(size: 9, weight: .bold))
-                        .foregroundStyle(.white)
-                        .frame(width: 24, height: 24)
-                        .background(.black.opacity(0.6))
-                        .clipShape(Circle())
+                    hoverButtonIcon("arrow.uturn.backward", size: 9)
                 }
                 .buttonStyle(.plain)
                 .padding(8)
@@ -254,17 +240,7 @@ struct GridItemView: View {
         .overlay(alignment: .bottomLeading) {
             if !item.isAnalyzing && item.analysisError != nil {
                 Button(action: onRetryAnalysis) {
-                    HStack(spacing: 4) {
-                        Image(systemName: "arrow.clockwise")
-                            .font(.caption2)
-                        Text("Retry")
-                            .font(.caption.weight(.medium))
-                    }
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(.red.opacity(0.7))
-                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                    retryBadge
                 }
                 .buttonStyle(.plain)
                 .padding(8)
@@ -420,6 +396,65 @@ struct GridItemView: View {
         }
     }
 
+    // MARK: - Glass-aware sub-views
+
+    /// "Analyzing..." shimmer badge with glass on macOS 26+.
+    @ViewBuilder
+    private var shimmerBadge: some View {
+        let base = ShimmerText("Analyzing...")
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+
+        if #available(macOS 26, *) {
+            base
+                .glassEffect(.regular, in: .rect(cornerRadius: 10))
+                .environment(\.colorScheme, .dark)
+        } else {
+            base
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10))
+                .environment(\.colorScheme, .dark)
+        }
+    }
+
+    /// Circular hover-action button icon with glass on macOS 26+.
+    @ViewBuilder
+    private func hoverButtonIcon(_ systemName: String, size: CGFloat) -> some View {
+        let base = Image(systemName: systemName)
+            .font(.system(size: size, weight: .bold))
+            .foregroundStyle(.white)
+            .frame(width: 24, height: 24)
+
+        if #available(macOS 26, *) {
+            base.glassEffect(.regular.interactive(), in: .circle)
+        } else {
+            base
+                .background(.black.opacity(0.6))
+                .clipShape(Circle())
+        }
+    }
+
+    /// Retry analysis badge with red-tinted glass on macOS 26+.
+    @ViewBuilder
+    private var retryBadge: some View {
+        let base = HStack(spacing: 4) {
+            Image(systemName: "arrow.clockwise")
+                .font(.caption2)
+            Text("Retry")
+                .font(.caption.weight(.medium))
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+
+        if #available(macOS 26, *) {
+            base.glassEffect(.regular.tint(.red).interactive(), in: .rect(cornerRadius: 6))
+        } else {
+            base
+                .background(.red.opacity(0.7))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+    }
+
     private func loadThumbnail() async {
         if let loaded = await ImageCacheService.shared.loadThumbnail(id: item.id, filename: item.filename) {
             self.thumbnail = loaded
@@ -462,7 +497,7 @@ struct ShimmerText: View {
     var body: some View {
         if reduceMotion {
             Text(text)
-                .font(.caption)
+                .font(.callout)
                 .foregroundStyle(.white.opacity(ShimmerConfig.peakBrightness))
         } else {
             TimelineView(.animation) { timeline in
@@ -473,7 +508,7 @@ struct ShimmerText: View {
                     + ShimmerConfig.rangeStart
 
                 Text(text)
-                    .font(.caption)
+                    .font(.callout)
                     .foregroundStyle(
                         .linearGradient(
                             colors: [

--- a/SnapGrid/SnapGrid/Views/Grid/SelectionBadge.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/SelectionBadge.swift
@@ -4,15 +4,25 @@ struct SelectionBadge: View {
     let count: Int
 
     var body: some View {
-        Text("\(count) selected")
+        let base = Text("\(count) selected")
             .font(.callout.weight(.medium))
             .foregroundStyle(.white)
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
-            .background(Color.accentColor)
-            .clipShape(Capsule())
-            .shadow(color: .black.opacity(0.3), radius: 8, y: 4)
-            .accessibilityLabel("\(count) items selected")
-            .accessibilityAddTraits(.updatesFrequently)
+
+        if #available(macOS 26, *) {
+            base
+                .glassEffect(.regular.tint(.accentColor), in: .capsule)
+                .shadow(color: .black.opacity(0.3), radius: 8, y: 4)
+                .accessibilityLabel("\(count) items selected")
+                .accessibilityAddTraits(.updatesFrequently)
+        } else {
+            base
+                .background(Color.accentColor)
+                .clipShape(Capsule())
+                .shadow(color: .black.opacity(0.3), radius: 8, y: 4)
+                .accessibilityLabel("\(count) items selected")
+                .accessibilityAddTraits(.updatesFrequently)
+        }
     }
 }

--- a/SnapGrid/SnapGrid/Views/Shared/FloatingVideoLayer.swift
+++ b/SnapGrid/SnapGrid/Views/Shared/FloatingVideoLayer.swift
@@ -190,12 +190,18 @@ struct VideoControlsOverlay: View {
     private var controlsContent: some View {
         // Center play/pause button
         Button(action: togglePlayback) {
-            Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+            let icon = Image(systemName: isPlaying ? "pause.fill" : "play.fill")
                 .font(.title3.weight(.semibold))
                 .foregroundStyle(.white)
                 .frame(width: 44, height: 44)
-                .background(.black.opacity(0.5))
-                .clipShape(Circle())
+
+            if #available(macOS 26, *) {
+                icon.glassEffect(.regular.interactive(), in: .circle)
+            } else {
+                icon
+                    .background(.black.opacity(0.5))
+                    .clipShape(Circle())
+            }
         }
         .buttonStyle(.plain)
         .accessibilityLabel(isPlaying ? "Pause" : "Play")
@@ -204,13 +210,19 @@ struct VideoControlsOverlay: View {
         VStack {
             Spacer()
             HStack {
-                Text("\(formatTime(currentTime)) / \(formatTime(duration))")
+                let timeText = Text("\(formatTime(currentTime)) / \(formatTime(duration))")
                     .font(.caption.weight(.medium).monospacedDigit())
                     .foregroundStyle(.white.opacity(0.8))
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(.black.opacity(0.4))
-                    .clipShape(RoundedRectangle(cornerRadius: 4))
+
+                if #available(macOS 26, *) {
+                    timeText.glassEffect(.regular, in: .rect(cornerRadius: 4))
+                } else {
+                    timeText
+                        .background(.black.opacity(0.4))
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                }
                 Spacer()
             }
             .padding(8)

--- a/SnapGrid/SnapGrid/Views/Shared/PatternPill.swift
+++ b/SnapGrid/SnapGrid/Views/Shared/PatternPill.swift
@@ -1,18 +1,32 @@
 import SwiftUI
 
 /// Hover-state pattern name pill used on grid thumbnails and the floating video layer.
-/// Uses `.ultraThinMaterial` so it composites correctly above NSView-backed video content.
+/// On macOS 26+ uses Liquid Glass; falls back to `.ultraThinMaterial` for compositing
+/// above NSView-backed video content on earlier systems.
 struct PatternPill: View {
     let name: String
     var large: Bool = false
+    /// Set to `false` when rendering above NSViewRepresentable layers where
+    /// `.glassEffect()` may not composite correctly (e.g. FloatingVideoLayer).
+    var useGlass: Bool = true
+
+    private var cornerRadius: CGFloat { large ? 12 : 10 }
 
     var body: some View {
-        Text(name)
+        let base = Text(name)
             .font(large ? .subheadline : .callout)
             .foregroundStyle(.white.opacity(0.9))
             .padding(.horizontal, large ? 10 : 8)
             .padding(.vertical, large ? 5 : 3)
-            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: large ? 12 : 10))
-            .environment(\.colorScheme, .dark)
+
+        if #available(macOS 26, *), useGlass {
+            base
+                .glassEffect(.regular.tint(.black.opacity(0.3)), in: .rect(cornerRadius: cornerRadius))
+                .environment(\.colorScheme, .dark)
+        } else {
+            base
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: cornerRadius))
+                .environment(\.colorScheme, .dark)
+        }
     }
 }

--- a/SnapGrid/SnapGrid/Views/Shared/ToastView.swift
+++ b/SnapGrid/SnapGrid/Views/Shared/ToastView.swift
@@ -7,18 +7,29 @@ struct ToastOverlay: View {
         VStack(spacing: 8) {
             Spacer()
             ForEach(toasts) { toast in
-                Text(toast.message)
+                let base = Text(toast.message)
                     .font(.callout.weight(.medium))
                     .foregroundStyle(.white)
                     .padding(.horizontal, 16)
                     .padding(.vertical, 10)
-                    .background(.ultraThinMaterial.opacity(0.9))
-                    .background(.black.opacity(0.6))
-                    .clipShape(Capsule())
-                    .shadow(color: .black.opacity(0.2), radius: 8, y: 4)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
-                    .accessibilityLabel(toast.message)
-                    .accessibilityAddTraits(.updatesFrequently)
+
+                if #available(macOS 26, *) {
+                    base
+                        .glassEffect(.regular, in: .capsule)
+                        .shadow(color: .black.opacity(0.2), radius: 8, y: 4)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                        .accessibilityLabel(toast.message)
+                        .accessibilityAddTraits(.updatesFrequently)
+                } else {
+                    base
+                        .background(.ultraThinMaterial.opacity(0.9))
+                        .background(.black.opacity(0.6))
+                        .clipShape(Capsule())
+                        .shadow(color: .black.opacity(0.2), radius: 8, y: 4)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                        .accessibilityLabel(toast.message)
+                        .accessibilityAddTraits(.updatesFrequently)
+                }
             }
         }
         .padding(.bottom, 24)


### PR DESCRIPTION
### Why?

The native Mac app uses `.ultraThinMaterial` and solid-color backgrounds for floating UI surfaces (pattern pills, toasts, hover buttons, badges). macOS 26 introduces the Liquid Glass design language with `.glassEffect()` as the modern replacement — adopting it keeps the app aligned with platform conventions.

### How?

Add `#available(macOS 26, *)` gated `.glassEffect()` calls to 9 surfaces across 5 view files, with the existing rendering as fallback for macOS 15. Pattern pills use a dark-tinted glass for legibility over thumbnails. Grid hover buttons (delete, remove, retry) get interactive glass. Extracted glass-aware helper views in GridItemView to keep the body readable.

<details>
<summary>Implementation Plan</summary>

## Surfaces Changed (9 total across 5 files)

### PatternPill.swift — tag badges on grid/video hover
- `.background(.ultraThinMaterial)` → `.glassEffect(.regular.tint(.black.opacity(0.3)))` on macOS 26
- Added `useGlass: Bool` param as escape hatch for NSView compositing issues

### ToastView.swift — notification capsules
- Dual-layer material + black → single `.glassEffect(.regular, in: .capsule)`

### SelectionBadge.swift — "N selected" floating badge
- Solid `Color.accentColor` → `.glassEffect(.regular.tint(.accentColor), in: .capsule)`

### GridItemView.swift — 4 surfaces
- "Analyzing..." badge: `.glassEffect(.regular, in: .rect(cornerRadius: 10))`
- Delete button: `.glassEffect(.regular.interactive(), in: .circle)`
- Remove-from-space button: same pattern as delete
- Retry button: `.glassEffect(.regular.tint(.red).interactive(), in: .rect(cornerRadius: 6))`
- Bumped shimmer badge font from `.caption` to `.callout` to match pattern pill sizing

### FloatingVideoLayer.swift — VideoControlsOverlay (2 surfaces)
- Play/pause button: `.glassEffect(.regular.interactive(), in: .circle)`
- Time bar: `.glassEffect(.regular, in: .rect(cornerRadius: 4))`

## Surfaces NOT Changed
- HeroDetailOverlay backdrop (dimming layer, not a floating surface)
- SpaceTabBar (text tabs with underline indicator, no material)
- Small video play badge (too small for glass treatment)
- project.yml deployment target stays macOS 15.0

</details>

<sub>Generated with Claude Code</sub>