### PR TITLE
Bump iOS app version to 2.0.0

### DIFF
--- a/ios/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
+++ b/ios/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
@@ -641,7 +641,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.snapgrid.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -677,7 +677,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.snapgrid.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";


### PR DESCRIPTION
### Why?

The iOS app was still at version 1.0.0 while the native Mac app is already at 2.0.0. Aligning both apps to the same version ahead of the 2.0 release.

### How?

Updates `MARKETING_VERSION` from 1.0.0 to 2.0.0 in the iOS Xcode project for both Debug and Release configurations.

<sub>Generated with Claude Code</sub>