### PR TITLE
Show full metadata descriptions in Mac and iOS detail overlays

### DIFF
--- a/SnapGrid/SnapGrid/Views/Detail/HeroDetailOverlay.swift
+++ b/SnapGrid/SnapGrid/Views/Detail/HeroDetailOverlay.swift
@@ -572,8 +572,8 @@ struct HeroDetailOverlay: View {
                     }
                 }
                 .frame(width: max(min(finalFrame.width, 500), 400))
-                .padding(.top, 20)
-                .padding(.bottom, 60)
+                .padding(.top, 40)
+                .padding(.bottom, 40)
                 .mask(metadataFadeMask)
             }
             .frame(maxWidth: .infinity)
@@ -736,7 +736,6 @@ private struct DetailMetadataSection: View {
     let item: MediaItem
     let stage: Int
     var onSearchPattern: ((String) -> Void)?
-    @State private var isDescriptionExpanded = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -788,18 +787,11 @@ private struct DetailMetadataSection: View {
                 }
 
                 if hasDescription(result) {
-                    ExpandableText(
-                        text: result.imageContext,
-                        lineLimit: 3,
-                        font: .caption,
-                        platformFont: .systemFont(ofSize: NSFont.systemFontSize(for: .small)),
-                        lineSpacing: 2,
-                        textColor: .white.opacity(0.4),
-                        animation: MetadataReveal.spring,
-                        isExpanded: $isDescriptionExpanded
-                    )
-                    .opacity(stage >= 3 ? 1 : 0)
-                    .animation(MetadataReveal.spring, value: stage)
+                    Text(result.imageContext)
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.4))
+                        .lineSpacing(2)
+                        .stageReveal(stage: stage, threshold: 3)
                 }
             }
 
@@ -820,7 +812,6 @@ private struct DetailMetadataSection: View {
             .padding(.top, 12)
         }
         .padding(.horizontal, 16)
