### PR TITLE
Save X source URL in metadata and show link in detail view

### DIFF
--- a/SnapGrid/SnapGrid/Models/MediaItem.swift
+++ b/SnapGrid/SnapGrid/Models/MediaItem.swift
@@ -26,6 +26,7 @@ class MediaItem {
 
     // Import tracking
     var sourceId: String?
+    var sourceURL: String?
 
     var aspectRatio: CGFloat {
         guard height > 0 else { return 1.0 }

--- a/SnapGrid/SnapGrid/Services/ImportService.swift
+++ b/SnapGrid/SnapGrid/Services/ImportService.swift
@@ -66,7 +66,7 @@ final class ImportService {
         }
     }
 
-    private func importSingleFile(_ url: URL, into context: ModelContext, spaceId: String?) async throws {
+    private func importSingleFile(_ url: URL, into context: ModelContext, spaceId: String?, sourceURL: String? = nil) async throws {
         let ext = url.pathExtension.lowercased()
         let isVideo = videoTypes.contains(ext)
         let isImage = imageTypes.contains(ext)
@@ -128,6 +128,10 @@ final class ImportService {
         }
 
         context.insert(item)
+
+        // Set sourceURL after insert so SwiftData tracks the property change
+        item.sourceURL = sourceURL
+
         try context.save()
         sidecarService.writeSidecar(for: item)
 
@@ -226,13 +230,13 @@ final class ImportService {
         let result = try await TwitterVideoService.extractMediaURL(from: url)
         switch result {
         case .video(let mediaURL), .image(let mediaURL):
-            try await importFromURL(mediaURL, into: context, spaceId: spaceId)
+            try await importFromURL(mediaURL, into: context, spaceId: spaceId, sourceURL: url.absoluteString)
         }
     }
 
     /// Import media from a remote HTTP/HTTPS URL — downloads the file, determines its type,
     /// and runs it through the standard import pipeline.
-    func importFromURL(_ url: URL, into context: ModelContext, spaceId: String? = nil) async throws {
+    func importFromURL(_ url: URL, into context: ModelContext, spaceId: String? = nil, sourceURL: String? = nil) async throws {
         let (data, response) = try await URLSession.shared.data(from: url)
 
         guard let httpResponse = response as? HTTPURLResponse,
@@ -255,7 +259,7 @@ final class ImportService {
         try data.write(to: tempFile)
         defer { try? FileManager.default.removeItem(at: tempFile) }
 
-        try await importSingleFile(tempFile, into: context, spaceId: spaceId)
+        try await importSingleFile(tempFile, into: context, spaceId: spaceId, sourceURL: sourceURL)
     }
 
     /// Map a Content-Type MIME string to a file extension. Falls back to URL path extension.

--- a/SnapGrid/SnapGrid/Services/MetadataSidecarService.swift
+++ b/SnapGrid/SnapGrid/Services/MetadataSidecarService.swift
@@ -13,6 +13,7 @@ struct SidecarMetadata: Codable, Sendable {
     let imageContext: String?
     let imageSummary: String?
     let patterns: [SidecarPattern]?
+    let sourceURL: String?
 }
 
 struct SidecarPattern: Codable, Sendable {
@@ -71,7 +72,8 @@ final class MetadataSidecarService: Sendable {
             spaceId: item.space?.id,
             imageContext: item.analysisResult?.imageContext,
             imageSummary: item.analysisResult?.imageSummary,
-            patterns: item.analysisResult?.patterns.map { SidecarPattern(name: $0.name, confidence: $0.confidence) }
+            patterns: item.analysisResult?.patterns.map { SidecarPattern(name: $0.name, confidence: $0.confidence) },
+            sourceURL: item.sourceURL
         )
 
         let url = storage.metadataDir.appendingPathComponent("\(item.id).json")

--- a/SnapGrid/SnapGrid/Services/SyncWatcher.swift
+++ b/SnapGrid/SnapGrid/Services/SyncWatcher.swift
@@ -38,10 +38,11 @@ final class SyncWatcher {
         let needsThumbnail: Bool
     }
 
-    /// Lightweight update for existing items whose sidecar changed (e.g. space assignment).
+    /// Lightweight update for existing items whose sidecar changed (e.g. space assignment, source URL).
     private struct SidecarUpdateData: Sendable {
         let id: String
         let spaceId: String?
+        let sourceURL: String?
     }
 
     // MARK: - Public API
@@ -202,7 +203,7 @@ final class SyncWatcher {
             var updates: [SidecarUpdateData] = []
             for id in modifiedIds {
                 if let sidecar = MetadataSidecarService.shared.readSidecar(id: id) {
-                    updates.append(SidecarUpdateData(id: id, spaceId: sidecar.spaceId))
+                    updates.append(SidecarUpdateData(id: id, spaceId: sidecar.spaceId, sourceURL: sidecar.sourceURL))
                 }
             }
 
@@ -294,12 +295,15 @@ final class SyncWatcher {
         let dataId = data.id
         let descriptor = FetchDescriptor<MediaItem>(predicate: #Predicate { $0.id == dataId })
         if let existing = try? context.fetch(descriptor), let existingItem = existing.first {
-            // Item already imported — still reconcile space assignment
+            // Item already imported — still reconcile space assignment and sourceURL
             if let spaceId = data.sidecar.spaceId, existingItem.space?.id != spaceId {
                 let spaceDescriptor = FetchDescriptor<Space>(predicate: #Predicate { $0.id == spaceId })
                 existingItem.space = try? context.fetch(spaceDescriptor).first
             } else if data.sidecar.spaceId == nil && existingItem.space != nil {
                 existingItem.space = nil
+            }
+            if existingItem.sourceURL == nil, let sourceURL = data.sidecar.sourceURL {
+                existingItem.sourceURL = sourceURL
             }
             return
         }
@@ -318,6 +322,8 @@ final class SyncWatcher {
             createdAt: data.sidecar.createdAt,
             duration: data.sidecar.duration
         )
+
+        item.sourceURL = data.sidecar.sourceURL
 
         if let spaceId = data.sidecar.spaceId {
             let spaceDescriptor = FetchDescriptor<Space>(predicate: #Predicate { $0.id == spaceId })
@@ -364,7 +370,7 @@ final class SyncWatcher {
         print("[SyncWatcher] Removed \(id) (sidecar deleted on other device)")
     }
 
-    /// Update space assignment on an existing item. No file I/O.
+    /// Update space assignment and source URL on an existing item. No file I/O.
     private func applySpaceUpdate(_ update: SidecarUpdateData) {
         guard let context else { return }
 
@@ -381,6 +387,11 @@ final class SyncWatcher {
         } else if item.space != nil {
             item.space = nil
             print("[SyncWatcher] Removed space assignment for \(update.id)")
+        }
+
+        if item.sourceURL == nil, let sourceURL = update.sourceURL {
+            item.sourceURL = sourceURL
+            print("[SyncWatcher] Updated sourceURL for \(update.id)")
         }
     }
 

--- a/SnapGrid/SnapGrid/Views/Detail/HeroDetailOverlay.swift
+++ b/SnapGrid/SnapGrid/Views/Detail/HeroDetailOverlay.swift
@@ -885,6 +885,12 @@ private struct DetailMetadataSection: View {
             .foregroundStyle(.white.opacity(0.25))
             .stageReveal(stage: stage, threshold: 4)
             .padding(.top, 12)
+
+            if let urlString = item.sourceURL, let url = URL(string: urlString) {
+                SourceLinkButton(url: url)
+                    .stageReveal(stage: stage, threshold: 4)
+                    .padding(.top, 8)
+            }
         }
         .padding(.horizontal, 16)
     }
@@ -897,6 +903,45 @@ private struct DetailMetadataSection: View {
         guard seconds.isFinite else { return "0:00" }
         let total = Int(seconds)
         return "\(total / 60):\(String(format: "%02d", total % 60))"
+    }
+}
+
+// MARK: - Source Link Button
+
+private struct SourceLinkButton: View {
+    let url: URL
+    @State private var isHovered = false
+
+    private var label: String {
+        if let host = url.host?.lowercased(),
+           host.contains("x.com") || host.contains("twitter.com") {
+            return "View on X"
+        }
+        return "View source"
+    }
+
+    private var iconName: String {
+        if let host = url.host?.lowercased(),
+           host.contains("x.com") || host.contains("twitter.com") {
+            return "arrow.up.right.square"
+        }
+        return "link"
+    }
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Image(systemName: iconName)
+                .font(.caption2)
+            Text(label)
+                .font(.caption)
+        }
+        .foregroundStyle(.white.opacity(isHovered ? 0.6 : 0.3))
+        .onHover { isHovered = $0 }
+        .onTapGesture {
+            NSWorkspace.shared.open(url)
+        }
+        .accessibilityLabel("View original post on X")
+        .accessibilityAddTraits(.isLink)
     }
 }
 

--- a/ios/SnapGrid/ShareExtension/ShareViewController.swift
+++ b/ios/SnapGrid/ShareExtension/ShareViewController.swift
@@ -307,12 +307,12 @@ class ShareViewController: UIViewController {
 
                 switch result {
                 case .video:
-                    await MainActor.run { self.saveVideo(data) }
+                    await MainActor.run { self.saveVideo(data, sourceURL: tweetURL.absoluteString) }
                 case .image:
                     guard let image = UIImage(data: data) else {
                         throw TwitterVideoService.TwitterError.malformedResponse
                     }
-                    await MainActor.run { self.saveImage(image) }
+                    await MainActor.run { self.saveImage(image, sourceURL: tweetURL.absoluteString) }
                 }
             } catch {
                 log.error("Twitter media extraction failed: \(error.localizedDescription)")
@@ -367,7 +367,7 @@ class ShareViewController: UIViewController {
 
     // MARK: - Save to App Group Shared Container
 
-    private func saveImage(_ image: UIImage) {
+    private func saveImage(_ image: UIImage, sourceURL: String? = nil) {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
 
@@ -423,7 +423,8 @@ class ShareViewController: UIViewController {
                 spaceId: nil,
                 imageContext: nil,
                 imageSummary: nil,
-                patterns: nil
+                patterns: nil,
+                sourceURL: sourceURL
             )
 
             let encoder = JSONEncoder()
@@ -443,7 +444,7 @@ class ShareViewController: UIViewController {
 
     // MARK: - Save Video
 
-    private func saveVideo(_ videoData: Data) {
+    private func saveVideo(_ videoData: Data, sourceURL: String? = nil) {
         Task.detached(priority: .userInitiated) { [weak self] in
             guard let self else { return }
 
@@ -507,7 +508,8 @@ class ShareViewController: UIViewController {
                 spaceId: nil,
                 imageContext: nil,
                 imageSummary: nil,
-                patterns: nil
+                patterns: nil,
+                sourceURL: sourceURL
             )
 
             let encoder = JSONEncoder()
@@ -564,6 +566,7 @@ private struct ShareSidecarMetadata: Codable {
     let imageContext: String?
     let imageSummary: String?
     let patterns: [ShareSidecarPattern]?
+    let sourceURL: String?
 }
 
 private struct ShareSidecarPattern: Codable {

--- a/ios/SnapGrid/SnapGrid/Models/MediaItem.swift
+++ b/ios/SnapGrid/SnapGrid/Models/MediaItem.swift
@@ -26,6 +26,7 @@ class MediaItem {
 
     // Import tracking
     var sourceId: String?
+    var sourceURL: String?
 
     var aspectRatio: CGFloat {
         guard height > 0 else { return 1.0 }

--- a/ios/SnapGrid/SnapGrid/Services/ImageImportService.swift
+++ b/ios/SnapGrid/SnapGrid/Services/ImageImportService.swift
@@ -62,7 +62,8 @@ enum ImageImportService {
                     spaceId: spaceId,
                     imageContext: nil,
                     imageSummary: nil,
-                    patterns: nil
+                    patterns: nil,
+                    sourceURL: nil
                 )
 
                 guard let jsonData = try? encoder.encode(sidecar) else { return false }

--- a/ios/SnapGrid/SnapGrid/Services/SyncService.swift
+++ b/ios/SnapGrid/SnapGrid/Services/SyncService.swift
@@ -14,6 +14,7 @@ struct SidecarMetadata: Codable, Sendable {
     let imageContext: String?
     let imageSummary: String?
     let patterns: [SidecarPattern]?
+    let sourceURL: String?
 }
 
 struct SidecarPattern: Codable, Sendable {
@@ -154,6 +155,7 @@ final class SyncService {
                     createdAt: sidecar.createdAt,
                     duration: sidecar.duration
                 )
+                item.sourceURL = sidecar.sourceURL
 
                 // Assign space
                 if let spaceId = sidecar.spaceId {
@@ -258,6 +260,11 @@ final class SyncService {
             }
         } else if item.space != nil {
             item.space = nil
+        }
+
+        // Update source URL if it was added
+        if item.sourceURL == nil, let sourceURL = sidecar.sourceURL {
+            item.sourceURL = sourceURL
         }
 
         // Update analysis if it was added/changed

--- a/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
@@ -1281,6 +1281,12 @@ private struct DetailMetadataSection: View {
             .foregroundStyle(.white.opacity(0.3))
             .stageReveal(stage: stage, threshold: 4)
             .padding(.top, 14)
+
+            if let urlString = item.sourceURL, let url = URL(string: urlString) {
+                SourceLinkButton(url: url)
+                    .stageReveal(stage: stage, threshold: 4)
+                    .padding(.top, 8)
+            }
         }
         .padding(.horizontal, 32)
         .padding(.bottom, 32)
@@ -1358,6 +1364,46 @@ private struct DetailMetadataSection: View {
                     value: stage
                 )
         }
+    }
+}
+
+// MARK: - Source Link Button
+
+private struct SourceLinkButton: View {
+    let url: URL
+    @Environment(\.openURL) private var openURL
+
+    private var label: String {
+        if let host = url.host?.lowercased(),
+           host.contains("x.com") || host.contains("twitter.com") {
+            return "View on X"
+        }
+        return "View source"
+    }
+
+    private var iconName: String {
+        if let host = url.host?.lowercased(),
+           host.contains("x.com") || host.contains("twitter.com") {
+            return "arrow.up.right.square"
+        }
+        return "link"
+    }
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Image(systemName: iconName)
+                .font(.system(size: 11))
+            Text(label)
+                .font(.system(size: 13))
+        }
+        .foregroundStyle(.white.opacity(0.35))
+        .contentShape(Rectangle())
+        .onTapGesture {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            openURL(url)
+        }
+        .accessibilityLabel("View original post on X")
+        .accessibilityAddTraits(.isLink)
     }
 }
 


### PR DESCRIPTION
### Why?

When importing screenshots or videos from X/Twitter, there's no way to trace back to the original post. Users want to quickly revisit the source tweet from within the app.

### How?

Adds a `sourceURL` field to the MediaItem model and sidecar JSON, populated during X/Twitter import on both platforms. The Mac and iOS detail views display a "View on X" link button when a source URL is present. Cross-device sync is handled by reading/writing sourceURL in all sidecar paths — Mac SyncWatcher, iOS SyncService, and the iOS share extension.

<sub>Generated with Claude Code</sub>