### PR TITLE
Mac: Prevent grid self-drop from re-importing items

### DIFF
--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -109,6 +109,7 @@ struct ContentView: View {
                     }
                 }
                 .onDrop(of: [.fileURL, .image], isTargeted: $isDragTargeted) { providers in
+                    if appState.isDraggingFromApp { return false }
                     handleDrop(providers)
                     return true
                 }


### PR DESCRIPTION
### Why?

Dragging an image from the Mac app's grid and dropping it back onto the same grid re-imports the item as a duplicate. The `.onDrop` handler on the content area didn't distinguish internal drags from external ones, so the image fallback path in `handleDrop` would load the file as a new `NSImage` and import it again.

### How?

Early-return `false` from the `.onDrop` closure when `appState.isDraggingFromApp` is true, preventing `handleDrop` from ever running for internal drags. Space tab drops (which use a separate `.dropDestination(for: String.self)` handler) and outbound export drags are unaffected.

<sub>Generated with Claude Code</sub>