-        .animation(MetadataReveal.spring, value: isDescriptionExpanded)
     }
 
     private func hasDescription(_ result: AnalysisResult) -> Bool {
@@ -831,109 +822,6 @@ private struct DetailMetadataSection: View {
         guard seconds.isFinite else { return "0:00" }
         let total = Int(seconds)
         return "\(total / 60):\(String(format: "%02d", total % 60))"
-    }
-}
-
-// MARK: - Expandable Text
-
-/// Truncates to N lines with inline "…" at the exact word boundary.
-/// Expands/collapses with a smooth height-clip animation (no text reflow).
-private struct ExpandableText: View {
-    let text: String
-    let lineLimit: Int
-    let font: Font
-    let platformFont: NSFont
-    let lineSpacing: CGFloat
-    let textColor: Color
-    let animation: Animation
-    @Binding var isExpanded: Bool
-
-    @State private var availableWidth: CGFloat = 0
-    @State private var truncatedString: String?
-    @State private var fullHeight: CGFloat = 0
-    @State private var collapsedHeight: CGFloat = 0
-
-    private var isTruncated: Bool { truncatedString != nil }
-
-    var body: some View {
-        Text(isExpanded ? text : (truncatedString ?? text))
-            .font(font)
-            .foregroundStyle(textColor)
-            .lineSpacing(lineSpacing)
-            .fixedSize(horizontal: false, vertical: true)
-            .frame(
-                maxWidth: .infinity,
-                maxHeight: isExpanded ? max(fullHeight, collapsedHeight) : collapsedHeight,
-                alignment: .topLeading
-            )
-            .clipped()
-            .background(GeometryReader { proxy in
-                Color.clear
-                    .onAppear { updateWidth(proxy.size.width) }
-                    .onChange(of: proxy.size.width) { _, new in updateWidth(new) }
-            })
-            .contentShape(Rectangle())
-            .onTapGesture {
-                guard isTruncated else { return }
-                withAnimation(animation) { isExpanded.toggle() }
-            }
-    }
-
-    private func updateWidth(_ width: CGFloat) {
-        guard width > 0, width != availableWidth else { return }
-        availableWidth = width
-        recalculate()
-    }
-
-    private func recalculate() {
-        let ps = NSMutableParagraphStyle()
-        ps.lineSpacing = lineSpacing
-        ps.lineBreakMode = .byWordWrapping
-        let attrs: [NSAttributedString.Key: Any] = [.font: platformFont, .paragraphStyle: ps]
-        let size = CGSize(width: availableWidth, height: .greatestFiniteMagnitude)
-
-        fullHeight = ceil(NSAttributedString(string: text, attributes: attrs)
-            .boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil).height)
-        let fontLineHeight = ceil(platformFont.ascender - platformFont.descender + platformFont.leading)
-        collapsedHeight = ceil(fontLineHeight * CGFloat(lineLimit) + lineSpacing * CGFloat(lineLimit - 1))
-
-        guard fullHeight > collapsedHeight + 2 else { truncatedString = nil; return }
-
-        let ellipsis = "\u{2026}"
-        let words = wordSegments(text)
-        var lo = 0, hi = words.count
-        while lo < hi {
-            let mid = (lo + hi + 1) / 2
-            let candidate = words[0..<mid].joined().trimmingTrailingWhitespace + ellipsis
-            let h = ceil(NSAttributedString(string: candidate, attributes: attrs)
-                .boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil).height)
-            if h <= collapsedHeight + 2 { lo = mid } else { hi = mid - 1 }
-        }
-        truncatedString = lo > 0 ? words[0..<lo].joined().trimmingTrailingWhitespace + ellipsis : ellipsis
-    }
-
-    private func wordSegments(_ text: String) -> [String] {
-        var segments: [String] = []
-        var current = ""
-        var inWord = false
-        for ch in text {
-            if ch.isWhitespace || ch.isNewline {
-                current.append(ch)
-                inWord = false
-            } else {
-                if !inWord && !current.isEmpty { segments.append(current); current = "" }
-                current.append(ch)
-                inWord = true
-            }
-        }
-        if !current.isEmpty { segments.append(current) }
-        return segments
-    }
-}
-
-private extension String {
-    var trimmingTrailingWhitespace: String {
-        replacingOccurrences(of: "\\s+$", with: "", options: .regularExpression)
     }
 }
 

