### PR TITLE
Soften iOS space tab bar separator opacity

### DIFF
--- a/ios/SnapGrid/SnapGrid/Views/Main/SpaceTabBar.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/SpaceTabBar.swift
@@ -37,7 +37,7 @@ struct SpaceTabBar: View {
         }
         .overlay(alignment: .bottom) {
             Rectangle()
-                .fill(Color.white.opacity(0.15))
+                .fill(Color.white.opacity(0.08))
                 .frame(height: 1)
         }
     }


### PR DESCRIPTION
### Why?

The tab bar bottom border was visually prominent, drawing attention away from the tab content. A subtler separator better matches the dark tab bar aesthetic.

### How?

Reduced the white overlay opacity from `0.15` to `0.08` for a softer divider line.

<sub>Generated with Claude Code</sub>