### PR TITLE
Add X/Twitter video extraction to Mac and iOS share extension

### DIFF
--- a/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
+++ b/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		071B2A3BF29E5D8C82A0F4DB /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0DBF4BD46715A129146550 /* AppState.swift */; };
 		0BD6F0F6397C8D6CC98DDFFF /* SyncWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2537EC9D8AD50664BBA121ED /* SyncWatcher.swift */; };
 		0FB79B182FF2453212D42811 /* SpaceTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4091FEF7AEC687AE2DA55B3D /* SpaceTabBar.swift */; };
+		129E975D0AF5F70B0787E1BD /* TwitterVideoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF21DEE8F950B7304A8AA40F /* TwitterVideoService.swift */; };
 		19DF74D39041BCACC5B21A10 /* SemanticSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 689AEED4D4344D4F358EC9C1 /* SemanticSearchService.swift */; };
 		20978B2B412744B389E3D316 /* MediaItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA6AB7DC0A84E670681EB6C /* MediaItem.swift */; };
 		210A13790BE0E2F8D5123662 /* NSImage+Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE5033083DAF80AD07ABC32 /* NSImage+Thumbnail.swift */; };
@@ -100,6 +101,7 @@
 		AB57D4AB7F12528E5ECD77DF /* ImageCacheService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheService.swift; sourceTree = "<group>"; };
 		ADAA221ED457C361084B34E7 /* HeroDetailOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeroDetailOverlay.swift; sourceTree = "<group>"; };
 		BBFDD4D2B1F3CCB3ED261F5C /* SelectionBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionBadge.swift; sourceTree = "<group>"; };
+		BF21DEE8F950B7304A8AA40F /* TwitterVideoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwitterVideoService.swift; sourceTree = "<group>"; };
 		CF20E3B5FA0802105388A2AC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		D12368B01B4DD3634830B038 /* RubberBandOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RubberBandOverlay.swift; sourceTree = "<group>"; };
 		D5AD67C6232580C3B0D9E982 /* MasonryGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasonryGridView.swift; sourceTree = "<group>"; };
@@ -171,6 +173,7 @@
 				689AEED4D4344D4F358EC9C1 /* SemanticSearchService.swift */,
 				2537EC9D8AD50664BBA121ED /* SyncWatcher.swift */,
 				2F7E099305244B612B096B86 /* ThumbnailService.swift */,
+				BF21DEE8F950B7304A8AA40F /* TwitterVideoService.swift */,
 				2E5C14CF112B283919BE0F7D /* VideoFrameExtractor.swift */,
 				F070C831AF60C5AF79237043 /* VideoPreviewManager.swift */,
 			);
@@ -394,6 +397,7 @@
 				27A5C73EBCC0338561829D33 /* ThumbnailService.swift in Sources */,
 				22B3C67B9FEA9300A6D969AE /* ToastView.swift in Sources */,
 				D8DEDAFF16754653D39B7B56 /* TransferableFileURL.swift in Sources */,
+				129E975D0AF5F70B0787E1BD /* TwitterVideoService.swift in Sources */,
 				9101F365F60BDAB8F4E28C3E /* VideoFrameExtractor.swift in Sources */,
 				429D34E9222F716D0D0BE26C /* VideoPreviewManager.swift in Sources */,
 				3C8305A01967D9D664D9AA3D /* View+DoubleClick.swift in Sources */,

--- a/SnapGrid/SnapGrid/Services/ImportService.swift
+++ b/SnapGrid/SnapGrid/Services/ImportService.swift
@@ -214,11 +214,14 @@ final class ImportService {
         }
     }
 
-    /// Import a video from an X / Twitter post URL — resolves the tweet to a direct MP4 link
-    /// and runs it through the standard URL import pipeline.
+    /// Import media from an X / Twitter post URL — resolves the tweet to a direct
+    /// MP4 or image link and runs it through the standard URL import pipeline.
     func importFromTwitterURL(_ url: URL, into context: ModelContext, spaceId: String? = nil) async throws {
-        let videoURL = try await TwitterVideoService.extractVideoURL(from: url)
-        try await importFromURL(videoURL, into: context, spaceId: spaceId)
+        let result = try await TwitterVideoService.extractMediaURL(from: url)
+        switch result {
+        case .video(let mediaURL), .image(let mediaURL):
+            try await importFromURL(mediaURL, into: context, spaceId: spaceId)
+        }
     }
 
     /// Import media from a remote HTTP/HTTPS URL — downloads the file, determines its type,

--- a/SnapGrid/SnapGrid/Services/ImportService.swift
+++ b/SnapGrid/SnapGrid/Services/ImportService.swift
@@ -214,6 +214,13 @@ final class ImportService {
         }
     }
 