--- a/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
@@ -117,7 +117,6 @@ struct FullScreenImageOverlay: View {
     @State private var contentOffsetAtGestureStart: CGFloat = 0
     @State private var metadataStage: Int = 0
     @State private var revealTask: Task<Void, Never>?
-    @State private var isDescriptionExpanded = false
     @State private var metadataHeight: CGFloat = 0
 
     // Zoom state (owned here to avoid gesture conflicts with child views)
@@ -395,7 +394,7 @@ struct FullScreenImageOverlay: View {
             .offset(y: -effectiveContentOffset)
 
             // Metadata — positioned so top starts near screen bottom (peek)
-            DetailMetadataSection(item: item, stage: metadataStage, isDescriptionExpanded: $isDescriptionExpanded) { pattern in
+            DetailMetadataSection(item: item, stage: metadataStage) { pattern in
                 searchAndClose(pattern: pattern)
             }
                 .id(item.id)
@@ -818,7 +817,6 @@ struct FullScreenImageOverlay: View {
                 swipeOffset = 0
                 metadataStage = 4
                 contentOffset = 0
-                isDescriptionExpanded = false
                 isZoomed = false
                 zoomScale = minZoomScale
                 zoomLastScale = minZoomScale
@@ -1096,7 +1094,6 @@ struct FullScreenImageOverlay: View {
 private struct DetailMetadataSection: View {
     let item: MediaItem
     let stage: Int
-    @Binding var isDescriptionExpanded: Bool
     var onSearchPattern: ((String) -> Void)?
 
     var body: some View {
@@ -1160,18 +1157,12 @@ private struct DetailMetadataSection: View {
                 }
 
                 if hasDescription(result) {
-                    ExpandableText(
-                        text: result.imageContext,
-                        lineLimit: 3,
-                        font: .subheadline,
-                        platformFont: .preferredFont(forTextStyle: .subheadline),
-                        lineSpacing: 3,
-                        textColor: .white.opacity(0.5),
-                        animation: MetadataReveal.spring,
-                        isExpanded: $isDescriptionExpanded
-                    )
-                    .opacity(stage >= 3 ? 1 : 0)
-                    .animation(MetadataReveal.spring, value: stage)
+                    Text(result.imageContext)
+                        .font(.subheadline)
+                        .foregroundStyle(.white.opacity(0.5))
+                        .lineSpacing(3)
+                        .opacity(stage >= 3 ? 1 : 0)
+                        .animation(MetadataReveal.spring, value: stage)
                 }
             }
 
@@ -1193,7 +1184,6 @@ private struct DetailMetadataSection: View {
         }
         .padding(.horizontal, 32)
         .padding(.bottom, 64)
-        .animation(MetadataReveal.spring, value: isDescriptionExpanded)
     }
 
     private func hasDescription(_ result: AnalysisResult) -> Bool {
@@ -1213,108 +1203,6 @@ private struct MetadataHeightKey: PreferenceKey {
     static var defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = max(value, nextValue())
-    }
-}
-
-// MARK: - Expandable Text
-
-/// Truncates to N lines with inline "…" at the exact word boundary.
-/// Expands/collapses with a smooth height-clip animation (no text reflow).
-private struct ExpandableText: View {
-    let text: String
-    let lineLimit: Int
-    let font: Font
-    let platformFont: UIFont
-    let lineSpacing: CGFloat
-    let textColor: Color
-    let animation: Animation
-    @Binding var isExpanded: Bool
-
-    @State private var availableWidth: CGFloat = 0
-    @State private var truncatedString: String?
-    @State private var fullHeight: CGFloat = 0
-    @State private var collapsedHeight: CGFloat = 0
-
-    private var isTruncated: Bool { truncatedString != nil }
-
-    var body: some View {
-        Text(isExpanded ? text : (truncatedString ?? text))
-            .font(font)
-            .foregroundStyle(textColor)
-            .lineSpacing(lineSpacing)
-            .fixedSize(horizontal: false, vertical: true)
-            .frame(
-                maxWidth: .infinity,
-                maxHeight: isExpanded ? max(fullHeight, collapsedHeight) : collapsedHeight,
-                alignment: .topLeading
-            )
-            .clipped()
-            .background(GeometryReader { proxy in
-                Color.clear
-                    .onAppear { updateWidth(proxy.size.width) }
-                    .onChange(of: proxy.size.width) { _, new in updateWidth(new) }
-            })
-            .contentShape(Rectangle())
-            .onTapGesture {
-                guard isTruncated else { return }
-                withAnimation(animation) { isExpanded.toggle() }
-            }
-    }
-
-    private func updateWidth(_ width: CGFloat) {
-        guard width > 0, width != availableWidth else { return }
-        availableWidth = width
-        recalculate()
-    }
-
-    private func recalculate() {
-        let ps = NSMutableParagraphStyle()
-        ps.lineSpacing = lineSpacing
-        ps.lineBreakMode = .byWordWrapping
-        let attrs: [NSAttributedString.Key: Any] = [.font: platformFont, .paragraphStyle: ps]
-        let size = CGSize(width: availableWidth, height: .greatestFiniteMagnitude)
-
-        fullHeight = ceil(NSAttributedString(string: text, attributes: attrs)
-            .boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil).height)
-        collapsedHeight = ceil(platformFont.lineHeight * CGFloat(lineLimit) + lineSpacing * CGFloat(lineLimit - 1))
-
-        guard fullHeight > collapsedHeight + 2 else { truncatedString = nil; return }
-
-        let ellipsis = "\u{2026}"
-        let words = wordSegments(text)
-        var lo = 0, hi = words.count
-        while lo < hi {
-            let mid = (lo + hi + 1) / 2
-            let candidate = words[0..<mid].joined().trimmingTrailingWhitespace + ellipsis
-            let h = ceil(NSAttributedString(string: candidate, attributes: attrs)
-                .boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil).height)
-            if h <= collapsedHeight + 2 { lo = mid } else { hi = mid - 1 }
-        }
-        truncatedString = lo > 0 ? words[0..<lo].joined().trimmingTrailingWhitespace + ellipsis : ellipsis
-    }
-
-    private func wordSegments(_ text: String) -> [String] {
-        var segments: [String] = []
-        var current = ""
-        var inWord = false
-        for ch in text {
-            if ch.isWhitespace || ch.isNewline {
-                current.append(ch)
-                inWord = false
-            } else {
-                if !inWord && !current.isEmpty { segments.append(current); current = "" }
-                current.append(ch)
-                inWord = true
-            }
-        }
-        if !current.isEmpty { segments.append(current) }
-        return segments
-    }
-}
-
-private extension String {
-    var trimmingTrailingWhitespace: String {
-        replacingOccurrences(of: "\\s+$", with: "", options: .regularExpression)
     }
 }
 


### PR DESCRIPTION
### Why?

Metadata descriptions were truncated to 3 lines behind a tap-to-expand interaction, hiding useful AI analysis context. Descriptions should be fully visible without requiring interaction.

### How?

Replace the custom `ExpandableText` component with plain `Text` views in both Mac and iOS detail overlays, and balance the metadata section padding on the Mac app.

<details>
<summary>Implementation Plan</summary>

# Show full metadata descriptions (no truncation)

## Context
Metadata descriptions (`imageContext`) in the detail overlay are currently truncated to 3 lines via a custom `ExpandableText` component, requiring a tap to expand. The user wants descriptions shown in full by default — no truncation, no expand/collapse interaction.

## Changes

### 1. Mac App — `SnapGrid/SnapGrid/Views/Detail/HeroDetailOverlay.swift`

**Replace `ExpandableText` with plain `Text`** (lines 790-803):
```swift
// FROM:
ExpandableText(text: result.imageContext, lineLimit: 3, ...)

// TO:
Text(result.imageContext)
    .font(.caption)
    .foregroundStyle(.white.opacity(0.4))
    .lineSpacing(2)
    .stageReveal(stage: stage, threshold: 3)
```

**Clean up dead code:**
- Remove `@State private var isDescriptionExpanded = false` (line 739)
- Remove `.animation(MetadataReveal.spring, value: isDescriptionExpanded)` (line 823)
- Delete `ExpandableText` struct (lines 837-932)
- Delete `trimmingTrailingWhitespace` extension (lines 934-938)

### 2. iOS App — `ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift`

**Replace `ExpandableText` with plain `Text`** (lines 1162-1175):
```swift
// FROM:
ExpandableText(text: result.imageContext, lineLimit: 3, ...)

// TO:
Text(result.imageContext)
    .font(.subheadline)
    .foregroundStyle(.white.opacity(0.5))
    .lineSpacing(3)
    .opacity(stage >= 3 ? 1 : 0)
    .animation(MetadataReveal.spring, value: stage)
```

**Clean up dead code:**
- Remove `@State private var isDescriptionExpanded = false` (line 120)
- Remove `isDescriptionExpanded = false` from item-change reset (line 821)
- Remove `@Binding var isDescriptionExpanded: Bool` from `DetailMetadataSection` (line 1099)
- Update call site to remove `isDescriptionExpanded:` parameter (line 398)
- Remove `.animation(MetadataReveal.spring, value: isDescriptionExpanded)` (line 1196)
- Delete `ExpandableText` struct (lines 1223-1313)
- Delete `trimmingTrailingWhitespace` extension (lines 1315-1319)

</details>

<sub>Generated with Claude Code</sub>