### PR TITLE
Add iOS drag grid items to space tabs

### DIFF
--- a/ios/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -182,6 +182,19 @@ struct GridItemView: View {
                 Label("Delete", systemImage: "trash")
             }
         }
+        .draggable("snapgrid:\(item.id)") {
+            if let thumbnail {
+                Image(uiImage: thumbnail)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 80, height: 80 / item.gridAspectRatio)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            } else {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.snapDarkMuted)
+                    .frame(width: 80, height: 60)
+            }
+        }
         .task {
             await loadThumbnail()
         }

--- a/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
@@ -168,7 +168,8 @@ struct MainView: View {
                             SpaceTabBar(
                                 spaces: spaces,
                                 activeSpaceId: $activeSpaceId,
-                                scrollProgress: tabScrollProgress
+                                scrollProgress: tabScrollProgress,
+                                onAssignToSpace: handleAssignToSpace
                             )
 
                             ScrollView(.horizontal, showsIndicators: false) {
@@ -425,6 +426,52 @@ struct MainView: View {
         sourceRect = rect
         thumbnailImage = thumb
         showOverlay = true
+    }
+
+    // MARK: - Space Assignment (Drag & Drop)
+
+    private func handleAssignToSpace(itemId: String, spaceId: String?) {
+        guard let item = allItems.first(where: { $0.id == itemId }) else { return }
+
+        // Skip if already in the target space
+        let currentSpaceId = item.space?.id
+        if currentSpaceId == spaceId { return }
+
+        // Update SwiftData
+        let space: Space? = spaceId.flatMap { sid in
+            spaces.first(where: { $0.id == sid })
+        }
+        item.space = space
+        try? modelContext.save()
+
+        // Persist to sidecar JSON for iCloud sync
+        if let rootURL = fileSystem.rootURL {
+            writeSidecarSpaceId(for: item, rootURL: rootURL)
+        }
+
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+    }
+
+    private func writeSidecarSpaceId(for item: MediaItem, rootURL: URL) {
+        let sidecarURL = rootURL.appendingPathComponent("metadata/\(item.id).json")
+
+        guard let existingData = try? Data(contentsOf: sidecarURL),
+              var json = try? JSONSerialization.jsonObject(with: existingData) as? [String: Any] else {
+            return
+        }
+
+        if let spaceId = item.space?.id {
+            json["spaceId"] = spaceId
+        } else {
+            json.removeValue(forKey: "spaceId")
+        }
+
+        if let updatedData = try? JSONSerialization.data(
+            withJSONObject: json,
+            options: [.prettyPrinted, .sortedKeys]
+        ) {
+            try? updatedData.write(to: sidecarURL, options: .atomic)
+        }
     }
 
     // MARK: - Item Deletion

--- a/ios/SnapGrid/SnapGrid/Views/Main/SpaceTabBar.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/SpaceTabBar.swift
@@ -4,6 +4,9 @@ struct SpaceTabBar: View {
     let spaces: [Space]
     @Binding var activeSpaceId: String?
     var scrollProgress: CGFloat
+    var onAssignToSpace: ((String, String?) -> Void)?
+
+    @State private var dropTargetId: String?
 
     private var activeIndex: Int {
         guard let id = activeSpaceId else { return 0 }
@@ -12,22 +15,14 @@ struct SpaceTabBar: View {
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 4) {
-                TabButton(title: "All", index: 0, isActive: activeSpaceId == nil) {
-                    withAnimation(SnapSpring.resolvedStandard) {
-                        activeSpaceId = nil
-                    }
-                }
+            HStack(spacing: 0) {
+                tabDropTarget(title: "All", index: 0, spaceId: nil, isActive: activeSpaceId == nil)
 
                 ForEach(Array(spaces.enumerated()), id: \.element.id) { index, space in
-                    TabButton(title: space.name, index: index + 1, isActive: activeSpaceId == space.id) {
-                        withAnimation(SnapSpring.resolvedStandard) {
-                            activeSpaceId = space.id
-                        }
-                    }
+                    tabDropTarget(title: space.name, index: index + 1, spaceId: space.id, isActive: activeSpaceId == space.id)
                 }
             }
-            .padding(.horizontal, 16)
+            .padding(.horizontal, 12)
             .overlayPreferenceValue(TabAnchorPreferenceKey.self) { anchors in
                 GeometryReader { proxy in
                     let frames = anchors.mapValues { proxy[$0] }
@@ -41,6 +36,50 @@ struct SpaceTabBar: View {
                 .frame(height: 1)
         }
     }
+
+    // MARK: - Tab with Drop Target
+
+    @ViewBuilder
+    private func tabDropTarget(title: String, index: Int, spaceId: String?, isActive: Bool) -> some View {
+        let targetId = spaceId ?? "ALL"
+        let isDropTarget = dropTargetId == targetId
+
+        TabButton(title: title, index: index, isActive: isActive, isDropTarget: isDropTarget) {
+            withAnimation(SnapSpring.resolvedStandard) {
+                activeSpaceId = spaceId
+            }
+        }
+        .padding(.horizontal, 4)
+        .frame(minHeight: 44)
+        .contentShape(Rectangle())
+        .dropDestination(for: String.self) { strings, _ in
+            handleDrop(strings, spaceId: spaceId)
+        } isTargeted: { targeted in
+            withAnimation(SnapSpring.resolvedFast) {
+                dropTargetId = targeted ? targetId : nil
+            }
+            if targeted {
+                UISelectionFeedbackGenerator().selectionChanged()
+            }
+        }
+    }
+
+    // MARK: - Drop Handling
+
+    private func handleDrop(_ strings: [String], spaceId: String?) -> Bool {
+        for text in strings {
+            if text.hasPrefix("snapgrid:") {
+                let itemId = String(text.dropFirst("snapgrid:".count))
+                if !itemId.isEmpty {
+                    onAssignToSpace?(itemId, spaceId)
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    // MARK: - Tab Underline
 
     @ViewBuilder
     private func tabUnderline(frames: [Int: CGRect], containerHeight: CGFloat) -> some View {
@@ -82,6 +121,7 @@ private struct TabButton: View {
     let title: String
     let index: Int
     let isActive: Bool
+    var isDropTarget: Bool = false
     let action: () -> Void
 
     var body: some View {
@@ -95,13 +135,20 @@ private struct TabButton: View {
                 .overlay {
                     Text(title)
                         .font(.subheadline.weight(isActive ? .medium : .regular))
-                        .foregroundStyle(isActive ? .white : .white.opacity(0.5))
+                        .foregroundStyle(isActive ? .white : isDropTarget ? .white.opacity(0.7) : .white.opacity(0.5))
                 }
-                .padding(.horizontal, 10)
-                .padding(.top, 8)
-                .padding(.bottom, 16)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 8)
+                .frame(minWidth: 44)
+                .background {
+                    if isDropTarget && !isActive {
+                        RoundedRectangle(cornerRadius: 7)
+                            .fill(Color.white.opacity(0.12))
+                    }
+                }
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(title)
         .accessibilityAddTraits(isActive ? .isSelected : [])
         .anchorPreference(key: TabAnchorPreferenceKey.self, value: .bounds) { anchor in
             [index: anchor]


### PR DESCRIPTION
### Why?

The iOS app had no way to reassign items between spaces — space assignment only worked via the Mac app through iCloud-synced sidecar JSON. Users need to organize their grid items into spaces directly from iOS.

### How?

Adds `.draggable()` on grid items and `.dropDestination()` on space tabs, using the same `snapgrid:<id>` wire protocol as the Mac app. Drops update SwiftData and write the `spaceId` back to the sidecar JSON for bidirectional iCloud sync. Tab drop targets follow HIG with 44pt minimums and haptic feedback on target entry.

<details>
<summary>Implementation Plan</summary>

# iOS: Drag Grid Items to Space Tabs

## Context

The native Mac app supports dragging grid items onto space tabs to reassign them between spaces. The iOS app currently has no equivalent — space assignment only happens via iCloud-synced sidecar JSON files written by the Mac app. This change adds drag-and-drop to the iOS app using the same `"snapgrid:<id>"` wire protocol as the Mac app, allowing bidirectional space management.

## Changes (3 files)

### 1. `GridItemView.swift` — Make grid items draggable

**File:** `ios/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift`

Add `.draggable("snapgrid:\(item.id)")` modifier with a thumbnail drag preview. Place it after `.clipShape(RoundedRectangle(cornerRadius: 12))` (line 135) and before `.accessibilityLabel(...)` (line 136).

The drag preview shows a small thumbnail image (or placeholder) so the user sees what they're dragging.

### 2. `SpaceTabBar.swift` — Accept drops on tabs

**File:** `ios/SnapGrid/SnapGrid/Views/Main/SpaceTabBar.swift`

- Add `onAssignToSpace: ((String, String?) -> Void)?` callback property
- Add `@State private var dropTargetId: String?` for tracking hover target
- Add `isDropTarget: Bool` parameter to `TabButton` for visual feedback (brighter text + subtle background tint when hovered)
- Add `.dropDestination(for: String.self)` modifier on both the "All" tab and each space tab
- Add `handleDrop(_:spaceId:)` helper that parses the `"snapgrid:"` prefix and calls `onAssignToSpace`

Visual feedback: when a dragged item hovers over a tab, the tab brightens (text goes from 0.5 to 0.8 opacity) and gets a `Color.white.opacity(0.1)` background tint, matching the Mac app pattern.

### 3. `MainView.swift` — Wire callback + persist changes

**File:** `ios/SnapGrid/SnapGrid/Views/Main/MainView.swift`

- Pass `onAssignToSpace: handleAssignToSpace` when creating `SpaceTabBar` (line 164)
- Add `handleAssignToSpace(itemId:spaceId:)` method that:
  1. Finds the item in `allItems` by ID
  2. Skips if already in the target space
  3. Updates `item.space` in SwiftData
  4. Saves the model context
  5. Writes updated `spaceId` to sidecar JSON (read-modify-write preserving all fields)
  6. Fires haptic feedback (`UINotificationFeedbackGenerator.success`)
- Add `writeSidecarSpaceId(for:rootURL:)` helper using `JSONSerialization` read-modify-write (same pattern as existing `writeSidecar` but targeting the `spaceId` field)

### Sync Safety

The `SyncService.updateIfNeeded` reads `spaceId` from the sidecar file. After we write the new spaceId to the sidecar AND update SwiftData in-memory, the next sync cycle reads the same value from disk — no conflict or revert. iCloud will also propagate the sidecar change to the Mac app.

</details>

<sub>Generated with Claude Code</sub>