### PR TITLE
iOS: Add "Remove from Space" to grid item context menu

### DIFF
--- a/ios/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -20,6 +20,7 @@ struct GridItemView: View {
     var onSelect: ((MediaItem, CGRect, UIImage?) -> Void)?
     var onRetryAnalysis: (() -> Void)?
     var onShare: (() -> Void)?
+    var onRemoveFromSpace: (() -> Void)?
     var onDelete: (() -> Void)?
     @State private var thumbnail: UIImage?
     @State private var loadFailed = false
@@ -163,6 +164,14 @@ struct GridItemView: View {
                 onRetryAnalysis?()
             } label: {
                 Label("Redo Analysis", systemImage: "arrow.clockwise")
+            }
+
+            if let onRemoveFromSpace {
+                Button {
+                    onRemoveFromSpace()
+                } label: {
+                    Label("Remove from Space", systemImage: "folder.badge.minus")
+                }
             }
 
             Divider()

--- a/ios/SnapGrid/SnapGrid/Views/Grid/MasonryGrid.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Grid/MasonryGrid.swift
@@ -7,6 +7,7 @@ struct MasonryGrid: View {
     var onItemSelected: ((MediaItem, CGRect, UIImage?) -> Void)?
     var onRetryAnalysis: ((MediaItem) -> Void)?
     var onShareItem: ((MediaItem) -> Void)?
+    var onRemoveFromSpace: ((MediaItem) -> Void)?
     var onDeleteItem: ((MediaItem) -> Void)?
 
     private let columns = 2
@@ -44,6 +45,9 @@ struct MasonryGrid: View {
                                 { callback(item) }
                             },
                             onShare: onShareItem.map { callback in
+                                { callback(item) }
+                            },
+                            onRemoveFromSpace: onRemoveFromSpace.map { callback in
                                 { callback(item) }
                             },
                             onDelete: onDeleteItem.map { callback in

--- a/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
@@ -216,6 +216,7 @@ struct MainView: View {
                                                     onItemSelected: handleItemSelected,
                                                     onRetryAnalysis: handleRetryAnalysis,
                                                     onShareItem: handleShareItem,
+                                                    onRemoveFromSpace: handleRemoveFromSpace,
                                                     onDeleteItem: { item in itemToDelete = item }
                                                 )
                                                 .padding(.horizontal, 12)
@@ -450,6 +451,36 @@ struct MainView: View {
             shareItem = tempURL
         } catch {
             shareItem = url
+        }
+    }
+
+    // MARK: - Remove from Space
+
+    private func handleRemoveFromSpace(_ item: MediaItem) {
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        item.space = nil
+        try? modelContext.save()
+
+        if let rootURL = fileSystem.rootURL {
+            updateSidecarSpaceId(for: item, rootURL: rootURL)
+        }
+    }
+
+    private func updateSidecarSpaceId(for item: MediaItem, rootURL: URL) {
+        let metadataDir = rootURL.appendingPathComponent("metadata")
+        let sidecarURL = metadataDir.appendingPathComponent("\(item.id).json")
+
+        guard let existingData = try? Data(contentsOf: sidecarURL) else { return }
+        guard var json = try? JSONSerialization.jsonObject(with: existingData) as? [String: Any] else { return }
+
+        if let space = item.space {
+            json["spaceId"] = space.id
+        } else {
+            json["spaceId"] = NSNull()
+        }
+
+        if let updatedData = try? JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys]) {
+            try? updatedData.write(to: sidecarURL, options: .atomic)
         }
     }
 


### PR DESCRIPTION
### Why?

The iOS app's grid item context menu only offers Delete to remove items, with no way to unassign an item from a space without destroying it. The Mac app already has this capability — this brings parity.

### How?

Threads an optional `onRemoveFromSpace` callback through GridItemView → MasonryGrid → MainView, wired only for per-space grid pages so it never appears in the "All" view. The handler clears the SwiftData relationship and writes `spaceId: null` to the sidecar JSON for cross-device sync.

<details>
<summary>Implementation Plan</summary>

# Plan: Add "Remove from Space" to iOS Context Menu

## Context

The iOS app's long-press context menu on grid items currently offers Share, Redo Analysis, and Delete. There's no way to remove an item from a space without deleting it entirely. The Mac app already has this feature. This change brings parity so iOS users viewing a specific space can unassign items from it.

## Approach

Thread a new `onRemoveFromSpace` optional callback through the view hierarchy. Only pass it when the user is viewing a specific space (not "All" or no-spaces mode). Update both SwiftData and the sidecar JSON so the change syncs to the Mac app.

## Changes (3 files)

### 1. `ios/.../Views/Grid/GridItemView.swift`
- Add `var onRemoveFromSpace: (() -> Void)?` property (after line 23)
- Add conditional button in `.contextMenu` between "Redo Analysis" and the Divider:
  ```swift
  if let onRemoveFromSpace {
      Button {
          onRemoveFromSpace()
      } label: {
          Label("Remove from Space", systemImage: "folder.badge.minus")
      }
  }
  ```

### 2. `ios/.../Views/Grid/MasonryGrid.swift`
- Add `var onRemoveFromSpace: ((MediaItem) -> Void)?` property (after line 10)
- Thread to GridItemView using the existing `.map` pattern:
  ```swift
  onRemoveFromSpace: onRemoveFromSpace.map { callback in { callback(item) } },
  ```

### 3. `ios/.../Views/Main/MainView.swift`
- Pass `onRemoveFromSpace` **only** on the per-space MasonryGrid (line ~212, Instance 3). Leave nil for the no-spaces fallback and "All" page — the button won't appear there.
- Add `handleRemoveFromSpace(_:)` handler:
  - Light haptic feedback
  - Set `item.space = nil`, save context
  - Write updated `spaceId: null` to sidecar JSON
- Add `writeSidecarSpaceId(for:rootURL:)` helper using the same read-modify-write JSONSerialization pattern as the existing `writeSidecar`. Use `NSNull()` for the null value so JSON outputs `"spaceId": null` (important for Mac sync).

## Why the callback-nil approach

The button only makes sense in a space view. Rather than threading `activeSpaceId` into GridItemView, we keep the callback optional (nil = don't show). This matches the existing pattern where all callbacks are optional closures, and avoids adding space-awareness to a view that doesn't need it.

</details>

<sub>Generated with Claude Code</sub>