### PR TITLE
Fade iOS dismiss blur faster than tint overlay

### DIFF
--- a/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
@@ -248,6 +248,12 @@ struct FullScreenImageOverlay: View {
         return 1.0 - dragProgress * 0.5
     }
 
+    private var blurOpacity: Double {
+        if !isExpanded { return 0 }
+        let dragProgress = min(abs(effectiveDismissOffset) / 80.0, 1.0)
+        return 1.0 - dragProgress
+    }
+
     private var dismissScale: CGFloat {
         let progress = min(abs(effectiveDismissOffset) / 400.0, 1.0)
         return 1.0 - progress * 0.1
@@ -283,9 +289,10 @@ struct FullScreenImageOverlay: View {
             // 1. Backdrop — material blur + tint (matches Mac app)
             ZStack {
                 Rectangle().fill(.ultraThinMaterial)
+                    .opacity(blurOpacity)
                 Color.black.opacity(0.55)
+                    .opacity(backdropOpacity)
             }
-            .opacity(backdropOpacity)
             .ignoresSafeArea()
 
             // 2. Adjacent images — only after hero, hidden during close


### PR DESCRIPTION
### Why?

The background blur during drag-to-dismiss looks foggy — the `.ultraThinMaterial` stays too opaque throughout the gesture, making the transition feel muddy.

### How?

Split the backdrop into two independent opacity tracks so the material blur clears fully within 80pt of drag while the dark tint keeps its original slower fade curve.

<sub>Generated with Claude Code</sub>