### PR TITLE
Add context menus with share, redo analysis, and delete to iOS and Mac

### DIFF
--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import SwiftData
+import AppKit
 import UniformTypeIdentifiers
 
 struct ContentView: View {
@@ -131,7 +132,21 @@ struct ContentView: View {
                     },
                     onCurrentItemChanged: { newId in
                         appState.detailItem = newId
-                    }
+                    },
+                    onShare: { id, frame in
+                        shareItems(Set([id]), sourceFrame: frame)
+                    },
+                    onRedoAnalysis: { id in
+                        retryAnalysis(Set([id]))
+                    },
+                    onDelete: { id in
+                        deleteItems(Set([id]))
+                    },
+                    onAssignToSpace: { id, spaceId in
+                        assignToSpace(itemIds: Set([id]), spaceId: spaceId)
+                    },
+                    spaces: spaces,
+                    activeSpaceId: appState.activeSpaceId
                 )
                 }
             }
@@ -387,6 +402,7 @@ struct ContentView: View {
                         onDelete: deleteItems,
                         onAssignToSpace: assignToSpace,
                         onRetryAnalysis: retryAnalysis,
+                        onShare: { ids, frame in shareItems(ids, sourceFrame: frame) },
                         onSetSelection: { ids in appState.selectedIds = ids },
                         coordinateSpaceName: "gridContent-\(spaceId ?? "all")"
                     )
@@ -739,6 +755,32 @@ struct ContentView: View {
             Task {
                 await importService.analyzeItem(item, context: modelContext)
             }
+        }
+    }
+
+    private func shareItems(_ ids: Set<String>, sourceFrame: CGRect) {
+        let urls = allItems
+            .filter { ids.contains($0.id) }
+            .map { MediaStorageService.shared.mediaURL(filename: $0.filename) }
+            .filter { FileManager.default.fileExists(atPath: $0.path) }
+        guard !urls.isEmpty else { return }
+
+        // Copy to temp directory so macOS shows "Send Copy" only (no Collaborate option)
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("SnapGridShare")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let tempURLs = urls.compactMap { url -> URL? in
+            let dest = tempDir.appendingPathComponent(url.lastPathComponent)
+            try? FileManager.default.removeItem(at: dest)
+            try? FileManager.default.copyItem(at: url, to: dest)
+            return dest
+        }
+        guard !tempURLs.isEmpty else { return }
+
+        let picker = NSSharingServicePicker(items: tempURLs)
+        if let window = NSApp.keyWindow,
+           let contentView = window.contentView {
+            let rect = contentView.convert(sourceFrame, from: nil)
+            picker.show(relativeTo: rect, of: contentView, preferredEdge: .minY)
         }
     }
 

