### PR TITLE
Mac: Fix double analysis on import

### DIFF
--- a/SnapGrid/SnapGrid/Services/ImportService.swift
+++ b/SnapGrid/SnapGrid/Services/ImportService.swift
@@ -138,6 +138,12 @@ final class ImportService {
     }
 
     func analyzeItem(_ item: MediaItem, context: ModelContext) async {
+        // Prevent duplicate analysis (e.g. SyncWatcher detecting our own sidecar write)
+        guard !item.isAnalyzing else {
+            print("[Analysis] Skipping \(item.id) — already analyzing")
+            return
+        }
+
         // Check for API key
         let provider = AIProvider(rawValue: UserDefaults.standard.string(forKey: "aiProvider") ?? "openai") ?? .openai
         guard KeychainService.exists(service: provider.keychainService) else {

--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -439,11 +439,13 @@ struct ContentView: View {
                 }
             }
 
-            if !urls.isEmpty {
+            if !urls.isEmpty || !images.isEmpty {
+                syncWatcher.beginLocalChange()
                 await importService.importFiles(urls, into: modelContext, spaceId: appState.activeSpaceId)
-            }
-            for image in images {
-                await importService.importImage(image, into: modelContext, spaceId: appState.activeSpaceId)
+                for image in images {
+                    await importService.importImage(image, into: modelContext, spaceId: appState.activeSpaceId)
+                }
+                syncWatcher.endLocalChange()
             }
         }
     }
@@ -471,8 +473,10 @@ struct ContentView: View {
                                                "mp4","webm","mov","avi","m4v"]
             let validURLs = urls.filter { supportedExts.contains($0.pathExtension.lowercased()) }
             if !validURLs.isEmpty {
+                syncWatcher.beginLocalChange()
                 Task {
                     await importService.importFiles(validURLs, into: modelContext, spaceId: appState.activeSpaceId)
+                    syncWatcher.endLocalChange()
                     appState.showToast("Pasted \(validURLs.count) item\(validURLs.count == 1 ? "" : "s")")
                 }
                 return
@@ -481,10 +485,12 @@ struct ContentView: View {
 
         // Fall back to image data (e.g. copied from browser, Preview, screenshot)
         if let images = pasteboard.readObjects(forClasses: [NSImage.self]) as? [NSImage], !images.isEmpty {
+            syncWatcher.beginLocalChange()
             Task {
                 for image in images {
                     await importService.importImage(image, into: modelContext, spaceId: appState.activeSpaceId)
                 }
+                syncWatcher.endLocalChange()
                 appState.showToast("Pasted \(images.count) image\(images.count == 1 ? "" : "s")")
             }
             return
@@ -500,6 +506,7 @@ struct ContentView: View {
                 return url
             }
             if !urls.isEmpty {
+                syncWatcher.beginLocalChange()
                 Task {
                     let hasTwitterURL = urls.contains(where: { TwitterVideoService.isTwitterURL($0) })
                     appState.showToast(hasTwitterURL ? "Downloading from X..." : "Downloading\(urls.count == 1 ? "" : " \(urls.count) items")...")
@@ -519,6 +526,7 @@ struct ContentView: View {
                             }
                         }
                     }
+                    syncWatcher.endLocalChange()
                     if successCount > 0 {
                         appState.showToast("Imported \(successCount) item\(successCount == 1 ? "" : "s")")
                     } else if !hasTwitterURL {
@@ -542,8 +550,10 @@ struct ContentView: View {
 
         panel.begin { response in
             if response == .OK {
+                syncWatcher.beginLocalChange()
                 Task {
                     await importService.importFiles(panel.urls, into: modelContext, spaceId: appState.activeSpaceId)
+                    syncWatcher.endLocalChange()
                 }
             }
         }


### PR DESCRIPTION
### Why?

Importing media (paste, drag-drop, URL import, file dialog) triggers AI analysis twice. The user sees an initial set of pattern tags, then they change to something different a few seconds later — because two concurrent API calls race and the second overwrites the first.

### How?

The SyncWatcher's DispatchSource detects locally-written sidecar files as if they arrived from iCloud, triggering a second `analyzeItem()` call. Fixed by wrapping all import paths with `beginLocalChange()`/`endLocalChange()` (matching the existing pattern used by delete, undo, and space operations) and adding an `isAnalyzing` guard in `analyzeItem()` as a safety net.

<details>
<summary>Implementation Plan</summary>

# Fix: Double analysis on import (SyncWatcher race condition)

## Context

When pasting an X/Twitter URL (or any import), images get analyzed twice. The user sees initial pattern tags, then they change to different ones a few seconds later. This is caused by a race condition between the import pipeline and the SyncWatcher filesystem monitor.

**This affects ALL import paths** (paste image, paste URL, drag-drop, file import panel), not just X URLs. X URLs just make it more visible because the download adds delay.

## Root Cause

The import flow in `ImportService.importSingleFile()` (line 130-137):
1. Inserts `MediaItem` into SwiftData
2. Writes sidecar JSON to `metadata/` directory (**no analysis data yet**)
3. Queues `analyzeItem()` in a separate `Task`

The SyncWatcher has a `DispatchSource` monitoring the `metadata/` directory. When the sidecar is written:
1. DispatchSource fires → `scheduleSync()` (1.5s debounce)
2. `suppressingLocalChanges` is `false` — import code never calls `beginLocalChange()`
3. After 1.5s, `syncMetadata()` finds the new sidecar with empty `imageContext` → adds to `unanalyzedIds`
4. `onNewUnanalyzedItems` callback calls `analyzeItem()` again — no `isAnalyzing` guard
5. **Two concurrent AI API calls** run for the same image; second overwrites first with different results

## Plan

### 1. Add `isAnalyzing` guard in `analyzeItem()` (safety net)

**File**: `SnapGrid/SnapGrid/Services/ImportService.swift:140`

Add early return at the top of `analyzeItem`:
```swift
func analyzeItem(_ item: MediaItem, context: ModelContext) async {
    guard !item.isAnalyzing else {
        print("[Analysis] Skipping \(item.id) — already analyzing")
        return
    }
    // ... existing code
}
```

This is the primary fix. By the time the 1.5s debounce fires, the first `analyzeItem` Task has already set `isAnalyzing = true`, so the second call bails out.

### 2. Suppress SyncWatcher during imports (root cause fix)

**File**: `SnapGrid/SnapGrid/Views/ContentView/ContentView.swift`

Wrap all import operations with `syncWatcher.beginLocalChange()` / `endLocalChange()`:

- **`handlePaste()`** (~line 463): Wrap each of the three branches (file URLs, image data, text URLs) — call `beginLocalChange()` before the `Task`, call `endLocalChange()` inside the Task after the import completes
- **Drop handler** (~line 430): Same pattern around `importFiles`/`importImage` calls
- **`openImportPanel()`** (~line 532): Same pattern around `importFiles` call

Pattern for each:
```swift
syncWatcher.beginLocalChange()
Task {
    await importService.importFiles(urls, into: modelContext, ...)
    syncWatcher.endLocalChange()
}
```

`endLocalChange()` updates `knownSidecarIds` from disk (so the watcher won't see the sidecar as "new") and suppresses events for 500ms.

</details>

<sub>Generated with Claude Code</sub>