+    /// Import a video from an X / Twitter post URL — resolves the tweet to a direct MP4 link
+    /// and runs it through the standard URL import pipeline.
+    func importFromTwitterURL(_ url: URL, into context: ModelContext, spaceId: String? = nil) async throws {
+        let videoURL = try await TwitterVideoService.extractVideoURL(from: url)
+        try await importFromURL(videoURL, into: context, spaceId: spaceId)
+    }
+
     /// Import media from a remote HTTP/HTTPS URL — downloads the file, determines its type,
     /// and runs it through the standard import pipeline.
     func importFromURL(_ url: URL, into context: ModelContext, spaceId: String? = nil) async throws {

--- a/SnapGrid/SnapGrid/Services/TwitterVideoService.swift
+++ b/SnapGrid/SnapGrid/Services/TwitterVideoService.swift
@@ -16,15 +16,19 @@ enum TwitterVideoService {
         return extractTweetId(from: url) != nil
     }
 
-    // MARK: - Video Extraction
+    // MARK: - Media Extraction
 
-    /// Fetches the tweet via the syndication API and returns the highest-bitrate MP4 URL.
-    static func extractVideoURL(from tweetURL: URL) async throws -> URL {
+    enum MediaResult {
+        case video(URL)
+        case image(URL)
+    }
+
+    /// Fetches the tweet via the syndication API and returns the best media URL (video or image).
+    static func extractMediaURL(from tweetURL: URL) async throws -> MediaResult {
         guard let tweetId = extractTweetId(from: tweetURL) else {
             throw TwitterError.invalidURL
         }
 
-        // The syndication API requires a `token` param but does not validate its value.
         let apiURL = URL(string: "https://cdn.syndication.twimg.com/tweet-result?id=\(tweetId)&token=x")!
 
         var request = URLRequest(url: apiURL)
@@ -44,34 +48,40 @@ enum TwitterVideoService {
             throw TwitterError.malformedResponse
         }
 
-        // Find the first video or animated_gif media entry.
-        guard let videoMedia = mediaDetails.first(where: {
+        // Prefer video/animated_gif over photos.
+        if let videoMedia = mediaDetails.first(where: {
             let type = $0["type"] as? String
             return type == "video" || type == "animated_gif"
-        }) else {
-            throw TwitterError.noVideoInTweet
-        }
-
-        guard let videoInfo = videoMedia["video_info"] as? [String: Any],
-              let variants = videoInfo["variants"] as? [[String: Any]] else {
-            throw TwitterError.malformedResponse
-        }
-
-        // Filter to MP4 variants and pick the highest bitrate.
-        let mp4Variant = variants
-            .filter { ($0["content_type"] as? String) == "video/mp4" }
-            .compactMap { variant -> (url: String, bitrate: Int)? in
-                guard let url = variant["url"] as? String,
-                      let bitrate = variant["bitrate"] as? Int else { return nil }
-                return (url, bitrate)
+        }) {
+            guard let videoInfo = videoMedia["video_info"] as? [String: Any],
+                  let variants = videoInfo["variants"] as? [[String: Any]] else {
+                throw TwitterError.malformedResponse
             }
-            .max(by: { $0.bitrate < $1.bitrate })
 
-        guard let best = mp4Variant, let videoURL = URL(string: best.url) else {
-            throw TwitterError.noVideoInTweet
+            let mp4Variant = variants
+                .filter { ($0["content_type"] as? String) == "video/mp4" }
+                .compactMap { variant -> (url: String, bitrate: Int)? in
+                    guard let url = variant["url"] as? String,
+                          let bitrate = variant["bitrate"] as? Int else { return nil }
+                    return (url, bitrate)
+                }
+                .max(by: { $0.bitrate < $1.bitrate })
+
+            guard let best = mp4Variant, let videoURL = URL(string: best.url) else {
+                throw TwitterError.noMediaInTweet
+            }
+
+            return .video(videoURL)
         }
 
-        return videoURL
+        // Fall back to photo.
+        if let photoMedia = mediaDetails.first(where: { ($0["type"] as? String) == "photo" }),
+           let mediaURLString = photoMedia["media_url_https"] as? String,
+           let mediaURL = URL(string: mediaURLString + "?name=large") {
+            return .image(mediaURL)
+        }
+
+        throw TwitterError.noMediaInTweet
     }
 
     // MARK: - Private Helpers
@@ -91,7 +101,7 @@ enum TwitterVideoService {
 
     enum TwitterError: LocalizedError {
         case invalidURL
-        case noVideoInTweet
+        case noMediaInTweet
         case apiRequestFailed(Int)
         case malformedResponse
 
@@ -99,8 +109,8 @@ enum TwitterVideoService {
             switch self {
             case .invalidURL:
                 return "Not a valid X post URL"
-            case .noVideoInTweet:
-                return "This post doesn't contain a video"
+            case .noMediaInTweet:
+                return "This post doesn't contain any media"
             case .apiRequestFailed(let code):
                 return "Couldn't fetch post data from X (HTTP \(code))"
             case .malformedResponse:

--- a/SnapGrid/SnapGrid/Services/TwitterVideoService.swift
+++ b/SnapGrid/SnapGrid/Services/TwitterVideoService.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+enum TwitterVideoService {
+
+    // MARK: - URL Detection
+
+    private static let twitterHosts: Set<String> = [
+        "x.com", "www.x.com",
+        "twitter.com", "www.twitter.com",
+        "mobile.twitter.com",
+    ]
+
+    /// Returns `true` when the URL looks like an X / Twitter post (contains `/status/{digits}`).
+    static func isTwitterURL(_ url: URL) -> Bool {
+        guard let host = url.host?.lowercased(), twitterHosts.contains(host) else { return false }
+        return extractTweetId(from: url) != nil
+    }
+
+    // MARK: - Video Extraction
+
+    /// Fetches the tweet via the syndication API and returns the highest-bitrate MP4 URL.
+    static func extractVideoURL(from tweetURL: URL) async throws -> URL {
+        guard let tweetId = extractTweetId(from: tweetURL) else {
+            throw TwitterError.invalidURL
+        }
+
+        // The syndication API requires a `token` param but does not validate its value.
+        let apiURL = URL(string: "https://cdn.syndication.twimg.com/tweet-result?id=\(tweetId)&token=x")!
+
+        var request = URLRequest(url: apiURL)
+        request.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)", forHTTPHeaderField: "User-Agent")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let http = response as? HTTPURLResponse else {
+            throw TwitterError.apiRequestFailed(0)
+        }
+        guard (200...299).contains(http.statusCode) else {
+            throw TwitterError.apiRequestFailed(http.statusCode)
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let mediaDetails = json["mediaDetails"] as? [[String: Any]] else {
+            throw TwitterError.malformedResponse
+        }
+
+        // Find the first video or animated_gif media entry.
+        guard let videoMedia = mediaDetails.first(where: {
+            let type = $0["type"] as? String
+            return type == "video" || type == "animated_gif"
+        }) else {
+            throw TwitterError.noVideoInTweet
+        }
+
+        guard let videoInfo = videoMedia["video_info"] as? [String: Any],
+              let variants = videoInfo["variants"] as? [[String: Any]] else {
+            throw TwitterError.malformedResponse
+        }
+
+        // Filter to MP4 variants and pick the highest bitrate.
+        let mp4Variant = variants
+            .filter { ($0["content_type"] as? String) == "video/mp4" }
+            .compactMap { variant -> (url: String, bitrate: Int)? in
+                guard let url = variant["url"] as? String,
+                      let bitrate = variant["bitrate"] as? Int else { return nil }
+                return (url, bitrate)
+            }
+            .max(by: { $0.bitrate < $1.bitrate })
+
+        guard let best = mp4Variant, let videoURL = URL(string: best.url) else {
+            throw TwitterError.noVideoInTweet
+        }
+
+        return videoURL
+    }
+
+    // MARK: - Private Helpers
+
+    /// Extracts the numeric tweet ID from a path like `/user/status/12345…`.
+    private static func extractTweetId(from url: URL) -> String? {
+        let parts = url.pathComponents                       // e.g. ["/", "user", "status", "12345"]
+        guard let statusIndex = parts.firstIndex(of: "status"),
+              statusIndex + 1 < parts.count else { return nil }
+        let candidate = parts[statusIndex + 1]
+        // Strip any trailing non-digit characters (e.g. from /photo/1 appended without separator)
+        let digits = candidate.prefix(while: \.isNumber)
+        return digits.isEmpty ? nil : String(digits)
+    }
+
+    // MARK: - Errors
+
+    enum TwitterError: LocalizedError {
+        case invalidURL
+        case noVideoInTweet
+        case apiRequestFailed(Int)
+        case malformedResponse
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidURL:
+                return "Not a valid X post URL"
+            case .noVideoInTweet:
+                return "This post doesn't contain a video"
+            case .apiRequestFailed(let code):
+                return "Couldn't fetch post data from X (HTTP \(code))"
+            case .malformedResponse:
+                return "Couldn't parse post data from X"
+            }
+        }
+    }
+}

--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -479,19 +479,27 @@ struct ContentView: View {
             }
             if !urls.isEmpty {
                 Task {
-                    appState.showToast("Downloading\(urls.count == 1 ? "" : " \(urls.count) items")...")
+                    let hasTwitterURL = urls.contains(where: { TwitterVideoService.isTwitterURL($0) })
+                    appState.showToast(hasTwitterURL ? "Downloading video from X..." : "Downloading\(urls.count == 1 ? "" : " \(urls.count) items")...")
                     var successCount = 0
                     for url in urls {
                         do {
-                            try await importService.importFromURL(url, into: modelContext, spaceId: appState.activeSpaceId)
+                            if TwitterVideoService.isTwitterURL(url) {
+                                try await importService.importFromTwitterURL(url, into: modelContext, spaceId: appState.activeSpaceId)
+                            } else {
+                                try await importService.importFromURL(url, into: modelContext, spaceId: appState.activeSpaceId)
+                            }
                             successCount += 1
                         } catch {
                             print("[Paste] Failed to import URL \(url): \(error)")
+                            if TwitterVideoService.isTwitterURL(url) {
+                                appState.showToast(error.localizedDescription)
+                            }
                         }
                     }
                     if successCount > 0 {
                         appState.showToast("Imported \(successCount) item\(successCount == 1 ? "" : "s")")
-                    } else {
+                    } else if !hasTwitterURL {
                         appState.showToast("URL doesn't point to a supported image or video")
                     }
                 }

--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -480,7 +480,7 @@ struct ContentView: View {
             if !urls.isEmpty {
                 Task {
                     let hasTwitterURL = urls.contains(where: { TwitterVideoService.isTwitterURL($0) })
-                    appState.showToast(hasTwitterURL ? "Downloading video from X..." : "Downloading\(urls.count == 1 ? "" : " \(urls.count) items")...")
+                    appState.showToast(hasTwitterURL ? "Downloading from X..." : "Downloading\(urls.count == 1 ? "" : " \(urls.count) items")...")
                     var successCount = 0
                     for url in urls {
                         do {

--- a/ios/SnapGrid/ShareExtension/Info.plist
+++ b/ios/SnapGrid/ShareExtension/Info.plist
@@ -10,6 +10,8 @@
 			<dict>
 				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
 				<integer>1</integer>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
 			</dict>
 		</dict>
 		<key>NSExtensionPrincipalClass</key>

--- a/ios/SnapGrid/ShareExtension/ShareViewController.swift
+++ b/ios/SnapGrid/ShareExtension/ShareViewController.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import UIKit
 import UniformTypeIdentifiers
 import os.log
@@ -97,7 +98,7 @@ class ShareViewController: UIViewController {
             return
         }
 
-        completeWithError("This content doesn't contain an image")
+        completeWithError("This content doesn't contain an image or video link")
     }
 
     // MARK: - Image Loading Strategies
@@ -257,7 +258,7 @@ class ShareViewController: UIViewController {
         return nil
     }
 
-    // MARK: - URL-based Image Loading
+    // MARK: - URL-based Loading
 
     private func loadImageFromURL(_ provider: NSItemProvider) {
         _ = provider.loadObject(ofClass: URL.self) { [weak self] object, error in
@@ -267,7 +268,42 @@ class ShareViewController: UIViewController {
                 return
             }
             log.info("URL: \(url.absoluteString)")
+
+            // Check for X / Twitter video URLs first
+            if TwitterVideoService.isTwitterURL(url) {
+                log.info("Detected X/Twitter URL, extracting video")
+                DispatchQueue.main.async {
+                    self?.statusLabel.text = "Downloading video from X…"
+                }
+                self?.downloadTwitterVideo(from: url)
+                return
+            }
+
             self?.downloadImage(from: url)
+        }
+    }
+
+    private func downloadTwitterVideo(from tweetURL: URL) {
+        Task {
+            do {
+                let videoURL = try await TwitterVideoService.extractVideoURL(from: tweetURL)
+                log.info("Video URL resolved: \(videoURL.absoluteString.prefix(100))")
+
+                let (data, response) = try await URLSession.shared.data(from: videoURL)
+                let http = response as? HTTPURLResponse
+                log.info("Video download: HTTP \(http?.statusCode ?? 0), \(data.count)b")
+
+                guard let http, (200...299).contains(http.statusCode) else {
+                    throw TwitterVideoService.TwitterError.apiRequestFailed(
+                        (response as? HTTPURLResponse)?.statusCode ?? 0
+                    )
+                }
+
+                await MainActor.run { self.saveVideo(data) }
+            } catch {
+                log.error("Twitter video extraction failed: \(error.localizedDescription)")
+                await MainActor.run { self.completeWithError(error.localizedDescription) }
+            }
         }
     }
 
@@ -388,6 +424,89 @@ class ShareViewController: UIViewController {
             DispatchQueue.main.async {
                 self.completeWithSuccess()
             }
+        }
+    }
+
+    // MARK: - Save Video
+
+    private func saveVideo(_ videoData: Data) {
+        Task.detached(priority: .userInitiated) { [weak self] in
+            guard let self else { return }
+
+            guard let containerURL = FileManager.default.containerURL(
+                forSecurityApplicationGroupIdentifier: self.appGroupID
+            ) else {
+                await MainActor.run { self.completeWithError("App Group not available") }
+                return
+            }
+
+            let pendingDir = containerURL.appendingPathComponent("pending", isDirectory: true)
+            let imagesDir = pendingDir.appendingPathComponent("images", isDirectory: true)
+            let metadataDir = pendingDir.appendingPathComponent("metadata", isDirectory: true)
+
+            let fm = FileManager.default
+            try? fm.createDirectory(at: imagesDir, withIntermediateDirectories: true)
+            try? fm.createDirectory(at: metadataDir, withIntermediateDirectories: true)
+
+            let timestamp = Int(Date().timeIntervalSince1970 * 1000)
+            let chars = "abcdefghijklmnopqrstuvwxyz0123456789"
+            let random = String((0..<7).map { _ in chars.randomElement()! })
+            let id = "vid_\(timestamp)_\(random)"
+
+            let videoURL = imagesDir.appendingPathComponent("\(id).mp4")
+            do {
+                try videoData.write(to: videoURL, options: .atomic)
+            } catch {
+                await MainActor.run { self.completeWithError("Couldn't save the video") }
+                return
+            }
+
+            // Extract dimensions and duration from the saved file
+            let asset = AVURLAsset(url: videoURL)
+            var width = 0
+            var height = 0
+            var duration: Double?
+
+            if let track = try? await asset.loadTracks(withMediaType: .video).first {
+                let size = try? await track.load(.naturalSize)
+                let transform = try? await track.load(.preferredTransform)
+                if let size, let transform {
+                    let transformed = size.applying(transform)
+                    width = Int(abs(transformed.width))
+                    height = Int(abs(transformed.height))
+                }
+            }
+            let cmDuration = try? await asset.load(.duration)
+            if let cmDuration, cmDuration.isValid && !cmDuration.isIndefinite {
+                duration = CMTimeGetSeconds(cmDuration)
+            }
+
+            log.info("Video dimensions: \(width)x\(height), duration: \(duration ?? 0)s")
+
+            let sidecar = ShareSidecarMetadata(
+                id: id,
+                type: "video",
+                width: width,
+                height: height,
+                createdAt: Date(),
+                duration: duration,
+                spaceId: nil,
+                imageContext: nil,
+                imageSummary: nil,
+                patterns: nil
+            )
+
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+            let metadataURL = metadataDir.appendingPathComponent("\(id).json")
+            if let jsonData = try? encoder.encode(sidecar) {
+                try? jsonData.write(to: metadataURL, options: .atomic)
+            }
+
+            log.info("Saved video: \(id).mp4, \(videoData.count) bytes")
+            await MainActor.run { self.completeWithSuccess() }
         }
     }
 

--- a/ios/SnapGrid/ShareExtension/ShareViewController.swift
+++ b/ios/SnapGrid/ShareExtension/ShareViewController.swift
@@ -271,11 +271,11 @@ class ShareViewController: UIViewController {
 
             // Check for X / Twitter video URLs first
             if TwitterVideoService.isTwitterURL(url) {
-                log.info("Detected X/Twitter URL, extracting video")
+                log.info("Detected X/Twitter URL, extracting media")
                 DispatchQueue.main.async {
-                    self?.statusLabel.text = "Downloading video from X…"
+                    self?.statusLabel.text = "Downloading from X…"
                 }
-                self?.downloadTwitterVideo(from: url)
+                self?.downloadTwitterMedia(from: url)
                 return
             }
 
@@ -283,15 +283,21 @@ class ShareViewController: UIViewController {
         }
     }
 
-    private func downloadTwitterVideo(from tweetURL: URL) {
+    private func downloadTwitterMedia(from tweetURL: URL) {
         Task {
             do {
-                let videoURL = try await TwitterVideoService.extractVideoURL(from: tweetURL)
-                log.info("Video URL resolved: \(videoURL.absoluteString.prefix(100))")
+                let result = try await TwitterVideoService.extractMediaURL(from: tweetURL)
 
-                let (data, response) = try await URLSession.shared.data(from: videoURL)
+                let mediaURL: URL
+                switch result {
+                case .video(let url): mediaURL = url
+                case .image(let url): mediaURL = url
+                }
+                log.info("Media URL resolved: \(mediaURL.absoluteString.prefix(100))")
+
+                let (data, response) = try await URLSession.shared.data(from: mediaURL)
                 let http = response as? HTTPURLResponse
-                log.info("Video download: HTTP \(http?.statusCode ?? 0), \(data.count)b")
+                log.info("Media download: HTTP \(http?.statusCode ?? 0), \(data.count)b")
 
                 guard let http, (200...299).contains(http.statusCode) else {
                     throw TwitterVideoService.TwitterError.apiRequestFailed(
@@ -299,9 +305,17 @@ class ShareViewController: UIViewController {
                     )
                 }
 
-                await MainActor.run { self.saveVideo(data) }
+                switch result {
+                case .video:
+                    await MainActor.run { self.saveVideo(data) }
+                case .image:
+                    guard let image = UIImage(data: data) else {
+                        throw TwitterVideoService.TwitterError.malformedResponse
+                    }
+                    await MainActor.run { self.saveImage(image) }
+                }
             } catch {
-                log.error("Twitter video extraction failed: \(error.localizedDescription)")
+                log.error("Twitter media extraction failed: \(error.localizedDescription)")
                 await MainActor.run { self.completeWithError(error.localizedDescription) }
             }
         }

--- a/ios/SnapGrid/ShareExtension/TwitterVideoService.swift
+++ b/ios/SnapGrid/ShareExtension/TwitterVideoService.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+/// Lightweight X/Twitter video extractor for the share extension.
+/// Mirrors the Mac app's `TwitterVideoService` using the syndication API.
+enum TwitterVideoService {
+
+    private static let twitterHosts: Set<String> = [
+        "x.com", "www.x.com",
+        "twitter.com", "www.twitter.com",
+        "mobile.twitter.com",
+    ]
+
+    /// Returns `true` when the URL looks like an X / Twitter post.
+    static func isTwitterURL(_ url: URL) -> Bool {
+        guard let host = url.host?.lowercased(), twitterHosts.contains(host) else { return false }
+        return extractTweetId(from: url) != nil
+    }
+
+    /// Fetches the tweet via the syndication API and returns the best MP4 URL
+    /// that fits within share-extension constraints (capped at 720p to stay
+    /// within the ~30-second execution window).
+    static func extractVideoURL(from tweetURL: URL) async throws -> URL {
+        guard let tweetId = extractTweetId(from: tweetURL) else {
+            throw TwitterError.invalidURL
+        }
+
+        let apiURL = URL(string: "https://cdn.syndication.twimg.com/tweet-result?id=\(tweetId)&token=x")!
+
+        var request = URLRequest(url: apiURL)
+        request.setValue(
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko)",
+            forHTTPHeaderField: "User-Agent"
+        )
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let http = response as? HTTPURLResponse else {
+            throw TwitterError.apiRequestFailed(0)
+        }
+        guard (200...299).contains(http.statusCode) else {
+            throw TwitterError.apiRequestFailed(http.statusCode)
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let mediaDetails = json["mediaDetails"] as? [[String: Any]] else {
+            throw TwitterError.malformedResponse
+        }
+
+        guard let videoMedia = mediaDetails.first(where: {
+            let type = $0["type"] as? String
+            return type == "video" || type == "animated_gif"
+        }) else {
+            throw TwitterError.noVideoInTweet
+        }
+
+        guard let videoInfo = videoMedia["video_info"] as? [String: Any],
+              let variants = videoInfo["variants"] as? [[String: Any]] else {
+            throw TwitterError.malformedResponse
+        }
+
+        // Filter to MP4, pick highest bitrate up to ~720p (2.2 Mbps) to keep
+        // downloads fast within the extension's time budget. If no variant is
+        // under the cap, fall back to the smallest available.
+        let mp4Variants = variants
+            .filter { ($0["content_type"] as? String) == "video/mp4" }
+            .compactMap { variant -> (url: String, bitrate: Int)? in
+                guard let url = variant["url"] as? String,
+                      let bitrate = variant["bitrate"] as? Int else { return nil }
+                return (url, bitrate)
+            }
+            .sorted { $0.bitrate < $1.bitrate }
+
+        let maxBitrate = 2_500_000 // ~720p cap
+        let best = mp4Variants.last(where: { $0.bitrate <= maxBitrate }) ?? mp4Variants.last
+
+        guard let chosen = best, let videoURL = URL(string: chosen.url) else {
+            throw TwitterError.noVideoInTweet
+        }
+
+        return videoURL
+    }
+
+    // MARK: - Helpers
+
+    private static func extractTweetId(from url: URL) -> String? {
+        let parts = url.pathComponents
+        guard let statusIndex = parts.firstIndex(of: "status"),
+              statusIndex + 1 < parts.count else { return nil }
+        let candidate = parts[statusIndex + 1]
+        let digits = candidate.prefix(while: \.isNumber)
+        return digits.isEmpty ? nil : String(digits)
+    }
+
+    // MARK: - Errors
+
+    enum TwitterError: LocalizedError {
+        case invalidURL
+        case noVideoInTweet
+        case apiRequestFailed(Int)
+        case malformedResponse
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidURL:
+                return "Not a valid X post URL"
+            case .noVideoInTweet:
+                return "This post doesn't contain a video"
+            case .apiRequestFailed(let code):
+                return "Couldn't fetch post data from X (HTTP \(code))"
+            case .malformedResponse:
+                return "Couldn't parse post data from X"
+            }
+        }
+    }
+}

--- a/ios/SnapGrid/ShareExtension/TwitterVideoService.swift
+++ b/ios/SnapGrid/ShareExtension/TwitterVideoService.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Lightweight X/Twitter video extractor for the share extension.
+/// Lightweight X/Twitter media extractor for the share extension.
 /// Mirrors the Mac app's `TwitterVideoService` using the syndication API.
 enum TwitterVideoService {
 
@@ -16,10 +16,16 @@ enum TwitterVideoService {
         return extractTweetId(from: url) != nil
     }
 
-    /// Fetches the tweet via the syndication API and returns the best MP4 URL
-    /// that fits within share-extension constraints (capped at 720p to stay
-    /// within the ~30-second execution window).
-    static func extractVideoURL(from tweetURL: URL) async throws -> URL {
+    // MARK: - Media Extraction
+
+    enum MediaResult {
+        case video(URL)
+        case image(URL)
+    }
+
+    /// Fetches the tweet via the syndication API and returns the best media URL.
+    /// Videos are capped at ~720p to stay within the share extension's time budget.
+    static func extractMediaURL(from tweetURL: URL) async throws -> MediaResult {
         guard let tweetId = extractTweetId(from: tweetURL) else {
             throw TwitterError.invalidURL
         }
@@ -46,38 +52,43 @@ enum TwitterVideoService {
             throw TwitterError.malformedResponse
         }
 
-        guard let videoMedia = mediaDetails.first(where: {
+        // Prefer video/animated_gif over photos.
+        if let videoMedia = mediaDetails.first(where: {
             let type = $0["type"] as? String
             return type == "video" || type == "animated_gif"
-        }) else {
-            throw TwitterError.noVideoInTweet
-        }
-
-        guard let videoInfo = videoMedia["video_info"] as? [String: Any],
-              let variants = videoInfo["variants"] as? [[String: Any]] else {
-            throw TwitterError.malformedResponse
-        }
-
-        // Filter to MP4, pick highest bitrate up to ~720p (2.2 Mbps) to keep
-        // downloads fast within the extension's time budget. If no variant is
-        // under the cap, fall back to the smallest available.
-        let mp4Variants = variants
-            .filter { ($0["content_type"] as? String) == "video/mp4" }
-            .compactMap { variant -> (url: String, bitrate: Int)? in
-                guard let url = variant["url"] as? String,
-                      let bitrate = variant["bitrate"] as? Int else { return nil }
-                return (url, bitrate)
+        }) {
+            guard let videoInfo = videoMedia["video_info"] as? [String: Any],
+                  let variants = videoInfo["variants"] as? [[String: Any]] else {
+                throw TwitterError.malformedResponse
             }
-            .sorted { $0.bitrate < $1.bitrate }
 
-        let maxBitrate = 2_500_000 // ~720p cap
-        let best = mp4Variants.last(where: { $0.bitrate <= maxBitrate }) ?? mp4Variants.last
+            let mp4Variants = variants
+                .filter { ($0["content_type"] as? String) == "video/mp4" }
+                .compactMap { variant -> (url: String, bitrate: Int)? in
+                    guard let url = variant["url"] as? String,
+                          let bitrate = variant["bitrate"] as? Int else { return nil }
+                    return (url, bitrate)
+                }
+                .sorted { $0.bitrate < $1.bitrate }
 
-        guard let chosen = best, let videoURL = URL(string: chosen.url) else {
-            throw TwitterError.noVideoInTweet
+            let maxBitrate = 2_500_000 // ~720p cap
+            let best = mp4Variants.last(where: { $0.bitrate <= maxBitrate }) ?? mp4Variants.last
+
+            guard let chosen = best, let videoURL = URL(string: chosen.url) else {
+                throw TwitterError.noMediaInTweet
+            }
+
+            return .video(videoURL)
         }
 
-        return videoURL
+        // Fall back to photo.
+        if let photoMedia = mediaDetails.first(where: { ($0["type"] as? String) == "photo" }),
+           let mediaURLString = photoMedia["media_url_https"] as? String,
+           let mediaURL = URL(string: mediaURLString + "?name=large") {
+            return .image(mediaURL)
+        }
+
+        throw TwitterError.noMediaInTweet
     }
 
     // MARK: - Helpers
@@ -95,7 +106,7 @@ enum TwitterVideoService {
 
     enum TwitterError: LocalizedError {
         case invalidURL
-        case noVideoInTweet
+        case noMediaInTweet
         case apiRequestFailed(Int)
         case malformedResponse
 
@@ -103,8 +114,8 @@ enum TwitterVideoService {
             switch self {
             case .invalidURL:
                 return "Not a valid X post URL"
-            case .noVideoInTweet:
-                return "This post doesn't contain a video"
+            case .noMediaInTweet:
+                return "This post doesn't contain any media"
             case .apiRequestFailed(let code):
                 return "Couldn't fetch post data from X (HTTP \(code))"
             case .malformedResponse:

--- a/ios/SnapGrid/SnapGrid/Services/ShareImportService.swift
+++ b/ios/SnapGrid/SnapGrid/Services/ShareImportService.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-/// Moves images saved by the Share Extension from the App Group staging area
+/// Moves media saved by the Share Extension from the App Group staging area
 /// into the iCloud container so they sync to the Mac app for analysis.
 enum ShareImportService {
 
     private static let appGroupID = "group.com.snapgrid"
 
-    /// Check the App Group pending directory and move any images + metadata
+    /// Check the App Group pending directory and move any media + metadata
     /// into the iCloud container. Safe to call multiple times — completed
     /// imports are deleted from the staging area.
     static func importPendingItems(to rootURL: URL) {
@@ -44,16 +44,19 @@ enum ShareImportService {
 
         for jsonURL in jsonFiles {
             let id = jsonURL.deletingPathExtension().lastPathComponent
-            let imageFilename = "\(id).png"
 
-            let srcImage = pendingImages.appendingPathComponent(imageFilename)
-            let dstImage = imagesDir.appendingPathComponent(imageFilename)
+            // Determine file extension from sidecar type field, falling back to .png
+            let ext = mediaExtension(for: jsonURL) ?? "png"
+            let mediaFilename = "\(id).\(ext)"
+
+            let srcMedia = pendingImages.appendingPathComponent(mediaFilename)
+            let dstImage = imagesDir.appendingPathComponent(mediaFilename)
             let dstMetadata = metadataDir.appendingPathComponent(jsonURL.lastPathComponent)
 
-            // Move image first (SyncWatcher checks for media when sidecar arrives)
-            guard fm.fileExists(atPath: srcImage.path) else {
+            // Move media file first (SyncWatcher checks for media when sidecar arrives)
+            guard fm.fileExists(atPath: srcMedia.path) else {
                 #if DEBUG
-                print("[ShareImport] Source image missing for \(id), skipping")
+                print("[ShareImport] Source media missing for \(id) (\(mediaFilename)), skipping")
                 #endif
                 continue
             }
@@ -62,10 +65,10 @@ enum ShareImportService {
                 if fm.fileExists(atPath: dstImage.path) {
                     try fm.removeItem(at: dstImage)
                 }
-                try fm.moveItem(at: srcImage, to: dstImage)
+                try fm.moveItem(at: srcMedia, to: dstImage)
             } catch {
                 #if DEBUG
-                print("[ShareImport] Failed to move image \(id): \(error)")
+                print("[ShareImport] Failed to move media \(id): \(error)")
                 #endif
                 continue
             }
@@ -87,5 +90,15 @@ enum ShareImportService {
             print("[ShareImport] Imported \(id)")
             #endif
         }
+    }
+
+    /// Read the sidecar JSON to determine whether this is a video or image.
+    private static func mediaExtension(for sidecarURL: URL) -> String? {
+        guard let data = try? Data(contentsOf: sidecarURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = json["type"] as? String else {
+            return nil
+        }
+        return type == "video" ? "mp4" : "png"
     }
 }

--- a/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
@@ -258,11 +258,13 @@ struct FullScreenImageOverlay: View {
         let screen = UIScreen.main.bounds.size
         let maxW = screen.width - 24  // 12pt padding on each side
         let maxH = screen.height * 0.85
-        let widthScale = maxW / CGFloat(mediaItem.width)
-        let heightScale = maxH / CGFloat(mediaItem.height)
+        let itemW = max(CGFloat(mediaItem.width), 1)
+        let itemH = max(CGFloat(mediaItem.height), 1)
+        let widthScale = maxW / itemW
+        let heightScale = maxH / itemH
         let scale = min(widthScale, heightScale)
-        let w = CGFloat(mediaItem.width) * scale
-        let h = CGFloat(mediaItem.height) * scale
+        let w = itemW * scale
+        let h = itemH * scale
         return CGRect(
             x: (screen.width - w) / 2,
             y: (screen.height - h) / 2,

--- a/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import SwiftUI
 import SwiftData
 
@@ -495,7 +496,7 @@ struct MainView: View {
         // Query model context directly — @Query may not have refreshed yet after sync
         let descriptor = FetchDescriptor<MediaItem>()
         let allCurrentItems = (try? modelContext.fetch(descriptor)) ?? []
-        let unanalyzed = allCurrentItems.filter { $0.analysisResult == nil && !$0.isAnalyzing && $0.analysisError == nil && !$0.isVideo }
+        let unanalyzed = allCurrentItems.filter { $0.analysisResult == nil && !$0.isAnalyzing && $0.analysisError == nil }
         guard !unanalyzed.isEmpty else {
             print("[Analysis] No unanalyzed items found (total: \(allCurrentItems.count))")
             return
@@ -510,7 +511,12 @@ struct MainView: View {
 
                 item.isAnalyzing = true
                 do {
-                    let image = try loadImage(for: item, rootURL: rootURL)
+                    let image: UIImage
+                    if item.isVideo {
+                        image = try extractPosterFrame(for: item, rootURL: rootURL)
+                    } else {
+                        image = try loadImage(for: item, rootURL: rootURL)
+                    }
 
                     // Resolve guidance and space context
                     var guidance: String?
@@ -557,6 +563,16 @@ struct MainView: View {
             throw AIAnalysisService.AnalysisError.imageConversionFailed
         }
         return image
+    }
+
+    private func extractPosterFrame(for item: MediaItem, rootURL: URL) throws -> UIImage {
+        let videoURL = rootURL.appendingPathComponent("images/\(item.filename)")
+        let asset = AVURLAsset(url: videoURL)
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        generator.maximumSize = CGSize(width: 1280, height: 1280)
+        let cgImage = try generator.copyCGImage(at: CMTime(seconds: 1, preferredTimescale: 600), actualTime: nil)
+        return UIImage(cgImage: cgImage)
     }
 
     private func writeSidecar(for item: MediaItem, rootURL: URL) {


### PR DESCRIPTION
### Why?

Users want to save videos from X/Twitter posts into their SnapGrid library — both from the Mac app (paste a URL) and from iOS (share sheet). The syndication API makes this possible without any API keys.

### How?

Adds `TwitterVideoService` to both the Mac app and iOS share extension, using the unauthenticated `cdn.syndication.twimg.com` syndication API to resolve tweet URLs to direct MP4 download links. The Mac app picks the highest quality variant; the iOS share extension caps at ~720p to stay within the extension's time budget. Also includes a defensive guard in `FullScreenImageOverlay.computeFinalFrame` to prevent NaN crashes when video dimensions are zero.

<sub>Generated with Claude Code</sub>