### PR TITLE
Mac: Card-crush delete animation with smooth reflow

### DIFF
--- a/SnapGrid/SnapGrid/App/AppState.swift
+++ b/SnapGrid/SnapGrid/App/AppState.swift
@@ -29,6 +29,14 @@ final class AppState {
     var isSettingsOpen: Bool = false
     var isDraggingFromApp: Bool = false
 
+    /// Per-item delete animation stage: 1 = height crush, 2 = width crush + fade.
+    /// Items not in this dictionary are at stage 0 (normal).
+    var deletingItemStages: [String: Int] = [:]
+
+    func deleteStage(for id: String) -> Int {
+        deletingItemStages[id] ?? 0
+    }
+
     // Undo stack — stores enough info to fully restore deleted items
     private(set) var deletedBatches: [[DeletedItemInfo]] = []
 

--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -535,6 +535,9 @@ struct ContentView: View {
 
     private func deleteItems(_ ids: Set<String>) {
         let items = allItems.filter { ids.contains($0.id) }
+        guard !items.isEmpty else { return }
+
+        // Snapshot for undo
         let batch = items.map { item in
             let ar = item.analysisResult
             return DeletedItemInfo(
@@ -554,6 +557,42 @@ struct ContentView: View {
             )
         }
         appState.pushDeleteBatch(batch)
+        appState.clearSelection()
+
+        let reduceMotion = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+
+        if reduceMotion {
+            withAnimation(CardCrush.reducedMotionFade) {
+                for id in ids { appState.deletingItemStages[id] = 2 }
+            }
+            Task { @MainActor in
+                try? await Task.sleep(for: CardCrush.reducedMotionDelay)
+                commitDeletion(ids)
+            }
+        } else {
+            // Stage 1 — height crushes inward
+            withAnimation(CardCrush.heightCrush) {
+                for id in ids { appState.deletingItemStages[id] = 1 }
+            }
+            Task { @MainActor in
+                // Stage 2 — width collapses + fade out
+                try? await Task.sleep(for: CardCrush.widthDelay)
+                withAnimation(CardCrush.widthCrush) {
+                    for id in ids { appState.deletingItemStages[id] = 2 }
+                }
+
+                // Crush complete — commit deletion
+                try? await Task.sleep(for: CardCrush.completeDelay)
+                commitDeletion(ids)
+            }
+        }
+    }
+
+    private func commitDeletion(_ ids: Set<String>) {
+        // Guard: if undo already removed these from the stage dictionary, skip
+        guard ids.contains(where: { appState.deletingItemStages[$0] != nil }) else { return }
+
+        let items = allItems.filter { ids.contains($0.id) }
 
         syncWatcher.beginLocalChange()
         var trashedCount = 0
@@ -566,9 +605,19 @@ struct ContentView: View {
                 print("[Delete] Failed to trash \(item.id): \(error)")
             }
         }
-        try? modelContext.save()
+        withAnimation(SnapSpring.standard) {
+            try? modelContext.save()
+        }
         syncWatcher.endLocalChange()
-        appState.clearSelection()
+
+        // Clean up animation state after SwiftUI finishes removing views.
+        // If cleaned up immediately, deleteStage snaps to 0 and the crushed
+        // item briefly flashes at full size during the removal transition.
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(500))
+            for id in ids { appState.deletingItemStages.removeValue(forKey: id) }
+        }
+
         if trashedCount > 0 {
             appState.showToast("Moved \(trashedCount) item\(trashedCount == 1 ? "" : "s") to trash")
         }

--- a/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -72,6 +72,10 @@ struct GridItemView: View {
         return item.id == hiddenItemId ? 0 : 1
     }
 
+    private var deleteStage: Int {
+        appState.deleteStage(for: item.id)
+    }
+
     /// Whether this item is part of a multi-selection context menu
     private var isBulk: Bool {
         isSelected && selectedCount > 1
@@ -249,12 +253,19 @@ struct GridItemView: View {
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: 12))
+        // Delete animation — wallet card crush (mask approach)
+        .mask {
+            let maskH = deleteStage >= 1 ? height * CardCrush.crushedScaleY : height
+            let maskW = deleteStage >= 2 ? width * CardCrush.crushedScaleX : width
+            RoundedRectangle(cornerRadius: 12)
+                .frame(width: maskW, height: maskH)
+        }
         .overlay(
             RoundedRectangle(cornerRadius: 12)
-                .strokeBorder(isSelected ? Color.accentColor : Color.clear, lineWidth: 2)
+                .strokeBorder(isSelected && deleteStage == 0 ? Color.accentColor : Color.clear, lineWidth: 2)
         )
         .shadow(
-            color: .black.opacity(effectiveHover ? 0.1 : 0.05),
+            color: .black.opacity(deleteStage > 0 ? 0 : (effectiveHover ? 0.1 : 0.05)),
             radius: effectiveHover ? 6 : 2,
             x: 0,
             y: effectiveHover ? 4 : 1
@@ -263,7 +274,12 @@ struct GridItemView: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityDescription)
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+        .accessibilityHidden(deleteStage > 0)
         .onHover { hovering in
+            guard deleteStage == 0 else {
+                isHovered = false
+                return
+            }
             isHovered = hovering
             hoverTask?.cancel()
             if item.isVideo {
@@ -332,7 +348,7 @@ struct GridItemView: View {
             }
             .opacity(0.85)
         }
-        .opacity(gridItemOpacity)
+        .opacity(deleteStage >= 2 ? 0 : gridItemOpacity)
         .onGeometryChange(for: CGRect.self) { proxy in
             proxy.frame(in: .global)
         } action: { newValue in

--- a/SnapGrid/SnapGrid/Views/Shared/AnimationTokens.swift
+++ b/SnapGrid/SnapGrid/Views/Shared/AnimationTokens.swift
@@ -34,3 +34,16 @@ enum SnapSpring {
         reduced ? .easeInOut(duration: 0.15) : metadata
     }
 }
+
+/// Card-crush delete animation presets (matches iOS wallet-style crush).
+enum CardCrush {
+    static let heightCrush = Animation.spring(response: 0.2, dampingFraction: 0.85)
+    static let widthCrush  = Animation.spring(response: 0.15, dampingFraction: 0.92)
+    static let widthDelay: Duration = .milliseconds(160)
+    static let completeDelay: Duration = .milliseconds(300)
+    static let crushedScaleY: CGFloat = 0.05
+    static let crushedScaleX: CGFloat = 0.0
+
+    static let reducedMotionFade = Animation.easeInOut(duration: 0.15)
+    static let reducedMotionDelay: Duration = .milliseconds(200)
+}


### PR DESCRIPTION
### Why?

When deleting grid items on macOS, they disappeared abruptly with no visual feedback — and a previous attempt at adding a card crush animation caused a flash where deleted items briefly appeared at full size before vanishing.

### How?

Adds a two-stage wallet-style card crush animation (matching the iOS implementation) driven by `AppState.deletingItemStages`. The key fix is deferring animation state cleanup by 500ms so the crushed/invisible state persists through SwiftUI's removal transition, preventing the full-size flash.

<sub>Generated with Claude Code</sub>