### PR TITLE
Add iOS Liquid Glass effects with morphing delete confirmation

### DIFF
--- a/ios/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
+++ b/ios/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		69A2FAEBC4355557E9BBF91D /* MediaItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA2C659B43CBFC9C4825931 /* MediaItem.swift */; };
+		787BBD33FD14A7CC420B8C71 /* SyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC24EBA6AD6068C4ADA26030 /* SyncService.swift */; };
+		810E66F164E96C78F5095B7B /* AnalysisResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A78C6996F3AEB37B949CCE /* AnalysisResult.swift */; };
 		A0E9D3DA2F7328AC00E35403 /* ShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = A0E9D3D02F7328AC00E35403 /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		A100000001 /* SnapGridApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000001 /* SnapGridApp.swift */; };
 		A100000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000002 /* ContentView.swift */; };
@@ -28,10 +31,6 @@
 		A100000021 /* FullScreenImageOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000021 /* FullScreenImageOverlay.swift */; };
 		A100000022 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = B100000022 /* AppIcon.icon */; };
 		A100000023 /* ShareImportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000025 /* ShareImportService.swift */; };
-		69A2FAEBC4355557E9BBF91D /* MediaItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA2C659B43CBFC9C4825931 /* MediaItem.swift */; };
-		810E66F164E96C78F5095B7B /* AnalysisResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A78C6996F3AEB37B949CCE /* AnalysisResult.swift */; };
-		787BBD33FD14A7CC420B8C71 /* SyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC24EBA6AD6068C4ADA26030 /* SyncService.swift */; };
-		F2AD76603369201957F4E1FD /* SearchIndexService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFAB07291230EAED58390B4 /* SearchIndexService.swift */; };
 		A100000030 /* AnimationTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000030 /* AnimationTokens.swift */; };
 		A100000031 /* ImageImportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000031 /* ImageImportService.swift */; };
 		A100000032 /* PhotoPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000032 /* PhotoPickerView.swift */; };
@@ -39,6 +38,7 @@
 		A100000036 /* KeySyncCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000036 /* KeySyncCrypto.swift */; };
 		A100000037 /* KeySyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000037 /* KeySyncService.swift */; };
 		A100000038 /* AIAnalysisService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000038 /* AIAnalysisService.swift */; };
+		F2AD76603369201957F4E1FD /* SearchIndexService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFAB07291230EAED58390B4 /* SearchIndexService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,6 +66,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5CFAB07291230EAED58390B4 /* SearchIndexService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchIndexService.swift; sourceTree = "<group>"; };
+		71A78C6996F3AEB37B949CCE /* AnalysisResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisResult.swift; sourceTree = "<group>"; };
+		8EA2C659B43CBFC9C4825931 /* MediaItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaItem.swift; sourceTree = "<group>"; };
 		A0E9D3D02F7328AC00E35403 /* ShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		B100000001 /* SnapGridApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapGridApp.swift; sourceTree = "<group>"; };
 		B100000002 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -82,7 +85,6 @@
 		B100000016 /* ImageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDetailView.swift; sourceTree = "<group>"; };
 		B100000017 /* ZoomableImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomableImageView.swift; sourceTree = "<group>"; };
 		B100000018 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
-		B100000030 /* AnimationTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationTokens.swift; sourceTree = "<group>"; };
 		B100000019 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B100000020 /* iCloudDownloadMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iCloudDownloadMonitor.swift; sourceTree = "<group>"; };
 		B100000021 /* FullScreenImageOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenImageOverlay.swift; sourceTree = "<group>"; };
@@ -90,17 +92,15 @@
 		B100000023 /* SnapGrid.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SnapGrid.entitlements; sourceTree = "<group>"; };
 		B100000024 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B100000025 /* ShareImportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareImportService.swift; sourceTree = "<group>"; };
-		C100000001 /* SnapGrid.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SnapGrid.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		8EA2C659B43CBFC9C4825931 /* MediaItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaItem.swift; sourceTree = "<group>"; };
-		71A78C6996F3AEB37B949CCE /* AnalysisResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisResult.swift; sourceTree = "<group>"; };
-		FC24EBA6AD6068C4ADA26030 /* SyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncService.swift; sourceTree = "<group>"; };
-		5CFAB07291230EAED58390B4 /* SearchIndexService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchIndexService.swift; sourceTree = "<group>"; };
+		B100000030 /* AnimationTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationTokens.swift; sourceTree = "<group>"; };
 		B100000031 /* ImageImportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageImportService.swift; sourceTree = "<group>"; };
 		B100000032 /* PhotoPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPickerView.swift; sourceTree = "<group>"; };
 		B100000033 /* MediaDeleteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDeleteService.swift; sourceTree = "<group>"; };
 		B100000036 /* KeySyncCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeySyncCrypto.swift; sourceTree = "<group>"; };
 		B100000037 /* KeySyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeySyncService.swift; sourceTree = "<group>"; };
 		B100000038 /* AIAnalysisService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIAnalysisService.swift; sourceTree = "<group>"; };
+		C100000001 /* SnapGrid.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SnapGrid.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		FC24EBA6AD6068C4ADA26030 /* SyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */

--- a/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
@@ -141,6 +141,9 @@ struct FullScreenImageOverlay: View {
     // Share sheet
     @State private var shareItem: URL?
 
+    // Glass effect namespace for action toolbar union
+    @Namespace private var glassNS
+
     // Search-triggered close (skips rect correction since grid has re-laid out)
     @State private var isSearchDismiss = false
 
@@ -163,6 +166,15 @@ struct FullScreenImageOverlay: View {
     private var item: MediaItem { items[currentIndex] }
 
     private var displayImage: UIImage? { image ?? thumbnailImage }
+
+    /// On iOS 26+ the inline glass confirmation handles delete; skip the system dialog.
+    private var legacyDeleteDialogBinding: Binding<Bool> {
+        if #available(iOS 26.0, *) {
+            return .constant(false)
+        } else {
+            return $showDeleteConfirmation
+        }
+    }
 
     init(
         items: [MediaItem],
@@ -442,7 +454,7 @@ struct FullScreenImageOverlay: View {
                 }
             }
         }
-        .confirmationDialog("Delete this item?", isPresented: $showDeleteConfirmation, titleVisibility: .visible) {
+        .confirmationDialog("Delete this item?", isPresented: legacyDeleteDialogBinding, titleVisibility: .visible) {
             Button("Delete", role: .destructive) {
                 handleDelete()
             }
@@ -466,29 +478,80 @@ struct FullScreenImageOverlay: View {
     @ViewBuilder
     private var actionToolbar: some View {
         if #available(iOS 26.0, *) {
-            GlassEffectContainer(spacing: 0) {
-                HStack(spacing: 0) {
-                    Button {
-                        prepareShareItem()
-                    } label: {
-                        Image(systemName: "square.and.arrow.up")
-                            .font(.body.weight(.medium))
-                            .frame(width: 56, height: 50)
-                    }
+            GlassEffectContainer {
+                if showDeleteConfirmation {
+                    // Confirmation panel — glass morphs from the toolbar
+                    VStack(spacing: 0) {
+                        Text("Delete this item?")
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(.secondary)
+                            .padding(.top, 14)
+                            .padding(.bottom, 10)
 
-                    Divider()
-                        .frame(height: 24)
-                        .opacity(0.3)
+                        Divider().opacity(0.3)
 
-                    Button {
-                        showDeleteConfirmation = true
-                    } label: {
-                        Image(systemName: "trash")
-                            .font(.body.weight(.medium))
-                            .frame(width: 56, height: 50)
+                        Button(role: .destructive) {
+                            withAnimation(SnapSpring.fast) {
+                                showDeleteConfirmation = false
+                            }
+                            handleDelete()
+                        } label: {
+                            Text("Delete")
+                                .font(.body.weight(.medium))
+                                .foregroundStyle(.red)
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 44)
+                        }
+                        .buttonStyle(.plain)
+
+                        Divider().opacity(0.3)
+
+                        Button {
+                            withAnimation(SnapSpring.fast) {
+                                showDeleteConfirmation = false
+                            }
+                        } label: {
+                            Text("Cancel")
+                                .font(.body.weight(.medium))
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 44)
+                        }
+                        .buttonStyle(.plain)
                     }
+                    .frame(width: 200)
+                    .glassEffect(.regular, in: .rect(cornerRadius: 16))
+                    .glassEffectID("actionToolbar", in: glassNS)
+                } else {
+                    // Normal toolbar — share + delete
+                    HStack(spacing: 0) {
+                        Button {
+                            prepareShareItem()
+                        } label: {
+                            Image(systemName: "square.and.arrow.up")
+                                .font(.body.weight(.medium))
+                                .frame(width: 56, height: 50)
+                        }
+                        .buttonStyle(.plain)
+                        .glassEffect(.regular.interactive())
+                        .glassEffectUnion(id: "actionToolbar", namespace: glassNS)
+                        .accessibilityLabel("Share")
+
+                        Button {
+                            withAnimation(SnapSpring.fast) {
+                                showDeleteConfirmation = true
+                            }
+                        } label: {
+                            Image(systemName: "trash")
+                                .font(.body.weight(.medium))
+                                .frame(width: 56, height: 50)
+                        }
+                        .buttonStyle(.plain)
+                        .glassEffect(.regular.interactive())
+                        .glassEffectUnion(id: "actionToolbar", namespace: glassNS)
+                        .accessibilityLabel("Delete")
+                    }
+                    .glassEffectID("actionToolbar", in: glassNS)
                 }
-                .glassEffect(.regular.interactive())
             }
         } else {
             HStack(spacing: 0) {
@@ -500,6 +563,7 @@ struct FullScreenImageOverlay: View {
                         .foregroundStyle(.white.opacity(0.9))
                         .frame(width: 56, height: 50)
                 }
+                .accessibilityLabel("Share")
 
                 Divider()
                     .frame(height: 24)
@@ -513,6 +577,7 @@ struct FullScreenImageOverlay: View {
                         .foregroundStyle(.white.opacity(0.9))
                         .frame(width: 56, height: 50)
                 }
+                .accessibilityLabel("Delete")
             }
             .background(.ultraThinMaterial, in: Capsule())
             .environment(\.colorScheme, .dark)
@@ -1130,32 +1195,8 @@ private struct DetailMetadataSection: View {
                 }
 
                 if !result.patterns.isEmpty {
-                    FlowLayout(spacing: 8) {
-                        ForEach(Array(result.patterns.enumerated()), id: \.element.name) { index, pattern in
-                            Text(pattern.name)
-                                .font(.caption)
-                                .foregroundStyle(.white.opacity(0.9))
-                                .padding(.horizontal, 14)
-                                .padding(.vertical, 10)
-                                .background(.ultraThinMaterial, in: Capsule())
-                                .environment(\.colorScheme, .dark)
-                                .contentShape(Rectangle())
-                                .accessibilityHint("Double tap to search for this pattern")
-                                .onTapGesture {
-                                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                                    onSearchPattern?(pattern.name)
-                                }
-                                .opacity(stage >= 2 ? 1 : 0)
-                                .offset(y: stage >= 2 ? 0 : MetadataReveal.slideDistance)
-                                .animation(
-                                    UIAccessibility.isReduceMotionEnabled
-                                        ? SnapSpring.resolvedMetadata
-                                        : MetadataReveal.spring.delay(Double(index) * MetadataReveal.tagStagger),
-                                    value: stage
-                                )
-                        }
-                    }
-                    .padding(.bottom, 14)
+                    patternPillsGrid(result.patterns)
+                        .padding(.bottom, 14)
                 }
 
                 if hasDescription(result) {
@@ -1196,6 +1237,70 @@ private struct DetailMetadataSection: View {
         guard seconds.isFinite else { return "0:00" }
         let total = Int(seconds)
         return "\(total / 60):\(String(format: "%02d", total % 60))"
+    }
+
+    // MARK: - Pattern pills (glass on iOS 26+, material fallback)
+
+    @ViewBuilder
+    private func patternPillsGrid(_ patterns: [PatternTag]) -> some View {
+        let pills = FlowLayout(spacing: 8) {
+            ForEach(Array(patterns.enumerated()), id: \.element.name) { index, pattern in
+                patternPill(pattern: pattern, index: index)
+            }
+        }
+
+        if #available(iOS 26.0, *) {
+            GlassEffectContainer { pills }
+        } else {
+            pills
+        }
+    }
+
+    @ViewBuilder
+    private func patternPill(pattern: PatternTag, index: Int) -> some View {
+        let base = Text(pattern.name)
+            .font(.caption)
+            .foregroundStyle(.white.opacity(0.9))
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+
+        if #available(iOS 26.0, *) {
+            base
+                .environment(\.colorScheme, .dark)
+                .glassEffect(.regular.interactive(), in: .capsule)
+                .contentShape(Rectangle())
+                .accessibilityHint("Double tap to search for this pattern")
+                .onTapGesture {
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    onSearchPattern?(pattern.name)
+                }
+                .opacity(stage >= 2 ? 1 : 0)
+                .offset(y: stage >= 2 ? 0 : MetadataReveal.slideDistance)
+                .animation(
+                    UIAccessibility.isReduceMotionEnabled
+                        ? SnapSpring.resolvedMetadata
+                        : MetadataReveal.spring.delay(Double(index) * MetadataReveal.tagStagger),
+                    value: stage
+                )
+        } else {
+            base
+                .background(.ultraThinMaterial, in: Capsule())
+                .environment(\.colorScheme, .dark)
+                .contentShape(Rectangle())
+                .accessibilityHint("Double tap to search for this pattern")
+                .onTapGesture {
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    onSearchPattern?(pattern.name)
+                }
+                .opacity(stage >= 2 ? 1 : 0)
+                .offset(y: stage >= 2 ? 0 : MetadataReveal.slideDistance)
+                .animation(
+                    UIAccessibility.isReduceMotionEnabled
+                        ? SnapSpring.resolvedMetadata
+                        : MetadataReveal.spring.delay(Double(index) * MetadataReveal.tagStagger),
+                    value: stage
+                )
+        }
     }
 }
 


### PR DESCRIPTION
### Why?

The iOS app's Liquid Glass implementation had correctness issues — `.interactive()` was applied at the container level instead of per-button, so both toolbar buttons highlighted as one unit on press. Pattern pills over photo content were still using `ultraThinMaterial` instead of glass. The delete confirmation used a system `confirmationDialog` which can't morph from the glass toolbar.

### How?

Refactored the action toolbar to use per-button `glassEffect` + `glassEffectUnion` for independent press feedback within a unified glass shape. Added a morphing inline delete confirmation that flows from the toolbar using `glassEffectID`. Upgraded pattern pills to `glassEffect(.regular.interactive())` in a `GlassEffectContainer`. All changes are gated behind `#available(iOS 26.0, *)` with unchanged pre-iOS 26 fallbacks. Also fixed missing accessibility labels on toolbar buttons.

<details>
<summary>Implementation Plan</summary>

# Liquid Glass Review & Fixes — iOS SnapGrid

## Context

The iOS app has minimal Liquid Glass adoption — only the action toolbar in `FullScreenImageOverlay` uses `glassEffect`. This review found design correctness issues with that implementation and one strong upgrade candidate (pattern pills). The goal is to make glass usage idiomatic, visually correct, and consistent with Apple's API design intent.

## Current State Summary

| Surface | Current treatment | Glass? | Verdict |
|---|---|---|---|
| Action toolbar (share/delete) | `glassEffect(.regular.interactive())` on HStack | Yes | **Fix** — interactive on wrong level |
| Pattern pills (metadata tags) | `.ultraThinMaterial` in Capsule | No | **Upgrade** — interactive, over photo content |
| Bottom bar toolbar (MainView) | System `.bottomBar` placement | System | **Correct** — no changes |
| Full-screen backdrop | `.ultraThinMaterial` + black | No | **Keep** — intentionally opaque dimming layer |
| Grid "Analyzing..." badge | `.ultraThinMaterial` rounded rect | No | **Keep** — transient, non-interactive, small |
| Space tab bar | No material (transparent) | No | **Keep** — clean as-is, lower priority |

---

## Changes

### 1. Fix action toolbar glass — per-button interactive treatment

**Problem:** `.glassEffect(.regular.interactive())` is applied to the HStack containing both buttons. This means the entire bar highlights as one unit on press — the user can't see which button they're pressing. A split-button should have independent press feedback.

**Fix:**
- Add `@Namespace private var glassNS` to the struct properties
- Replace the iOS 26+ branch to use `glassEffect(.regular.interactive())` on each button individually
- Use `.glassEffectUnion(id: "actionToolbar", namespace: glassNS)` on each button to visually merge them into one continuous glass shape while preserving independent press states
- Remove the `Divider` — the union handles the visual split naturally with button press states
- Add missing `.accessibilityLabel("Share")` and `.accessibilityLabel("Delete")` to both the glass and fallback toolbar buttons

### 2. Morphing delete confirmation (iOS 26+)

Replace system `confirmationDialog` with inline glass confirmation that morphs from the toolbar using `glassEffectID`. Both the toolbar and confirmation panel share the same ID within a `GlassEffectContainer`, so the glass flows between shapes on state change.

### 3. Upgrade pattern pills to Liquid Glass on iOS 26+

Tappable capsule pills appear over photo content — ideal for glass refraction. Each pill gets `.glassEffect(.regular.interactive(), in: .capsule)` replacing `.background(.ultraThinMaterial, in: Capsule())`, wrapped in `GlassEffectContainer`.

### 4. No changes to these surfaces (confirmed correct)

- **Backdrop**: Keep `.ultraThinMaterial` + black overlay. Glass is for discrete elements, not full-screen dimming.
- **Grid badge**: Keep `.ultraThinMaterial`. Non-interactive, transient shimmer state.
- **MainView toolbar**: Already correct — uses system bar placement which auto-gets glass on iOS 26+.
- **SpaceTabBar**: No change. Clean transparent style works well; adding glass would compete with the system bottom bar.

</details>

<sub>Generated with Claude Code</sub>