### PR TITLE
Mac: Fix pattern pill hover jank on video thumbnails

### DIFF
--- a/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -206,7 +206,7 @@ struct GridItemView: View {
                             HStack {
                                 FlowLayout(spacing: 5) {
                                     ForEach(Array(patterns.prefix(5).enumerated()), id: \.element.name) { index, pattern in
-                                        PatternPill(name: pattern.name)
+                                        PatternPill(name: pattern.name, useGlass: false)
                                             .opacity(effectiveHover ? 1 : 0)
                                             .offset(y: effectiveHover ? 0 : (reduceMotion ? 0 : 8))
                                             .animation(

--- a/SnapGrid/SnapGrid/Views/Shared/FloatingVideoLayer.swift
+++ b/SnapGrid/SnapGrid/Views/Shared/FloatingVideoLayer.swift
@@ -101,7 +101,7 @@ struct FloatingVideoLayer: View {
                             HStack {
                                 FlowLayout(spacing: 5) {
                                     ForEach(videoPreview.gridPatternNames, id: \.self) { name in
-                                        PatternPill(name: name)
+                                        PatternPill(name: name, useGlass: false)
                                     }
                                 }
                                 Spacer()


### PR DESCRIPTION
### Why?

Hovering grid items caused pattern pills to visibly shift color. On videos, `.glassEffect()` can't reliably sample through the NSView-backed AVPlayerLayer, producing color flickering. On all items, the glass also wobbles during the slide-in offset animation as it samples different background regions each frame.

### How?

Switch pattern pills to `.ultraThinMaterial` (via the existing `useGlass: false` parameter) in both GridItemView and FloatingVideoLayer. The material still gives a frosted-glass appearance but composites stably during motion and above AppKit layers.

<details>
<summary>Implementation Plan</summary>

# Fix Video Pill Hover Jank

## Context

When hovering a video grid item, the pattern pills (glass-backed tag labels) change color in a janky way. The root cause is that:

1. **GridItemView** shows pills with `.glassEffect()` immediately on hover (over static thumbnail)
2. After 200ms, **FloatingVideoLayer** appears with an NSView-backed AVPlayerLayer + its own set of pills
3. `.glassEffect()` tries to sample the video content through the NSView layer, causing unstable compositing and color flickering
4. The `useGlass` parameter on `PatternPill` was designed for exactly this case but is never set to `false` in FloatingVideoLayer

## Changes

### 1. FloatingVideoLayer: disable glass on pills above NSView
**File:** `SnapGrid/SnapGrid/Views/Shared/FloatingVideoLayer.swift` ~line 104

```swift
// Before
PatternPill(name: name)

// After
PatternPill(name: name, useGlass: false)
```

This uses `.ultraThinMaterial` (still a frosted-glass look, but composites correctly above NSView-backed content) instead of `.glassEffect()` which can't reliably sample through the AppKit layer.

### 2. GridItemView: use material instead of glass for hover pills
**File:** `SnapGrid/SnapGrid/Views/Grid/GridItemView.swift` ~line 209

```swift
// Before
PatternPill(name: pattern.name)

// After
PatternPill(name: pattern.name, useGlass: false)
```

The offset animation (y: 8→0) causes `.glassEffect()` to sample different background regions each frame, producing a color wobble during slide-in. `.ultraThinMaterial` uses a fixed blur kernel that stays stable during motion.

</details>

<sub>Generated with Claude Code</sub>