--- a/SnapGrid/SnapGrid/Views/Detail/HeroDetailOverlay.swift
+++ b/SnapGrid/SnapGrid/Views/Detail/HeroDetailOverlay.swift
@@ -48,6 +48,12 @@ struct HeroDetailOverlay: View {
     let sourceFrame: CGRect
     let onAnimationComplete: () -> Void
     let onCurrentItemChanged: ((String) -> Void)?
+    let onShare: ((String, CGRect) -> Void)?
+    let onRedoAnalysis: ((String) -> Void)?
+    let onDelete: ((String) -> Void)?
+    let onAssignToSpace: ((String, String?) -> Void)?
+    let spaces: [Space]
+    let activeSpaceId: String?
 
     @Environment(VideoPreviewManager.self) private var videoPreview
     @Environment(AppState.self) private var appState
@@ -85,13 +91,25 @@ struct HeroDetailOverlay: View {
         startIndex: Int,
         sourceFrame: CGRect,
         onAnimationComplete: @escaping () -> Void,
-        onCurrentItemChanged: ((String) -> Void)? = nil
+        onCurrentItemChanged: ((String) -> Void)? = nil,
+        onShare: ((String, CGRect) -> Void)? = nil,
+        onRedoAnalysis: ((String) -> Void)? = nil,
+        onDelete: ((String) -> Void)? = nil,
+        onAssignToSpace: ((String, String?) -> Void)? = nil,
+        spaces: [Space] = [],
+        activeSpaceId: String? = nil
     ) {
         _items = State(initialValue: items)
         self.startIndex = startIndex
         self.sourceFrame = sourceFrame
         self.onAnimationComplete = onAnimationComplete
         self.onCurrentItemChanged = onCurrentItemChanged
+        self.onShare = onShare
+        self.onRedoAnalysis = onRedoAnalysis
+        self.onDelete = onDelete
+        self.onAssignToSpace = onAssignToSpace
+        self.spaces = spaces
+        self.activeSpaceId = activeSpaceId
         _currentIndex = State(initialValue: startIndex)
         _closeTargetFrame = State(initialValue: sourceFrame)
         _image = State(initialValue: ImageCacheService.shared.image(forKey: items[startIndex].id))
@@ -559,6 +577,7 @@ struct HeroDetailOverlay: View {
                 .clipShape(RoundedRectangle(cornerRadius: 16))
                 .onDrag { makeDragProvider() } preview: { dragPreview }
                 .onTapGesture { triggerClose() }
+                .contextMenu { detailContextMenu(frame: finalFrame) }
 
                 DetailMetadataSection(item: currentItem, stage: metadataStage) { pattern in
                     // Set search so grid re-layouts and reports new frame position
@@ -684,6 +703,62 @@ struct HeroDetailOverlay: View {
         }.value
         if let loaded, items[currentIndex].id == item.id {
             self.image = loaded
+        }
+    }
+
+    // MARK: - Context Menu
+
+    @ViewBuilder
+    private func detailContextMenu(frame: CGRect) -> some View {
+        if !spaces.isEmpty {
+            Menu {
+                ForEach(spaces) { space in
+                    Button {
+                        onAssignToSpace?(currentItem.id, space.id)
+                    } label: {
+                        if currentItem.space?.id == space.id {
+                            Label(space.name, systemImage: "checkmark")
+                        } else {
+                            Text(space.name)
+                        }
+                    }
+                }
+            } label: {
+                Label("Move to", systemImage: "folder")
+            }
+
+            if activeSpaceId != nil {
+                Button {
+                    onAssignToSpace?(currentItem.id, nil)
+                } label: {
+                    Label("Remove from Space", systemImage: "folder.badge.minus")
+                }
+            }
+
+            Divider()
+        }
+
+        Button {
+            onShare?(currentItem.id, frame)
+        } label: {
+            Label("Share...", systemImage: "square.and.arrow.up")
+        }
+
+        Button {
+            onRedoAnalysis?(currentItem.id)
+        } label: {
+            Label("Redo Analysis", systemImage: "arrow.clockwise")
+        }
+
+        Divider()
+
+        Button(role: .destructive) {
+            triggerClose()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                onDelete?(currentItem.id)
+            }
+        } label: {
+            Label("Delete", systemImage: "trash")
         }
     }
 

--- a/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -17,6 +17,7 @@ struct GridItemView: View {
     let onDelete: () -> Void
     let onAssignToSpace: (String?) -> Void
     let onRetryAnalysis: () -> Void
+    let onShare: (CGRect) -> Void
 
     @Environment(VideoPreviewManager.self) private var videoPreview
     @Environment(AppState.self) private var appState
@@ -26,7 +27,13 @@ struct GridItemView: View {
     @State private var globalFrame: CGRect = .zero
     @State private var hoverTask: Task<Void, Never>?
 
-    init(item: MediaItem, width: CGFloat, isSelected: Bool, spaces: [Space], activeSpaceId: String?, selectedCount: Int, effectiveIds: Set<String>, hiddenItemId: String?, onSelect: @escaping (CGRect) -> Void, onToggleSelect: @escaping () -> Void, onShiftSelect: @escaping () -> Void, onDelete: @escaping () -> Void, onAssignToSpace: @escaping (String?) -> Void, onRetryAnalysis: @escaping () -> Void) {
+    // Eagerly resolved SwiftData properties — prevents faults on detached backing stores
+    // when SwiftUI re-evaluates the body (e.g. for context menu snapshots).
+    private let itemIsVideo: Bool
+    private let itemSpaceId: String?
+    private let itemAspectRatio: CGFloat
+
+    init(item: MediaItem, width: CGFloat, isSelected: Bool, spaces: [Space], activeSpaceId: String?, selectedCount: Int, effectiveIds: Set<String>, hiddenItemId: String?, onSelect: @escaping (CGRect) -> Void, onToggleSelect: @escaping () -> Void, onShiftSelect: @escaping () -> Void, onDelete: @escaping () -> Void, onAssignToSpace: @escaping (String?) -> Void, onRetryAnalysis: @escaping () -> Void, onShare: @escaping (CGRect) -> Void) {
         self.item = item
         self.width = width
         self.isSelected = isSelected
@@ -41,16 +48,20 @@ struct GridItemView: View {
         self.onDelete = onDelete
         self.onAssignToSpace = onAssignToSpace
         self.onRetryAnalysis = onRetryAnalysis
+        self.onShare = onShare
+        self.itemIsVideo = item.isVideo
+        self.itemSpaceId = item.space?.id
+        self.itemAspectRatio = item.aspectRatio
         _thumbnail = State(initialValue: ImageCacheService.shared.image(forKey: item.id))
     }
 
     private var height: CGFloat {
-        width / item.aspectRatio
+        width / itemAspectRatio
     }
 
     private var accessibilityDescription: String {
         var parts: [String] = []
-        if item.isVideo { parts.append("Video") } else { parts.append("Image") }
+        if itemIsVideo { parts.append("Video") } else { parts.append("Image") }
         if let summary = item.analysisResult?.imageSummary, !summary.isEmpty {
             parts.append(summary)
         }
@@ -81,15 +92,15 @@ struct GridItemView: View {
     /// The NSView-backed AVPlayerLayer causes a spurious onHover(false) when it appears
     /// on top; this keeps hover UI visible for the duration of the grid preview.
     private var effectiveHover: Bool {
-        isHovered || (item.isVideo && videoPreview.activeItemId == item.id && videoPreview.displayState == .grid)
+        isHovered || (itemIsVideo && videoPreview.activeItemId == item.id && videoPreview.displayState == .grid)
     }
 
     /// Whether to show the SwiftUI gradient scrim behind pattern pills.
     /// Suppressed for video items when the floating video layer provides its own CAGradientLayer.
-    /// Guarded by `item.isVideo` so non-video items never subscribe to `activeItemId` changes.
+    /// Guarded by `itemIsVideo` so non-video items never subscribe to `activeItemId` changes.
     private var showHoverGradient: Bool {
         guard effectiveHover else { return false }
-        guard item.isVideo else { return true }
+        guard itemIsVideo else { return true }
         return videoPreview.activeItemId != item.id
     }
 
@@ -105,7 +116,7 @@ struct GridItemView: View {
                 } else {
                     // Pre-claim the video player BEFORE overlay appears —
                     // prevents onHover(false) race from destroying it
-                    if item.isVideo {
+                    if itemIsVideo {
                         videoPreview.claimForDetail()
                     }
                     onSelect(globalFrame)
@@ -134,7 +145,7 @@ struct GridItemView: View {
             // LAYER 2: Non-interactive visual overlays
             Group {
                 // Video badge (hidden during active preview — floating layer renders video)
-                if item.isVideo && videoPreview.activeItemId != item.id {
+                if itemIsVideo && videoPreview.activeItemId != item.id {
                     VStack {
                         Spacer()
                         HStack {
@@ -245,7 +256,7 @@ struct GridItemView: View {
                 .buttonStyle(.plain)
                 .padding(8)
                 .transition(.opacity.combined(with: .scale(scale: 0.8)))
-                .accessibilityLabel("Retry analysis")
+                .accessibilityLabel("Redo analysis")
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: 12))
@@ -266,7 +277,7 @@ struct GridItemView: View {
         .onHover { hovering in
             isHovered = hovering
             hoverTask?.cancel()
-            if item.isVideo {
+            if itemIsVideo {
                 if hovering {
                     hoverTask = Task {
                         try? await Task.sleep(for: .milliseconds(200))
@@ -313,7 +324,7 @@ struct GridItemView: View {
                     Image(nsImage: thumbnail)
                         .resizable()
                         .aspectRatio(contentMode: .fill)
-                        .frame(width: 96, height: 96 / item.aspectRatio)
+                        .frame(width: 96, height: 96 / itemAspectRatio)
                         .clipShape(RoundedRectangle(cornerRadius: 8))
                 } else {
                     RoundedRectangle(cornerRadius: 8)
@@ -338,7 +349,7 @@ struct GridItemView: View {
         } action: { newValue in
             globalFrame = newValue
             // Keep the floating video layer in sync with scroll/resize
-            if item.isVideo && videoPreview.activeItemId == item.id {
+            if itemIsVideo && videoPreview.activeItemId == item.id {
                 videoPreview.updateGridFrame(newValue)
             }
             // Keep detail source frame in sync when this item is the active detail
@@ -357,37 +368,51 @@ struct GridItemView: View {
         }
         .contextMenu {
             // Move to space submenu
-            Menu(isBulk ? "Move \(selectedCount) items to" : "Move to") {
+            Menu {
                 ForEach(spaces) { space in
                     Button {
                         onAssignToSpace(space.id)
                     } label: {
-                        if item.space?.id == space.id {
+                        if itemSpaceId == space.id {
                             Label(space.name, systemImage: "checkmark")
                         } else {
                             Text(space.name)
                         }
                     }
                 }
+            } label: {
+                Label(isBulk ? "Move \(selectedCount) Items to" : "Move to", systemImage: "folder")
             }
 
             // Remove from space
             if activeSpaceId != nil {
-                Button(isBulk ? "Remove \(selectedCount) from Space" : "Remove from Space") {
+                Button {
                     onAssignToSpace(nil)
+                } label: {
+                    Label(isBulk ? "Remove \(selectedCount) from Space" : "Remove from Space", systemImage: "folder.badge.minus")
                 }
             }
 
             Divider()
 
-            Button(isBulk ? "Retry Analysis for \(selectedCount) Items" : "Retry Analysis") {
+            Button {
+                onShare(globalFrame)
+            } label: {
+                Label("Share...", systemImage: "square.and.arrow.up")
+            }
+
+            Button {
                 onRetryAnalysis()
+            } label: {
+                Label(isBulk ? "Redo Analysis for \(selectedCount) Items" : "Redo Analysis", systemImage: "arrow.clockwise")
             }
 
             Divider()
 
-            Button(isBulk ? "Delete \(selectedCount) Items" : "Delete", role: .destructive) {
+            Button(role: .destructive) {
                 onDelete()
+            } label: {
+                Label(isBulk ? "Delete \(selectedCount) Items" : "Delete", systemImage: "trash")
             }
         }
         .task {

--- a/SnapGrid/SnapGrid/Views/Grid/MasonryGridView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/MasonryGridView.swift
@@ -13,6 +13,7 @@ struct MasonryGridView: View {
     let onDelete: (Set<String>) -> Void
     let onAssignToSpace: (Set<String>, String?) -> Void
     let onRetryAnalysis: (Set<String>) -> Void
+    let onShare: (Set<String>, CGRect) -> Void
     let onSetSelection: (Set<String>) -> Void
     var coordinateSpaceName: String = "gridContent"
 
@@ -109,7 +110,8 @@ struct MasonryGridView: View {
                                         onShiftSelect: { onShiftSelect(item.id) },
                                         onDelete: { onDelete(effectiveIds) },
                                         onAssignToSpace: { spaceId in onAssignToSpace(effectiveIds, spaceId) },
-                                        onRetryAnalysis: { onRetryAnalysis(effectiveIds) }
+                                        onRetryAnalysis: { onRetryAnalysis(effectiveIds) },
+                                        onShare: { frame in onShare(effectiveIds, frame) }
                                     )
                                     .background(
                                         GeometryReader { geo in

--- a/SnapGrid/SnapGrid/Views/Spaces/SpaceTabBar.swift
+++ b/SnapGrid/SnapGrid/Views/Spaces/SpaceTabBar.swift
@@ -72,7 +72,9 @@ struct SpaceTabBar: View {
             .onPreferenceChange(TabFrameKey.self) { tabFrames = $0 }
         }
         .overlay(alignment: .bottom) {
-            Divider().opacity(0.5)
+            Rectangle()
+                .fill(Color.white.opacity(0.1))
+                .frame(height: 1)
         }
         .alert("Delete Space?", isPresented: Binding(
             get: { spaceToDelete != nil },

--- a/ios/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
+++ b/ios/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		A100000036 /* KeySyncCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000036 /* KeySyncCrypto.swift */; };
 		A100000037 /* KeySyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000037 /* KeySyncService.swift */; };
 		A100000038 /* AIAnalysisService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000038 /* AIAnalysisService.swift */; };
+		A100000040 /* ActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000040 /* ActivityView.swift */; };
 		F2AD76603369201957F4E1FD /* SearchIndexService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFAB07291230EAED58390B4 /* SearchIndexService.swift */; };
 /* End PBXBuildFile section */
 
@@ -99,6 +100,7 @@
 		B100000036 /* KeySyncCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeySyncCrypto.swift; sourceTree = "<group>"; };
 		B100000037 /* KeySyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeySyncService.swift; sourceTree = "<group>"; };
 		B100000038 /* AIAnalysisService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIAnalysisService.swift; sourceTree = "<group>"; };
+		B100000040 /* ActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityView.swift; sourceTree = "<group>"; };
 		C100000001 /* SnapGrid.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SnapGrid.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FC24EBA6AD6068C4ADA26030 /* SyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -266,6 +268,7 @@
 		E100000014 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				B100000040 /* ActivityView.swift */,
 				B100000030 /* AnimationTokens.swift */,
 				B100000018 /* EmptyStateView.swift */,
 			);
@@ -422,6 +425,7 @@
 				A100000036 /* KeySyncCrypto.swift in Sources */,
 				A100000037 /* KeySyncService.swift in Sources */,
 				A100000038 /* AIAnalysisService.swift in Sources */,
+				A100000040 /* ActivityView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
@@ -1370,16 +1370,3 @@ private struct MetadataHeightKey: PreferenceKey {
     }
 }
 
-// MARK: - UIActivityViewController Wrapper
-
-/// Wraps UIActivityViewController for SwiftUI. Uses a temp file URL
-/// (outside iCloud) so iOS shows "Send a Copy" instead of "Collaborate".
-private struct ActivityView: UIViewControllerRepresentable {
-    let activityItems: [Any]
-
-    func makeUIViewController(context: Context) -> UIActivityViewController {
-        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
-    }
-
-    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
-}

--- a/ios/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -19,6 +19,8 @@ struct GridItemView: View {
     var isSelected: Bool = false
     var onSelect: ((MediaItem, CGRect, UIImage?) -> Void)?
     var onRetryAnalysis: (() -> Void)?
+    var onShare: (() -> Void)?
+    var onDelete: (() -> Void)?
     @State private var thumbnail: UIImage?
     @State private var loadFailed = false
 
@@ -150,6 +152,27 @@ struct GridItemView: View {
                     )
             }
         )
+        .contextMenu {
+            Button {
+                onShare?()
+            } label: {
+                Label("Share...", systemImage: "square.and.arrow.up")
+            }
+
+            Button {
+                onRetryAnalysis?()
+            } label: {
+                Label("Redo Analysis", systemImage: "arrow.clockwise")
+            }
+
+            Divider()
+
+            Button(role: .destructive) {
+                onDelete?()
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
         .task {
             await loadThumbnail()
         }

--- a/ios/SnapGrid/SnapGrid/Views/Grid/MasonryGrid.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Grid/MasonryGrid.swift
@@ -6,6 +6,8 @@ struct MasonryGrid: View {
     var selectedItemId: String?
     var onItemSelected: ((MediaItem, CGRect, UIImage?) -> Void)?
     var onRetryAnalysis: ((MediaItem) -> Void)?
+    var onShareItem: ((MediaItem) -> Void)?
+    var onDeleteItem: ((MediaItem) -> Void)?
 
     private let columns = 2
     private let spacing: CGFloat = 8
@@ -39,6 +41,12 @@ struct MasonryGrid: View {
                             isSelected: selectedItemId == item.id,
                             onSelect: onItemSelected,
                             onRetryAnalysis: onRetryAnalysis.map { callback in
+                                { callback(item) }
+                            },
+                            onShare: onShareItem.map { callback in
+                                { callback(item) }
+                            },
+                            onDelete: onDeleteItem.map { callback in
                                 { callback(item) }
                             }
                         )

--- a/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
@@ -77,6 +77,8 @@ struct MainView: View {
     @State private var showPhotosPicker = false
     @State private var showFilesPicker = false
     @State private var isImporting = false
+    @State private var itemToDelete: MediaItem?
+    @State private var shareItem: URL?
 
     // MARK: - Index ↔ activeSpaceId bridging
 
@@ -149,7 +151,9 @@ struct MainView: View {
                                     availableWidth: gridWidth,
                                     selectedItemId: showOverlay ? selectedItemId : nil,
                                     onItemSelected: handleItemSelected,
-                                    onRetryAnalysis: handleRetryAnalysis
+                                    onRetryAnalysis: handleRetryAnalysis,
+                                    onShareItem: handleShareItem,
+                                    onDeleteItem: { item in itemToDelete = item }
                                 )
                                 .padding(.horizontal, 12)
                                 .padding(.bottom, 70)
@@ -181,7 +185,10 @@ struct MainView: View {
                                                 items: allPageItems,
                                                 availableWidth: gridWidth,
                                                 selectedItemId: showOverlay ? selectedItemId : nil,
-                                                onItemSelected: handleItemSelected
+                                                onItemSelected: handleItemSelected,
+                                                onRetryAnalysis: handleRetryAnalysis,
+                                                onShareItem: handleShareItem,
+                                                onDeleteItem: { item in itemToDelete = item }
                                             )
                                             .padding(.horizontal, 12)
                                             .padding(.top, 12)
@@ -206,7 +213,10 @@ struct MainView: View {
                                                     items: spaceItems,
                                                     availableWidth: gridWidth,
                                                     selectedItemId: showOverlay ? selectedItemId : nil,
-                                                    onItemSelected: handleItemSelected
+                                                    onItemSelected: handleItemSelected,
+                                                    onRetryAnalysis: handleRetryAnalysis,
+                                                    onShareItem: handleShareItem,
+                                                    onDeleteItem: { item in itemToDelete = item }
                                                 )
                                                 .padding(.horizontal, 12)
                                                 .padding(.top, 12)
@@ -358,6 +368,30 @@ struct MainView: View {
                 handlePickedImages(images)
             }
         }
+        .sheet(isPresented: Binding(
+            get: { shareItem != nil },
+            set: { if !$0 { shareItem = nil } }
+        )) {
+            if let url = shareItem {
+                ActivityView(activityItems: [url])
+                    .presentationDetents([.medium, .large])
+            }
+        }
+        .confirmationDialog(
+            "Delete this item?",
+            isPresented: Binding(
+                get: { itemToDelete != nil },
+                set: { if !$0 { itemToDelete = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                if let item = itemToDelete {
+                    handleItemDeleted(item)
+                    itemToDelete = nil
+                }
+            }
+        }
     }
 
     // MARK: - Add Images Menu
@@ -402,6 +436,21 @@ struct MainView: View {
         }
         modelContext.delete(item)
         try? modelContext.save()
+    }
+
+    // MARK: - Item Sharing
+
+    private func handleShareItem(_ item: MediaItem) {
+        guard let url = item.mediaURL else { return }
+        let tempDir = FileManager.default.temporaryDirectory
+        let tempURL = tempDir.appendingPathComponent(url.lastPathComponent)
+        try? FileManager.default.removeItem(at: tempURL)
+        do {
+            try FileManager.default.copyItem(at: url, to: tempURL)
+            shareItem = tempURL
+        } catch {
+            shareItem = url
+        }
     }
 
     // MARK: - Image Import
@@ -466,7 +515,9 @@ struct MainView: View {
 
     private func handleRetryAnalysis(_ item: MediaItem) {
         item.analysisError = nil
-        analyzeUnanalyzedItems()
+        item.analysisResult = nil
+        try? modelContext.save()
+        analyzeSingleItem(item)
     }
 
     // MARK: - AI Analysis
@@ -559,6 +610,64 @@ struct MainView: View {
                     item.analysisError = error.localizedDescription
                     print("[Analysis] Failed for \(item.id): \(error.localizedDescription)")
                 }
+            }
+        }
+    }
+
+    private func analyzeSingleItem(_ item: MediaItem) {
+        guard keySyncService.isUnlocked else { return }
+        guard let providerStr = keySyncService.activeProvider,
+              let provider = AIProvider(rawValue: providerStr) else { return }
+        guard let apiKey = keySyncService.activeAPIKey() else { return }
+        guard let rootURL = fileSystem.rootURL else { return }
+
+        let model = keySyncService.activeModel ?? provider.defaultModel
+        let resolvedModel = (model == "auto") ? provider.defaultModel : model
+
+        Task {
+            item.isAnalyzing = true
+            do {
+                let image: UIImage
+                if item.isVideo {
+                    image = try extractPosterFrame(for: item, rootURL: rootURL)
+                } else {
+                    image = try loadImage(for: item, rootURL: rootURL)
+                }
+
+                var guidance: String?
+                var spaceContext: String?
+                if let space = item.space {
+                    spaceContext = "This image belongs to a collection called \"\(space.name)\". Use this as context to inform your analysis."
+                    if space.useCustomPrompt, let custom = space.customPrompt, !custom.isEmpty {
+                        guidance = custom
+                    }
+                }
+                if guidance == nil, UserDefaults.standard.bool(forKey: "useAllSpacePrompt") {
+                    let allGuidance = UserDefaults.standard.string(forKey: "allSpacePrompt") ?? ""
+                    if !allGuidance.isEmpty {
+                        guidance = allGuidance
+                    }
+                }
+
+                let result = try await AIAnalysisService.shared.analyze(
+                    image: image,
+                    provider: provider,
+                    model: resolvedModel,
+                    apiKey: apiKey,
+                    guidance: guidance,
+                    spaceContext: spaceContext
+                )
+                item.analysisResult = result
+                item.isAnalyzing = false
+                item.analysisError = nil
+                writeSidecar(for: item, rootURL: rootURL)
+                searchService.buildIndex(items: allItems)
+                try? modelContext.save()
+                print("[Analysis] Redo completed: \(item.id)")
+            } catch {
+                item.isAnalyzing = false
+                item.analysisError = error.localizedDescription
+                print("[Analysis] Redo failed for \(item.id): \(error.localizedDescription)")
             }
         }
     }

--- a/ios/SnapGrid/SnapGrid/Views/Shared/ActivityView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Shared/ActivityView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+/// Wraps UIActivityViewController for SwiftUI. Uses a temp file URL
+/// (outside iCloud) so iOS shows "Send a Copy" instead of "Collaborate".
+struct ActivityView: UIViewControllerRepresentable {
+    let activityItems: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}


### PR DESCRIPTION
### Why?

Both iOS and Mac apps lacked a context menu on grid items, so common actions like sharing, re-analyzing, and deleting required navigating into the full-screen view or using the action bar. This adds quick access to these actions directly from the grid via long-press (iOS) and right-click (Mac).

### How?

Adds context menus to grid items on both platforms and to the Mac full-screen detail overlay, with Share, Redo Analysis, Move to Space, and Delete actions. Fixes the "Redo Analysis" flow to actually clear existing results and re-analyze (previously it silently no-oped). Also fixes a SwiftData detached-fault crash on Mac by eagerly resolving faultable model properties in `GridItemView.init`.

<sub>Generated with Claude Code</sub>