### PR TITLE
Add simulate empty state toggle in developer settings

### DIFF
--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -21,6 +21,12 @@ struct ContentView: View {
     @State private var isSearchActive = false
     @State private var isSearchFieldPresented = false
 
+    #if DEBUG
+    @AppStorage("debugSimulateEmptyState") private var debugSimulateEmptyState = false
+    #else
+    private let debugSimulateEmptyState = false
+    #endif
+
     private func itemsForSpace(_ spaceId: String?) -> [MediaItem] {
         var items = allItems
 
@@ -79,7 +85,7 @@ struct ContentView: View {
                 // File-import .onDrop is scoped here (not the whole window) so it
                 // doesn't steal drags from SpaceTabBar's .onDrop for space assignment.
                 Group {
-                    if allItems.isEmpty {
+                    if allItems.isEmpty || debugSimulateEmptyState {
                         EmptyStateView(isDragTargeted: isDragTargeted)
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
                     } else {

--- a/SnapGrid/SnapGrid/Views/Settings/DeveloperSettingsTab.swift
+++ b/SnapGrid/SnapGrid/Views/Settings/DeveloperSettingsTab.swift
@@ -2,12 +2,22 @@ import SwiftUI
 import SwiftData
 
 struct DeveloperSettingsTab: View {
+    @AppStorage("debugSimulateEmptyState") private var simulateEmptyState = false
     @State private var showConfirmReset = false
     @State private var trashEmptied = false
     @State private var trashCount = 0
 
     var body: some View {
         Form {
+            Section("Simulation") {
+                Toggle("Simulate Empty State", isOn: $simulateEmptyState)
+                    .accessibilityLabel("Simulate empty state")
+
+                Text("Shows the empty state view without deleting any data.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Trash") {
                 LabeledContent("Items in trash") {
                     Text("\(trashCount)")


### PR DESCRIPTION
### Why?

There's no way to test or iterate on the empty state UI without actually having an empty library — which means deleting all data and re-importing to get back to a working state. This slows down development when working on the onboarding experience.

### How?

Adds a toggle in Developer settings (debug builds only) that forces the main content area to show the empty state view, using `@AppStorage` to bridge state between the separate Settings window scene and ContentView. Data remains untouched — toggling off instantly restores the grid.

<details>
<summary>Implementation Plan</summary>

# Plan: Add "Simulate Empty State" button to Developer Settings

## Context
The developer settings tab (DEBUG-only) needs a toggle to simulate the app's empty state without deleting any data. This lets developers test and iterate on the empty state UI (skeleton grid + onboarding card) without needing an actually empty library.

## Approach

The empty state in `ContentView` is triggered by `allItems.isEmpty` (line 82). Since `allItems` is a `@Query` result we can't mutate directly, we'll add a boolean flag to `AppState` that overrides the emptiness check.

### Changes

**1. `AppState.swift` — Add simulation flag**
- Add `var simulateEmptyState: Bool = false` (DEBUG-only)
- No persistence needed — resets on app relaunch

**2. `ContentView.swift` — Respect the flag**
- Change line 82 from `if allItems.isEmpty` to `if allItems.isEmpty || appState.simulateEmptyState`
- This makes the main content area show `EmptyStateView` when the flag is on, while keeping all data intact

**3. `DeveloperSettingsTab.swift` — Add toggle UI**
- Add `@Environment(AppState.self)` to access the flag
- Add a new "Simulation" section with a `Toggle("Simulate Empty State", ...)`
- Include a caption explaining it hides all items without deleting data

### Files to modify
- `SnapGrid/SnapGrid/App/AppState.swift`
- `SnapGrid/SnapGrid/Views/ContentView/ContentView.swift`
- `SnapGrid/SnapGrid/Views/Settings/DeveloperSettingsTab.swift`

## Verification
1. Open app with items in library
2. Go to Settings → Developer → toggle "Simulate Empty State" on
3. Main view should show the empty state (skeleton grid + onboarding card)
4. Toggle off → items reappear immediately
5. Items are not deleted — toggling off restores the normal grid

</details>

<sub>Generated with Claude Code</sub>