### PR TITLE
Refactor: extract iOS services, fix silent saves, clean up Mac app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,38 +4,40 @@ Visual media library app for collecting screenshots and videos, with AI-powered 
 
 | Project | Location | Stack |
 |---------|----------|-------|
-| Desktop Electron app | `/electron/` + `/src/` | Electron, React, TypeScript, Vite |
-| Companion iOS app | `/ios/SnapGrid/` | SwiftUI, iOS 17+ |
-| Experimental native Mac app | `/SnapGrid/` | SwiftUI + SwiftData, macOS 15+ |
+| Native Mac app (primary) | `/SnapGrid/` | SwiftUI + SwiftData, macOS 15+ |
+| iOS companion app | `/ios/SnapGrid/` | SwiftUI + SwiftData, iOS 17+ |
+| Legacy Electron app | `/electron/` + `/src/` | Electron, React, TypeScript, Vite |
 
-## Shared File Storage
+The Mac app is the reference implementation. iOS matches its patterns. The Electron app is legacy.
 
-All three apps read/write the same structure. iOS syncs via iCloud.
+## Shared file storage
+
+All apps read/write the same structure. iOS syncs via iCloud.
 
 ```
 ~/Documents/SnapGrid/
-├── images/     (PNG/MP4 — videos use vid_ prefix)
-├── metadata/   (JSON, same ID as media file)
-├── .trash/     (auto-emptied)
-└── queue/      (mobile import, auto-watched)
+├── images/     (media files: {id}.png, {id}.mp4, etc.)
+├── metadata/   (sidecar JSON: {id}.json — same ID as media)
+├── thumbnails/ (generated: {id}.jpg)
+├── spaces.json (space definitions + guidance config)
+├── .trash/     (auto-emptied after 30 days)
+└── queue/      (mobile import staging, auto-watched by Mac)
 ```
 
-## Electron App
+## Electron app (legacy)
 
 MUST use `HashRouter` — `BrowserRouter` breaks in Electron production.
 NEVER use `require()` in renderer — all communication via IPC (`electron/preload.cjs`).
-API keys use secure storage via IPC (`setApiKey`/`getApiKey`).
-State management uses modular hooks, not Redux (see `src/hooks/`).
 
 ```bash
-npm run electron:dev    # Development (Vite + Electron)
+npm run electron:dev    # Development
 npm run build          # TypeScript check
 npm run lint           # Before committing
 ```
 
-## iOS App
+## iOS app
 
-Read-only companion viewer. Shares storage with desktop app via iCloud sync. Zero external dependencies.
+Syncs media and spaces via iCloud. Can run AI analysis and write results back to sidecars. Zero external dependencies.
 
 **iCloud handling is critical** — files may exist as `.icloud` placeholders. All loading code must detect placeholders, trigger downloads with `startDownloadingUbiquitousItem()`, and wait for completion.
 
@@ -43,50 +45,47 @@ Read-only companion viewer. Shares storage with desktop app via iCloud sync. Zer
 
 **FullScreenImageOverlay gestures** use a mode-locking pattern (dismiss/scroll/swipe/zoom lock on first touch). Respect this when modifying gesture code.
 
-Open `ios/SnapGrid/SnapGrid.xcodeproj` in Xcode 15.4+. Bundle ID: `com.snapgrid.ios`.
+Bundle ID: `com.snapgrid.ios`.
 
-## Mac App (Experimental)
+## Mac app
 
-Native SwiftUI + SwiftData rewrite. Uses XcodeGen (`SnapGrid/project.yml`).
+Uses XcodeGen — run `cd SnapGrid && xcodegen generate` after adding/removing Swift files.
 
-Open `SnapGrid/SnapGrid.xcodeproj` in Xcode. Bundle ID: `com.snapgrid.app`.
+Bundle ID: `com.snapgrid.app`.
 
-## Testing (Mac & iOS)
+## Architecture patterns
 
-Both native apps have Swift Testing test suites. Tests run automatically via a pre-commit hook before every commit.
+**iOS AppState**: UI state lives in `AppState` (`@Observable @MainActor`), not scattered `@State` on views. Match this pattern for new state.
 
-**When adding new features or changing existing logic, you must:**
-- Write tests for any new service methods, model properties, or business logic
-- Update existing tests if you change the behavior of tested functions
-- Run tests locally before committing: `cd SnapGrid && xcodegen generate && xcodebuild test -project SnapGrid.xcodeproj -scheme SnapGrid -destination 'platform=macOS'`
+**Analysis coordination**: AI analysis logic lives in `AnalysisCoordinator` (iOS) and `ImportService` (Mac), NOT in views.
 
-**Test framework:** Swift Testing (`import Testing`, `@Test`, `@Suite`, `#expect`). Do NOT use XCTest for new tests.
+**Sidecar writes**: ALL sidecar JSON mutations go through `SidecarWriteService` (iOS) or `MetadataSidecarService` (Mac). NEVER write sidecar JSON directly in views.
 
-**Test locations:** `SnapGrid/SnapGridTests/` (Mac), `ios/SnapGrid/SnapGridTests/` (iOS). Shared test helpers in `Helpers/`. Tags defined in `TestTags.swift`.
+**Supported media types**: Use `SupportedMedia` enum (Mac) for file extensions and UTTypes. Don't define inline extension sets.
+
+**SwiftData saves**: Use `modelContext.saveOrLog()` (not `try? modelContext.save()`). The `saveOrLog()` extension logs errors and asserts in DEBUG to prevent silent data loss.
+
+**`isAnalyzing` is transient** — it's persisted on `MediaItem` but represents in-flight state. Both apps reset stuck flags on launch. Don't add more persisted transient flags; track ephemeral state on coordinators instead.
+
+## Testing
+
+Both native apps use Swift Testing (`import Testing`, `@Test`, `@Suite`, `#expect`). Do NOT use XCTest for new tests. Tests run via pre-commit hook.
+
+```bash
+# Mac tests
+cd SnapGrid && xcodegen generate && xcodebuild test -project SnapGrid.xcodeproj -scheme SnapGrid -destination 'platform=macOS'
+
+# iOS tests
+cd ios/SnapGrid && xcodebuild test -project SnapGrid.xcodeproj -scheme SnapGrid -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
 
 **SwiftData tests** use in-memory containers via `TestContainer.create()` — never touch the real database.
 
-**Access levels:** If you need to test a private method, change it to `internal` (Swift's default). Use `@testable import SnapGrid` in tests.
+**Access levels:** Change `private` to `internal` (Swift default) to make methods testable. Use `@testable import SnapGrid`.
 
-## Apple HIG Compliance (Mac & iOS)
+## Common gotchas
 
-All native SwiftUI code must follow Apple's Human Interface Guidelines. When writing or modifying views:
-
-**Accessibility (non-negotiable):**
-- Every interactive element needs `.accessibilityLabel()` — buttons, grid items, tabs, badges
-- Icon-only buttons always need a label (the icon is not enough for VoiceOver)
-- Status elements (toasts, badges, progress) need `.accessibilityAddTraits(.isStatusElement)`
-- Check `@Environment(\.accessibilityReduceMotion)` before applying spring animations, staggered reveals, or continuous animations (shimmer). Use `.easeInOut(duration: 0.15)` or `.identity` as fallback
-- Use semantic text styles (`.headline`, `.body`, `.caption`) instead of `.system(size: N)` so text scales with Dynamic Type
-
-**Colors & system integration:**
-- Use `Color.accentColor` for selection indicators and interactive highlights — never hardcode `Color.blue`
-- When defining custom adaptive colors, add Increase Contrast variants by checking `NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast`
-- Custom background colors are acceptable for media apps, but interactive/text colors should respect system accessibility settings
-
-**macOS-specific patterns:**
-- Settings must use `Settings {}` scene with `TabView` and `.formStyle(.grouped)`
-- Provide comprehensive menu bar commands with standard keyboard shortcuts
-- Support `Cmd+Click` toggle, `Shift+Click` range, and rubber band selection
-- Windows should have a title (even if title bar is hidden) for Mission Control/Window menu
-- Persist view state (`@AppStorage`/`@SceneStorage`) so the app restores on relaunch
+- Check `@Environment(\.accessibilityReduceMotion)` / `UIAccessibility.isReduceMotionEnabled` before spring animations or shimmer effects
+- Use `.glassEffect` on macOS 26+ / iOS 26+ with `.ultraThinMaterial` fallback for older versions
+- Menu bar commands use `NotificationCenter` to communicate with `ContentView` — add new notifications in `SnapGridApp.swift`
+- `NSWindow.allowsAutomaticWindowTabbing = false` — native tab bar is disabled; the app has its own Spaces tab bar

--- a/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
+++ b/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		638C67ABC5D710901F2CABF2 /* KeySyncCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16EB2E945029CE0D88016280 /* KeySyncCrypto.swift */; };
 		65160672513A59B8ED353208 /* SelectionBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFDD4D2B1F3CCB3ED261F5C /* SelectionBadge.swift */; };
 		6616D86A2EE273FDF8805951 /* iCloudDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EE0E51D2D80BFD49716AA0 /* iCloudDownloadManager.swift */; };
+		67C13EA251A2A6E0FBDD4FC0 /* SupportedMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FFBFE4624B0A09BB339F3A /* SupportedMedia.swift */; };
+		73ADFFEAA064D44BB340C37C /* ModelContext+SaveOrLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A60DA384E21F01587028216 /* ModelContext+SaveOrLog.swift */; };
 		7EC7FDEF2B1AB437602F7CBA /* SidecarCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6F116E4024331E85284A3D /* SidecarCodableTests.swift */; };
 		8167D57BFF6AAEC5E1CF20E1 /* AnimationTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 468F744BF11C8965B74EF95F /* AnimationTokens.swift */; };
 		8350DC604AC401431E9CD255 /* Space.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6477AAD40C3308F596D68729 /* Space.swift */; };
@@ -129,6 +131,8 @@
 		9391B9A3F7CE5C394F263B9C /* ModelDiscoveryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDiscoveryService.swift; sourceTree = "<group>"; };
 		963A5601AC378837EA06DF0E /* MediaStorageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStorageService.swift; sourceTree = "<group>"; };
 		998B3A855E657D80396A9CD7 /* KeySyncCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeySyncCryptoTests.swift; sourceTree = "<group>"; };
+		99FFBFE4624B0A09BB339F3A /* SupportedMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportedMedia.swift; sourceTree = "<group>"; };
+		9A60DA384E21F01587028216 /* ModelContext+SaveOrLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ModelContext+SaveOrLog.swift"; sourceTree = "<group>"; };
 		9B1BF47348836CDB70325FEE /* MigrationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationService.swift; sourceTree = "<group>"; };
 		9CF36B9F264117143DF32A8E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		9DB5BFB2BC5A94B434803361 /* ElectronImportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElectronImportView.swift; sourceTree = "<group>"; };
@@ -178,6 +182,7 @@
 				82D1884A0E94D6BC1F407855 /* AnalysisResult.swift */,
 				3BA6AB7DC0A84E670681EB6C /* MediaItem.swift */,
 				6477AAD40C3308F596D68729 /* Space.swift */,
+				99FFBFE4624B0A09BB339F3A /* SupportedMedia.swift */,
 				A7E3151FA585E1C6ACA7945E /* TransferableFileURL.swift */,
 			);
 			path = Models;
@@ -285,6 +290,7 @@
 			isa = PBXGroup;
 			children = (
 				EA3B7921F371383918892A5D /* Color+Theme.swift */,
+				9A60DA384E21F01587028216 /* ModelContext+SaveOrLog.swift */,
 				3CE5033083DAF80AD07ABC32 /* NSImage+Thumbnail.swift */,
 				6B6205D7E807323F142415FE /* View+DoubleClick.swift */,
 			);
@@ -483,6 +489,7 @@
 				968DDBB08FE3CED44009BC7D /* MediaStorageService.swift in Sources */,
 				F84D4B0142262DA02D0EF60D /* MetadataSidecarService.swift in Sources */,
 				DA12BF6C17557F0E8B625129 /* MigrationService.swift in Sources */,
+				73ADFFEAA064D44BB340C37C /* ModelContext+SaveOrLog.swift in Sources */,
 				439744C29794B39D02563DE6 /* ModelDiscoveryService.swift in Sources */,
 				210A13790BE0E2F8D5123662 /* NSImage+Thumbnail.swift in Sources */,
 				5C1E7DB8A91CE5B34721F868 /* PatternPill.swift in Sources */,
@@ -495,6 +502,7 @@
 				8350DC604AC401431E9CD255 /* Space.swift in Sources */,
 				0FB79B182FF2453212D42811 /* SpaceTabBar.swift in Sources */,
 				FA711149840B9BFF157A8239 /* StorageSettingsTab.swift in Sources */,
+				67C13EA251A2A6E0FBDD4FC0 /* SupportedMedia.swift in Sources */,
 				0BD6F0F6397C8D6CC98DDFFF /* SyncWatcher.swift in Sources */,
 				27A5C73EBCC0338561829D33 /* ThumbnailService.swift in Sources */,
 				22B3C67B9FEA9300A6D969AE /* ToastView.swift in Sources */,

--- a/SnapGrid/SnapGrid/App/SnapGridApp.swift
+++ b/SnapGrid/SnapGrid/App/SnapGridApp.swift
@@ -31,6 +31,10 @@ struct SnapGridApp: App {
         WindowGroup("SnapGrid") {
             ContentView()
                 .task { KeySyncService.syncToiCloud() }
+                .onAppear {
+                    // Disable native macOS window tabbing — this app has its own Spaces tab bar
+                    NSWindow.allowsAutomaticWindowTabbing = false
+                }
         }
         .modelContainer(container)
         .windowStyle(.hiddenTitleBar)
@@ -94,6 +98,22 @@ struct SnapGridApp: App {
                 .keyboardShortcut("a")
             }
 
+            CommandGroup(replacing: .toolbar) {
+                Button {
+                    NotificationCenter.default.post(name: .zoomIn, object: nil)
+                } label: {
+                    Label("Zoom In", systemImage: "plus.magnifyingglass")
+                }
+                .keyboardShortcut("+")
+
+                Button {
+                    NotificationCenter.default.post(name: .zoomOut, object: nil)
+                } label: {
+                    Label("Zoom Out", systemImage: "minus.magnifyingglass")
+                }
+                .keyboardShortcut("-")
+            }
+
             CommandGroup(replacing: .undoRedo) {
                 Button("Undo") {
                     NotificationCenter.default.post(name: .undoDelete, object: nil)
@@ -151,4 +171,6 @@ extension Notification.Name {
     static let pasteImages = Notification.Name("pasteImages")
     static let deleteSelected = Notification.Name("deleteSelected")
     static let analysisCompleted = Notification.Name("analysisCompleted")
+    static let zoomIn = Notification.Name("zoomIn")
+    static let zoomOut = Notification.Name("zoomOut")
 }

--- a/SnapGrid/SnapGrid/Extensions/ModelContext+SaveOrLog.swift
+++ b/SnapGrid/SnapGrid/Extensions/ModelContext+SaveOrLog.swift
@@ -1,0 +1,16 @@
+import SwiftData
+
+extension ModelContext {
+    /// Saves and logs failures instead of silently swallowing them.
+    /// In DEBUG builds, triggers an assertion so developers notice immediately.
+    func saveOrLog(file: String = #file, line: Int = #line) {
+        do {
+            try save()
+        } catch {
+            print("[SwiftData] Save failed at \(file):\(line): \(error)")
+            #if DEBUG
+            assertionFailure("SwiftData save failed: \(error)")
+            #endif
+        }
+    }
+}

--- a/SnapGrid/SnapGrid/Models/SupportedMedia.swift
+++ b/SnapGrid/SnapGrid/Models/SupportedMedia.swift
@@ -1,0 +1,27 @@
+import Foundation
+import UniformTypeIdentifiers
+
+enum SupportedMedia {
+    static let imageExtensions: Set<String> = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "heic"]
+    static let videoExtensions: Set<String> = ["mp4", "webm", "mov", "avi", "m4v"]
+    static let allExtensions: Set<String> = imageExtensions.union(videoExtensions)
+
+    static func isImage(_ ext: String) -> Bool { imageExtensions.contains(ext.lowercased()) }
+    static func isVideo(_ ext: String) -> Bool { videoExtensions.contains(ext.lowercased()) }
+    static func isSupported(_ ext: String) -> Bool { allExtensions.contains(ext.lowercased()) }
+
+    /// UTTypes for the import file picker. Note: .webm has no system UTType.
+    static let importableContentTypes: [UTType] = [
+        .png, .jpeg, .gif, .bmp, .tiff, .webP, .heic,
+        .mpeg4Movie, .movie, .avi
+    ]
+
+    /// Maps MIME types to file extensions for URL downloads.
+    static let mimeToExtension: [String: String] = [
+        "image/png": "png", "image/jpeg": "jpg", "image/jpg": "jpg",
+        "image/gif": "gif", "image/webp": "webp", "image/bmp": "bmp",
+        "image/tiff": "tiff", "image/heic": "heic",
+        "video/mp4": "mp4", "video/webm": "webm",
+        "video/quicktime": "mov", "video/x-msvideo": "avi", "video/x-m4v": "m4v",
+    ]
+}

--- a/SnapGrid/SnapGrid/Services/DataCleanupService.swift
+++ b/SnapGrid/SnapGrid/Services/DataCleanupService.swift
@@ -42,7 +42,7 @@ enum DataCleanupService {
         }
 
         if updated > 0 {
-            try? context.save()
+            context.saveOrLog()
             print("[DataCleanup] Migrated dimensions for \(updated) videos")
         }
 
@@ -75,7 +75,7 @@ enum DataCleanupService {
         }
 
         if removed > 0 {
-            try? context.save()
+            context.saveOrLog()
             print("[DataCleanup] Removed \(removed) orphaned records")
         }
 
@@ -90,9 +90,51 @@ enum DataCleanupService {
                 }
             }
             if orphanedResults > 0 {
-                try? context.save()
+                context.saveOrLog()
                 print("[DataCleanup] Removed \(orphanedResults) orphaned AnalysisResult records")
             }
+        }
+    }
+
+    /// Remove sidecar JSON files from metadata/ whose media file no longer exists.
+    /// This prevents "Media file not found" warnings on every launch.
+    static func cleanOrphanedSidecars() {
+        let storage = MediaStorageService.shared
+        let fm = FileManager.default
+
+        guard let files = try? fm.contentsOfDirectory(
+            at: storage.metadataDir,
+            includingPropertiesForKeys: nil
+        ) else { return }
+
+        let imageExtensions = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "heic"]
+        let videoExtensions = ["mp4", "webm", "mov", "avi", "m4v"]
+        let allExtensions = imageExtensions + videoExtensions
+
+        var removed = 0
+        for file in files where file.pathExtension == "json" {
+            let id = file.deletingPathExtension().lastPathComponent
+
+            // Check if any media file exists for this ID (any extension)
+            let hasMedia = allExtensions.contains { ext in
+                let mediaURL = storage.mediaDir.appendingPathComponent("\(id).\(ext)")
+                if fm.fileExists(atPath: mediaURL.path) { return true }
+                // Check iCloud placeholder
+                let placeholder = storage.mediaDir.appendingPathComponent(".\(id).\(ext).icloud")
+                return fm.fileExists(atPath: placeholder.path)
+            }
+
+            if !hasMedia {
+                try? fm.removeItem(at: file)
+                // Also clean up the thumbnail if it exists
+                let thumbURL = storage.thumbnailDir.appendingPathComponent("\(id).jpg")
+                try? fm.removeItem(at: thumbURL)
+                removed += 1
+            }
+        }
+
+        if removed > 0 {
+            print("[DataCleanup] Removed \(removed) orphaned sidecar files")
         }
     }
 

--- a/SnapGrid/SnapGrid/Services/ElectronImportService.swift
+++ b/SnapGrid/SnapGrid/Services/ElectronImportService.swift
@@ -190,7 +190,7 @@ final class ElectronImportService {
         // 3. Import spaces
         let (spaceMap, newSpaceCount) = await importSpaces(from: electronRoot, into: context)
         spacesImported = newSpaceCount
-        try? context.save()
+        context.saveOrLog()
 
         // 4. Process each metadata file — save after each item for safe incremental import
         for fileURL in allFiles {
@@ -230,7 +230,7 @@ final class ElectronImportService {
                     spaceMap: spaceMap,
                     context: context
                 )
-                try? context.save()
+                context.saveOrLog()
 
                 // Write JSON sidecar so item syncs to other devices via iCloud
                 let itemDescriptor = FetchDescriptor<MediaItem>(predicate: #Predicate<MediaItem> { $0.sourceId == electronId })

--- a/SnapGrid/SnapGrid/Services/ImportService.swift
+++ b/SnapGrid/SnapGrid/Services/ImportService.swift
@@ -11,8 +11,8 @@ final class ImportService {
     private let analysisService = AIAnalysisService.shared
     private let sidecarService = MetadataSidecarService.shared
 
-    private let imageTypes: Set<String> = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "heic"]
-    private let videoTypes: Set<String> = ["mp4", "webm", "mov", "avi", "m4v"]
+    private let imageTypes = SupportedMedia.imageExtensions
+    private let videoTypes = SupportedMedia.videoExtensions
 
     func importFiles(_ urls: [URL], into context: ModelContext, spaceId: String? = nil) async {
         for url in urls {
@@ -165,7 +165,7 @@ final class ImportService {
         print("[Analysis] Starting analysis with \(provider.rawValue)/\(model) for \(item.id)")
 
         item.isAnalyzing = true
-        try? context.save()
+        context.saveOrLog()
 
         do {
             let result: AnalysisResult
@@ -202,14 +202,14 @@ final class ImportService {
             item.analysisResult = result
             item.isAnalyzing = false
             item.analysisError = nil
-            try? context.save()
+            context.saveOrLog()
             sidecarService.writeSidecar(for: item)
             NotificationCenter.default.post(name: .analysisCompleted, object: nil, userInfo: ["itemId": item.id])
         } catch {
             print("[Analysis] Failed for \(item.id): \(error)")
             item.isAnalyzing = false
             item.analysisError = error.localizedDescription
-            try? context.save()
+            context.saveOrLog()
         }
     }
 
@@ -265,19 +265,10 @@ final class ImportService {
     /// Map a Content-Type MIME string to a file extension. Falls back to URL path extension.
     static func fileExtension(from contentType: String?, urlPathExtension: String?) -> String? {
         if let mime = contentType?.lowercased().split(separator: ";").first?.trimmingCharacters(in: .whitespaces) {
-            let mimeMap: [String: String] = [
-                "image/png": "png", "image/jpeg": "jpg", "image/jpg": "jpg",
-                "image/gif": "gif", "image/webp": "webp", "image/bmp": "bmp",
-                "image/tiff": "tiff", "image/heic": "heic",
-                "video/mp4": "mp4", "video/webm": "webm",
-                "video/quicktime": "mov", "video/x-msvideo": "avi", "video/x-m4v": "m4v",
-            ]
-            if let ext = mimeMap[mime] { return ext }
+            if let ext = SupportedMedia.mimeToExtension[mime] { return ext }
         }
 
-        let allKnown: Set<String> = ["png","jpg","jpeg","gif","bmp","tiff","webp","heic",
-                                      "mp4","webm","mov","avi","m4v"]
-        if let ext = urlPathExtension, allKnown.contains(ext) { return ext }
+        if let ext = urlPathExtension, SupportedMedia.allExtensions.contains(ext) { return ext }
         return nil
     }
 

--- a/SnapGrid/SnapGrid/Services/MetadataSidecarService.swift
+++ b/SnapGrid/SnapGrid/Services/MetadataSidecarService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftData
 
 // MARK: - Sidecar JSON Models
 
@@ -97,6 +98,16 @@ final class MetadataSidecarService: Sendable {
     }
 
     // MARK: - Spaces
+
+    /// Write spaces to spaces.json by fetching the current list from the model context.
+    /// Use this instead of manually constructing SidecarSpace arrays in views —
+    /// it always reflects the latest state after inserts/deletes.
+    @MainActor
+    func writeSpaces(from context: ModelContext) {
+        let descriptor = FetchDescriptor<Space>(sortBy: [SortDescriptor(\.order)])
+        let spaces = (try? context.fetch(descriptor)) ?? []
+        writeSpaces(spaces)
+    }
 
     /// Write spaces to spaces.json, automatically including the current all-space guidance from UserDefaults.
     func writeSpaces(_ spaces: [Space]) {

--- a/SnapGrid/SnapGrid/Services/SyncWatcher.swift
+++ b/SnapGrid/SnapGrid/Services/SyncWatcher.swift
@@ -444,7 +444,7 @@ final class SyncWatcher {
             }
         }
 
-        try? context.save()
+        context.saveOrLog()
     }
 
     // MARK: - Background File I/O Helpers (nonisolated)

--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -256,9 +256,18 @@ struct ContentView: View {
             }
         }
         .task {
+            // Reset any isAnalyzing flags stuck from a previous crash/kill
+            let stuckDescriptor = FetchDescriptor<MediaItem>(predicate: #Predicate { $0.isAnalyzing == true })
+            if let stuck = try? modelContext.fetch(stuckDescriptor), !stuck.isEmpty {
+                for item in stuck { item.isAnalyzing = false }
+                modelContext.saveOrLog()
+                print("[Cleanup] Reset \(stuck.count) stuck isAnalyzing flags")
+            }
+
             MediaStorageService.shared.emptyOldTrash()
             MigrationService.migrateIfNeeded(context: modelContext)
             DataCleanupService.cleanOrphanedRecords(context: modelContext)
+            DataCleanupService.cleanOrphanedSidecars()
             await DataCleanupService.migrateVideoDimensions(context: modelContext)
 
             // Sync items that arrived via iCloud while app was closed
@@ -335,15 +344,15 @@ struct ContentView: View {
                 appState.clearSelection()
             }
         }
-        .onKeyPress(.init("="), phases: .down) { press in
-            guard press.modifiers.contains(.command) else { return .ignored }
-            appState.zoomIn()
-            return .handled
+        .task {
+            for await _ in NotificationCenter.default.notifications(named: .zoomIn) {
+                appState.zoomIn()
+            }
         }
-        .onKeyPress(.init("-"), phases: .down) { press in
-            guard press.modifiers.contains(.command) else { return .ignored }
-            appState.zoomOut()
-            return .handled
+        .task {
+            for await _ in NotificationCenter.default.notifications(named: .zoomOut) {
+                appState.zoomOut()
+            }
         }
         .environment(appState)
         .environment(videoPreview)
@@ -470,9 +479,7 @@ struct ContentView: View {
         if let urls = pasteboard.readObjects(forClasses: [NSURL.self],
                                               options: [.urlReadingFileURLsOnly: true]) as? [URL],
            !urls.isEmpty {
-            let supportedExts: Set<String> = ["png","jpg","jpeg","gif","bmp","tiff","webp","heic",
-                                               "mp4","webm","mov","avi","m4v"]
-            let validURLs = urls.filter { supportedExts.contains($0.pathExtension.lowercased()) }
+            let validURLs = urls.filter { SupportedMedia.isSupported($0.pathExtension) }
             if !validURLs.isEmpty {
                 syncWatcher.beginLocalChange()
                 Task {
@@ -542,12 +549,7 @@ struct ContentView: View {
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = true
         panel.canChooseDirectories = false
-        // electron/main.js:1761 — jpg|jpeg|png|gif|webp|bmp|tiff|mp4|webm|mov|avi
-        // UploadZone.tsx:165 — image/*,video/*
-        panel.allowedContentTypes = [
-            .png, .jpeg, .gif, .bmp, .tiff, .webP, .heic,     // Images
-            .mpeg4Movie, .movie, .avi                           // Videos (.webm has no UTType)
-        ]
+        panel.allowedContentTypes = SupportedMedia.importableContentTypes
 
         panel.begin { response in
             if response == .OK {
@@ -633,7 +635,7 @@ struct ContentView: View {
             }
         }
         withAnimation(SnapSpring.standard) {
-            try? modelContext.save()
+            modelContext.saveOrLog()
         }
         syncWatcher.endLocalChange()
 
@@ -694,7 +696,7 @@ struct ContentView: View {
             modelContext.insert(item)
             MetadataSidecarService.shared.writeSidecar(for: item)
         }
-        try? modelContext.save()
+        modelContext.saveOrLog()
         syncWatcher.endLocalChange()
         appState.showToast("Restored \(batch.count) item\(batch.count == 1 ? "" : "s")")
     }
@@ -703,17 +705,8 @@ struct ContentView: View {
         syncWatcher.beginLocalChange()
         let space = Space(name: "New Space", order: spaces.count)
         modelContext.insert(space)
-        try? modelContext.save()
-        // Build sidecar array manually — @Query hasn't updated yet with the new space
-        var allSpaceSidecars = spaces.map { s in
-            SidecarSpace(id: s.id, name: s.name, order: s.order,
-                         createdAt: s.createdAt, customPrompt: s.customPrompt,
-                         useCustomPrompt: s.useCustomPrompt)
-        }
-        allSpaceSidecars.append(SidecarSpace(id: space.id, name: space.name, order: space.order,
-                                              createdAt: space.createdAt, customPrompt: space.customPrompt,
-                                              useCustomPrompt: space.useCustomPrompt))
-        MetadataSidecarService.shared.writeSpaceSidecars(allSpaceSidecars)
+        modelContext.saveOrLog()
+        MetadataSidecarService.shared.writeSpaces(from: modelContext)
         syncWatcher.endLocalChange()
         switchToSpace(space.id)
         pendingEditSpaceId = space.id
@@ -722,26 +715,17 @@ struct ContentView: View {
     private func deleteSpace(_ id: String) {
         guard let space = spaces.first(where: { $0.id == id }) else { return }
 
-        // 1. Capture plain data before any SwiftData mutation
-        let remainingSidecars = spaces.filter { $0.id != id }.map { s in
-            SidecarSpace(id: s.id, name: s.name, order: s.order,
-                         createdAt: s.createdAt, customPrompt: s.customPrompt,
-                         useCustomPrompt: s.useCustomPrompt)
-        }
-
-        // 2. Switch away before mutation
         if appState.activeSpaceId == id {
             appState.activeSpaceId = nil
         }
 
-        // 3. Suppress sync, manually nullify relationships, delete, write sidecar
         syncWatcher.beginLocalChange()
         for item in space.items {
             item.space = nil
         }
         modelContext.delete(space)
-        try? modelContext.save()
-        MetadataSidecarService.shared.writeSpaceSidecars(remainingSidecars)
+        modelContext.saveOrLog()
+        MetadataSidecarService.shared.writeSpaces(from: modelContext)
         syncWatcher.endLocalChange()
     }
 
@@ -749,7 +733,7 @@ struct ContentView: View {
         if let space = spaces.first(where: { $0.id == id }) {
             syncWatcher.beginLocalChange()
             space.name = newName
-            try? modelContext.save()
+            modelContext.saveOrLog()
             MetadataSidecarService.shared.writeSpaces(Array(spaces))
             syncWatcher.endLocalChange()
         }
@@ -768,7 +752,7 @@ struct ContentView: View {
         for (i, space) in ordered.enumerated() {
             space.order = i
         }
-        try? modelContext.save()
+        modelContext.saveOrLog()
         MetadataSidecarService.shared.writeSpaces(Array(spaces))
         syncWatcher.endLocalChange()
     }
@@ -781,7 +765,7 @@ struct ContentView: View {
         for item in itemsToUpdate {
             item.space = space
         }
-        try? modelContext.save()
+        modelContext.saveOrLog()
 
         for item in itemsToUpdate {
             MetadataSidecarService.shared.writeSidecar(for: item)
@@ -810,7 +794,7 @@ struct ContentView: View {
             item.analysisError = nil
             item.analysisResult = nil
         }
-        try? modelContext.save()
+        modelContext.saveOrLog()
         for item in items {
             Task {
                 await importService.analyzeItem(item, context: modelContext)

--- a/SnapGrid/SnapGrid/Views/Settings/PromptsSettingsTab.swift
+++ b/SnapGrid/SnapGrid/Views/Settings/PromptsSettingsTab.swift
@@ -88,7 +88,7 @@ struct GuidanceSettingsTab: View {
                                 Button(space.name) {
                                     space.useCustomPrompt = true
                                     if space.customPrompt == nil { space.customPrompt = "" }
-                                    try? modelContext.save()
+                                    modelContext.saveOrLog()
                                     persistToSpacesJson()
                                     selectedOverrideId = space.id
                                     editingTarget = .spaceGuidance(space.id, space.name, "")
@@ -102,7 +102,7 @@ struct GuidanceSettingsTab: View {
                             guard let space = selectedSpace else { return }
                             space.customPrompt = ""
                             space.useCustomPrompt = false
-                            try? modelContext.save()
+                            modelContext.saveOrLog()
                             persistToSpacesJson()
                             selectedOverrideId = nil
                         }
@@ -141,7 +141,7 @@ struct GuidanceSettingsTab: View {
             guard let space = spaces.first(where: { $0.id == spaceId }) else { return }
             space.customPrompt = text
             space.useCustomPrompt = !text.isEmpty
-            try? modelContext.save()
+            modelContext.saveOrLog()
             persistToSpacesJson()
         }
     }

--- a/ios/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
+++ b/ios/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
@@ -55,6 +55,10 @@
 		F1D89CA57FB5EB4C93E230F1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F5136715774C9C5C0651A4D4 /* Foundation.framework */; };
 		F2AD76603369201957F4E1FD /* SearchIndexService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFAB07291230EAED58390B4 /* SearchIndexService.swift */; };
 		FF030F761044AEE25ACAEA04 /* SyncServiceDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCAFF8A2EC042170AE7D0DA4 /* SyncServiceDataTests.swift */; };
+		A100000041 /* ModelContext+SaveOrLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000041 /* ModelContext+SaveOrLog.swift */; };
+		A100000042 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000042 /* AppState.swift */; };
+		A100000043 /* AnalysisCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000043 /* AnalysisCoordinator.swift */; };
+		A100000044 /* SidecarWriteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000044 /* SidecarWriteService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -132,6 +136,10 @@
 		B100000037 /* KeySyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeySyncService.swift; sourceTree = "<group>"; };
 		B100000038 /* AIAnalysisService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIAnalysisService.swift; sourceTree = "<group>"; };
 		B100000040 /* ActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityView.swift; sourceTree = "<group>"; };
+		B100000041 /* ModelContext+SaveOrLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ModelContext+SaveOrLog.swift"; sourceTree = "<group>"; };
+		B100000042 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		B100000043 /* AnalysisCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisCoordinator.swift; sourceTree = "<group>"; };
+		B100000044 /* SidecarWriteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidecarWriteService.swift; sourceTree = "<group>"; };
 		C100000001 /* SnapGrid.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SnapGrid.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC1856679647210724D1E66B /* TestTags.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestTags.swift; sourceTree = "<group>"; };
 		D03B2C30D0292058D69AC3B2 /* ShareImportServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShareImportServiceTests.swift; sourceTree = "<group>"; };
@@ -270,6 +278,7 @@
 			children = (
 				B100000001 /* SnapGridApp.swift */,
 				B100000002 /* ContentView.swift */,
+				B100000042 /* AppState.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -310,6 +319,8 @@
 				B100000036 /* KeySyncCrypto.swift */,
 				B100000037 /* KeySyncService.swift */,
 				B100000038 /* AIAnalysisService.swift */,
+				B100000043 /* AnalysisCoordinator.swift */,
+				B100000044 /* SidecarWriteService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -318,6 +329,7 @@
 			isa = PBXGroup;
 			children = (
 				B100000009 /* Color+SnapGrid.swift */,
+				B100000041 /* ModelContext+SaveOrLog.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -578,6 +590,10 @@
 				A100000037 /* KeySyncService.swift in Sources */,
 				A100000038 /* AIAnalysisService.swift in Sources */,
 				A100000040 /* ActivityView.swift in Sources */,
+				A100000041 /* ModelContext+SaveOrLog.swift in Sources */,
+				A100000042 /* AppState.swift in Sources */,
+				A100000043 /* AnalysisCoordinator.swift in Sources */,
+				A100000044 /* SidecarWriteService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/SnapGrid/SnapGrid/App/AppState.swift
+++ b/ios/SnapGrid/SnapGrid/App/AppState.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+@Observable
+@MainActor
+final class AppState {
+    var selectedIndex: Int?
+    var selectedItemId: String?
+    var sourceRect: CGRect = .zero
+    var thumbnailImage: UIImage?
+    var showOverlay = false
+    var activeSpaceId: String? = nil
+    var searchText = ""
+    var isSearchActive = false
+    var searchScores: [String: Double] = [:]
+    var currentPage: Int? = 0
+    var showPhotosPicker = false
+    var showFilesPicker = false
+    var isImporting = false
+    var itemToDelete: MediaItem?
+    var shareItem: URL?
+}

--- a/ios/SnapGrid/SnapGrid/Extensions/ModelContext+SaveOrLog.swift
+++ b/ios/SnapGrid/SnapGrid/Extensions/ModelContext+SaveOrLog.swift
@@ -1,0 +1,16 @@
+import SwiftData
+
+extension ModelContext {
+    /// Saves and logs failures instead of silently swallowing them.
+    /// In DEBUG builds, triggers an assertion so developers notice immediately.
+    func saveOrLog(file: String = #file, line: Int = #line) {
+        do {
+            try save()
+        } catch {
+            print("[SwiftData] Save failed at \(file):\(line): \(error)")
+            #if DEBUG
+            assertionFailure("SwiftData save failed: \(error)")
+            #endif
+        }
+    }
+}

--- a/ios/SnapGrid/SnapGrid/Services/AnalysisCoordinator.swift
+++ b/ios/SnapGrid/SnapGrid/Services/AnalysisCoordinator.swift
@@ -1,0 +1,147 @@
+import AVFoundation
+import SwiftData
+import UIKit
+
+/// Coordinates AI analysis of media items, extracting this logic from MainView.
+@Observable
+@MainActor
+final class AnalysisCoordinator {
+    private var analysisTask: Task<Void, Never>?
+
+    /// Analyze all unanalyzed items, or re-analyze a single item.
+    func analyzeItems(
+        _ items: [MediaItem],
+        keySyncService: KeySyncService,
+        fileSystem: FileSystemManager,
+        modelContext: ModelContext,
+        searchService: SearchIndexService,
+        allItems: [MediaItem]
+    ) {
+        guard keySyncService.isUnlocked else {
+            print("[Analysis] Skipped — keySyncService not unlocked")
+            return
+        }
+        guard let providerStr = keySyncService.activeProvider,
+              let provider = AIProvider(rawValue: providerStr) else {
+            print("[Analysis] Skipped — no active provider")
+            return
+        }
+        guard let apiKey = keySyncService.activeAPIKey() else {
+            print("[Analysis] Skipped — no API key for provider \(providerStr)")
+            return
+        }
+        guard let rootURL = fileSystem.rootURL else {
+            print("[Analysis] Skipped — no rootURL")
+            return
+        }
+
+        let model = keySyncService.activeModel ?? provider.defaultModel
+        let resolvedModel = (model == "auto") ? provider.defaultModel : model
+
+        guard !items.isEmpty else {
+            print("[Analysis] No items to analyze")
+            return
+        }
+
+        print("[Analysis] Starting analysis of \(items.count) item(s)")
+
+        analysisTask?.cancel()
+        analysisTask = Task {
+            for item in items {
+                guard !Task.isCancelled else { break }
+
+                item.isAnalyzing = true
+                do {
+                    let image = try loadImage(for: item, rootURL: rootURL)
+
+                    let (guidance, spaceContext) = resolveGuidance(for: item)
+
+                    let result = try await AIAnalysisService.shared.analyze(
+                        image: image,
+                        provider: provider,
+                        model: resolvedModel,
+                        apiKey: apiKey,
+                        guidance: guidance,
+                        spaceContext: spaceContext
+                    )
+                    item.analysisResult = result
+                    item.isAnalyzing = false
+                    item.analysisError = nil
+
+                    SidecarWriteService.writeAnalysis(for: item, rootURL: rootURL)
+                    searchService.buildIndex(items: allItems)
+                    modelContext.saveOrLog()
+                    print("[Analysis] Completed: \(item.id)")
+                } catch {
+                    item.isAnalyzing = false
+                    item.analysisError = error.localizedDescription
+                    print("[Analysis] Failed for \(item.id): \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    /// Find and analyze all unanalyzed items.
+    func analyzeUnanalyzed(
+        keySyncService: KeySyncService,
+        fileSystem: FileSystemManager,
+        modelContext: ModelContext,
+        searchService: SearchIndexService,
+        allItems: [MediaItem]
+    ) {
+        let descriptor = FetchDescriptor<MediaItem>()
+        let allCurrentItems = (try? modelContext.fetch(descriptor)) ?? []
+        let unanalyzed = allCurrentItems.filter {
+            $0.analysisResult == nil && !$0.isAnalyzing && $0.analysisError == nil
+        }
+
+        analyzeItems(
+            unanalyzed,
+            keySyncService: keySyncService,
+            fileSystem: fileSystem,
+            modelContext: modelContext,
+            searchService: searchService,
+            allItems: allItems
+        )
+    }
+
+    // MARK: - Private Helpers
+
+    private func loadImage(for item: MediaItem, rootURL: URL) throws -> UIImage {
+        let fileURL = rootURL.appendingPathComponent("images/\(item.filename)")
+        if item.isVideo {
+            let asset = AVURLAsset(url: fileURL)
+            let generator = AVAssetImageGenerator(asset: asset)
+            generator.appliesPreferredTrackTransform = true
+            generator.maximumSize = CGSize(width: 1280, height: 1280)
+            let cgImage = try generator.copyCGImage(at: CMTime(seconds: 1, preferredTimescale: 600), actualTime: nil)
+            return UIImage(cgImage: cgImage)
+        } else {
+            guard let data = try? Data(contentsOf: fileURL),
+                  let image = UIImage(data: data) else {
+                throw AIAnalysisService.AnalysisError.imageConversionFailed
+            }
+            return image
+        }
+    }
+
+    private func resolveGuidance(for item: MediaItem) -> (guidance: String?, spaceContext: String?) {
+        var guidance: String?
+        var spaceContext: String?
+
+        if let space = item.space {
+            spaceContext = "This image belongs to a collection called \"\(space.name)\". Use this as context to inform your analysis."
+            if space.useCustomPrompt, let custom = space.customPrompt, !custom.isEmpty {
+                guidance = custom
+            }
+        }
+        if guidance == nil, UserDefaults.standard.bool(forKey: "useAllSpacePrompt") {
+            let allGuidance = UserDefaults.standard.string(forKey: "allSpacePrompt") ?? ""
+            if !allGuidance.isEmpty {
+                guidance = allGuidance
+            }
+        }
+
+        return (guidance, spaceContext)
+    }
+}

--- a/ios/SnapGrid/SnapGrid/Services/SidecarWriteService.swift
+++ b/ios/SnapGrid/SnapGrid/Services/SidecarWriteService.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Centralizes all sidecar JSON write operations for the iOS app.
+/// Merges the previously duplicated writeSidecarSpaceId and updateSidecarSpaceId methods.
+enum SidecarWriteService {
+
+    /// Update the spaceId field in a media item's sidecar JSON.
+    /// Removes the key when spaceId is nil (not NSNull — that was a bug).
+    static func writeSpaceId(for item: MediaItem, rootURL: URL) {
+        let sidecarURL = rootURL.appendingPathComponent("metadata/\(item.id).json")
+
+        guard let existingData = try? Data(contentsOf: sidecarURL),
+              var json = try? JSONSerialization.jsonObject(with: existingData) as? [String: Any] else {
+            return
+        }
+
+        if let spaceId = item.space?.id {
+            json["spaceId"] = spaceId
+        } else {
+            json.removeValue(forKey: "spaceId")
+        }
+
+        if let updatedData = try? JSONSerialization.data(
+            withJSONObject: json,
+            options: [.prettyPrinted, .sortedKeys]
+        ) {
+            try? updatedData.write(to: sidecarURL, options: .atomic)
+        }
+    }
+
+    /// Write analysis results back to a media item's sidecar JSON.
+    static func writeAnalysis(for item: MediaItem, rootURL: URL) {
+        let sidecarURL = rootURL.appendingPathComponent("metadata/\(item.id).json")
+
+        guard let existingData = try? Data(contentsOf: sidecarURL),
+              var json = try? JSONSerialization.jsonObject(with: existingData) as? [String: Any] else {
+            return
+        }
+
+        if let result = item.analysisResult {
+            json["imageContext"] = result.imageContext
+            json["imageSummary"] = result.imageSummary
+            json["patterns"] = result.patterns.map { ["name": $0.name, "confidence": $0.confidence] }
+        }
+
+        if let updatedData = try? JSONSerialization.data(
+            withJSONObject: json,
+            options: [.prettyPrinted, .sortedKeys]
+        ) {
+            try? updatedData.write(to: sidecarURL, options: .atomic)
+        }
+    }
+}

--- a/ios/SnapGrid/SnapGrid/Services/SyncService.swift
+++ b/ios/SnapGrid/SnapGrid/Services/SyncService.swift
@@ -181,7 +181,7 @@ final class SyncService {
 
             // Yield periodically
             if imported % 20 == 0 && imported > 0 {
-                try? context.save()
+                context.saveOrLog()
                 await Task.yield()
             }
         }
@@ -191,7 +191,7 @@ final class SyncService {
             context.delete(orphan)
         }
 
-        try? context.save()
+        context.saveOrLog()
         print("[SyncService] Sync complete: \(imported) new, \(skipped) pending iCloud, \(existingById.count) removed")
         return skipped
     }
@@ -246,7 +246,7 @@ final class SyncService {
             context.delete(orphan)
         }
 
-        try? context.save()
+        context.saveOrLog()
     }
 
     // MARK: - Update Helpers

--- a/ios/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -94,11 +94,7 @@ struct GridItemView: View {
                     )
 
                     HStack {
-                        ShimmerText("Analyzing...")
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 3)
-                            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10))
-                            .environment(\.colorScheme, .dark)
+                        shimmerBadge
                         Spacer()
                     }
                     .padding(8)
@@ -201,6 +197,23 @@ struct GridItemView: View {
     }
 
     // MARK: - Thumbnail Loading
+
+    @ViewBuilder
+    private var shimmerBadge: some View {
+        let base = ShimmerText("Analyzing...")
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+
+        if #available(iOS 26, *) {
+            base
+                .glassEffect(.regular, in: .rect(cornerRadius: 10))
+                .environment(\.colorScheme, .dark)
+        } else {
+            base
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10))
+                .environment(\.colorScheme, .dark)
+        }
+    }
 
     private func loadThumbnail() async {
         let cache = ThumbnailCache.shared

--- a/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
@@ -1,4 +1,3 @@
-import AVFoundation
 import SwiftUI
 import SwiftData
 
@@ -54,36 +53,22 @@ struct MainView: View {
     @Environment(\.scenePhase) private var scenePhase
     @Query(sort: \MediaItem.createdAt, order: .reverse) private var allItems: [MediaItem]
     @Query(sort: \Space.order) private var spaces: [Space]
-    @State private var selectedIndex: Int?
-    @State private var selectedItemId: String?
-    @State private var sourceRect: CGRect = .zero
-    @State private var thumbnailImage: UIImage?
-    @State private var showOverlay = false
-    @State private var activeSpaceId: String? = nil
-    @State private var searchText = ""
+    @State private var appState = AppState()
     @State private var gridItemRects: [String: CGRect] = [:]
     @State private var isLoading = true
     @State private var error: String?
     @State private var hasAttemptedRescan = false
     @State private var tabScrollProgress: CGFloat = 0
     @State private var prefetchTask: Task<Void, Never>?
-    @State private var analysisTask: Task<Void, Never>?
     @State private var syncService = SyncService()
     @State private var searchService = SearchIndexService()
+    @State private var analysisCoordinator = AnalysisCoordinator()
     @State private var debounceTask: Task<Void, Never>?
-    @State private var searchScores: [String: Double] = [:]
-    @State private var isSearchActive = false
-    @State private var currentPage: Int? = 0
-    @State private var showPhotosPicker = false
-    @State private var showFilesPicker = false
-    @State private var isImporting = false
-    @State private var itemToDelete: MediaItem?
-    @State private var shareItem: URL?
 
     // MARK: - Index ↔ activeSpaceId bridging
 
     private var activeIndex: Int {
-        guard let id = activeSpaceId else { return 0 }
+        guard let id = appState.activeSpaceId else { return 0 }
         return (spaces.firstIndex { $0.id == id } ?? -1) + 1
     }
 
@@ -97,11 +82,11 @@ struct MainView: View {
             items = Array(allItems)
         }
 
-        guard isSearchActive else { return items }
+        guard appState.isSearchActive else { return items }
 
-        let scores = searchScores
+        let scores = appState.searchScores
         guard !scores.isEmpty else {
-            let query = searchText.lowercased().trimmingCharacters(in: .whitespaces)
+            let query = appState.searchText.lowercased().trimmingCharacters(in: .whitespaces)
             if query == "vid" { return items.filter { $0.isVideo } }
             if query == "img" { return items.filter { !$0.isVideo } }
             return []
@@ -117,7 +102,7 @@ struct MainView: View {
     }
 
     private var currentVisibleItems: [MediaItem] {
-        itemsForSpace(activeSpaceId)
+        itemsForSpace(appState.activeSpaceId)
     }
 
     // MARK: - Body
@@ -142,18 +127,18 @@ struct MainView: View {
                         EmptyStateView()
                     } else if spaces.isEmpty {
                         let items = itemsForSpace(nil)
-                        if items.isEmpty && isSearchActive {
+                        if items.isEmpty && appState.isSearchActive {
                             SearchEmptyStateView()
                         } else {
                             ScrollView {
                                 MasonryGrid(
                                     items: items,
                                     availableWidth: gridWidth,
-                                    selectedItemId: showOverlay ? selectedItemId : nil,
+                                    selectedItemId: appState.showOverlay ? appState.selectedItemId : nil,
                                     onItemSelected: handleItemSelected,
                                     onRetryAnalysis: handleRetryAnalysis,
                                     onShareItem: handleShareItem,
-                                    onDeleteItem: { item in itemToDelete = item }
+                                    onDeleteItem: { item in appState.itemToDelete = item }
                                 )
                                 .padding(.horizontal, 12)
                                 .padding(.bottom, 70)
@@ -167,7 +152,7 @@ struct MainView: View {
                         VStack(spacing: 0) {
                             SpaceTabBar(
                                 spaces: spaces,
-                                activeSpaceId: $activeSpaceId,
+                                activeSpaceId: $appState.activeSpaceId,
                                 scrollProgress: tabScrollProgress,
                                 onAssignToSpace: handleAssignToSpace
                             )
@@ -175,7 +160,7 @@ struct MainView: View {
                             ScrollView(.horizontal, showsIndicators: false) {
                                 HStack(spacing: 0) {
                                     let allPageItems = itemsForSpace(nil)
-                                    if allPageItems.isEmpty && isSearchActive {
+                                    if allPageItems.isEmpty && appState.isSearchActive {
                                         SearchEmptyStateView()
                                             .containerRelativeFrame(.horizontal)
                                             .id(0)
@@ -185,11 +170,11 @@ struct MainView: View {
                                             MasonryGrid(
                                                 items: allPageItems,
                                                 availableWidth: gridWidth,
-                                                selectedItemId: showOverlay ? selectedItemId : nil,
+                                                selectedItemId: appState.showOverlay ? appState.selectedItemId : nil,
                                                 onItemSelected: handleItemSelected,
                                                 onRetryAnalysis: handleRetryAnalysis,
                                                 onShareItem: handleShareItem,
-                                                onDeleteItem: { item in itemToDelete = item }
+                                                onDeleteItem: { item in appState.itemToDelete = item }
                                             )
                                             .padding(.horizontal, 12)
                                             .padding(.top, 12)
@@ -203,7 +188,7 @@ struct MainView: View {
 
                                     ForEach(Array(spaces.enumerated()), id: \.element.id) { index, space in
                                         let spaceItems = itemsForSpace(space.id)
-                                        if spaceItems.isEmpty && isSearchActive {
+                                        if spaceItems.isEmpty && appState.isSearchActive {
                                             SearchEmptyStateView()
                                                 .containerRelativeFrame(.horizontal)
                                                 .id(index + 1)
@@ -213,12 +198,12 @@ struct MainView: View {
                                                 MasonryGrid(
                                                     items: spaceItems,
                                                     availableWidth: gridWidth,
-                                                    selectedItemId: showOverlay ? selectedItemId : nil,
+                                                    selectedItemId: appState.showOverlay ? appState.selectedItemId : nil,
                                                     onItemSelected: handleItemSelected,
                                                     onRetryAnalysis: handleRetryAnalysis,
                                                     onShareItem: handleShareItem,
                                                     onRemoveFromSpace: handleRemoveFromSpace,
-                                                    onDeleteItem: { item in itemToDelete = item }
+                                                    onDeleteItem: { item in appState.itemToDelete = item }
                                                 )
                                                 .padding(.horizontal, 12)
                                                 .padding(.top, 12)
@@ -234,7 +219,7 @@ struct MainView: View {
                                 .scrollTargetLayout()
                             }
                             .scrollTargetBehavior(.paging)
-                            .scrollPosition(id: $currentPage)
+                            .scrollPosition(id: $appState.currentPage)
                             .coordinateSpace(name: "pagerContainer")
                             .onPreferenceChange(PageOffsetPreferenceKey.self) { data in
                                 guard let data = data else { return }
@@ -254,16 +239,16 @@ struct MainView: View {
                         DefaultToolbarItem(kind: .search, placement: .bottomBar)
                         ToolbarSpacer(.flexible, placement: .bottomBar)
                         ToolbarItem(placement: .bottomBar) {
-                            if isSearchActive {
-                                CloseSearchButton(searchText: $searchText)
+                            if appState.isSearchActive {
+                                CloseSearchButton(searchText: $appState.searchText)
                             } else {
                                 addImagesMenu
                             }
                         }
                     } else {
                         ToolbarItem(placement: .topBarTrailing) {
-                            if isSearchActive {
-                                CloseSearchButton(searchText: $searchText)
+                            if appState.isSearchActive {
+                                CloseSearchButton(searchText: $appState.searchText)
                             } else {
                                 addImagesMenu
                             }
@@ -271,35 +256,35 @@ struct MainView: View {
                     }
                 }
                 .toolbarColorScheme(.dark, for: .navigationBar)
-                .searchable(text: $searchText, prompt: "Search patterns, context...")
+                .searchable(text: $appState.searchText, prompt: "Search patterns, context...")
                 .onPreferenceChange(GridItemRectsPreferenceKey.self) { rects in
                     gridItemRects = rects
                 }
             }
             .overlay {
-                if showOverlay, let startIndex = selectedIndex {
+                if appState.showOverlay, let startIndex = appState.selectedIndex {
                     FullScreenImageOverlay(
                         items: currentVisibleItems,
                         startIndex: startIndex,
-                        sourceRect: sourceRect,
+                        sourceRect: appState.sourceRect,
                         screenSize: geo.size,
-                        thumbnailImage: thumbnailImage,
+                        thumbnailImage: appState.thumbnailImage,
                         gridItemRects: $gridItemRects,
                         onDismissing: { currentItemId in
-                            selectedItemId = currentItemId
+                            appState.selectedItemId = currentItemId
                         },
                         onClose: {
                             var t = Transaction()
                             t.disablesAnimations = true
                             withTransaction(t) {
-                                showOverlay = false
-                                selectedIndex = nil
-                                selectedItemId = nil
-                                thumbnailImage = nil
+                                appState.showOverlay = false
+                                appState.selectedIndex = nil
+                                appState.selectedItemId = nil
+                                appState.thumbnailImage = nil
                             }
                         },
                         onSearchPattern: { pattern in
-                            searchText = pattern
+                            appState.searchText = pattern
                         },
                         onDelete: handleItemDeleted
                     )
@@ -309,27 +294,27 @@ struct MainView: View {
         .task {
             await loadContent()
         }
-        .onChange(of: searchText) { _, newValue in
+        .onChange(of: appState.searchText) { _, newValue in
             debounceTask?.cancel()
             let trimmed = newValue.trimmingCharacters(in: .whitespaces)
             if trimmed.isEmpty {
-                isSearchActive = false
-                searchScores = [:]
+                appState.isSearchActive = false
+                appState.searchScores = [:]
             } else {
-                isSearchActive = true
+                appState.isSearchActive = true
                 debounceTask = Task { @MainActor in
                     try? await Task.sleep(for: .milliseconds(100))
                     guard !Task.isCancelled else { return }
 
                     let lowered = trimmed.lowercased()
                     if lowered == "vid" || lowered == "img" {
-                        searchScores = [:]
+                        appState.searchScores = [:]
                         return
                     }
 
                     let results = searchService.search(query: trimmed)
                     guard !Task.isCancelled else { return }
-                    searchScores = Dictionary(uniqueKeysWithValues: results.map { ($0.itemId, $0.score) })
+                    appState.searchScores = Dictionary(uniqueKeysWithValues: results.map { ($0.itemId, $0.score) })
                 }
             }
         }
@@ -344,37 +329,37 @@ struct MainView: View {
                 Task { await loadContent() }
             }
         }
-        .onChange(of: currentPage) { _, newPage in
+        .onChange(of: appState.currentPage) { _, newPage in
             let page = newPage ?? 0
             if page == 0 {
-                activeSpaceId = nil
+                appState.activeSpaceId = nil
             } else if page > 0 && page <= spaces.count {
-                activeSpaceId = spaces[page - 1].id
+                appState.activeSpaceId = spaces[page - 1].id
             }
         }
-        .onChange(of: activeSpaceId) { _, _ in
+        .onChange(of: appState.activeSpaceId) { _, _ in
             let target = activeIndex
-            if currentPage != target {
+            if appState.currentPage != target {
                 withAnimation(SnapSpring.resolvedStandard) {
-                    currentPage = target
+                    appState.currentPage = target
                 }
             }
         }
-        .sheet(isPresented: $showPhotosPicker) {
+        .sheet(isPresented: $appState.showPhotosPicker) {
             PhotosPickerWrapper { images in
                 handlePickedImages(images)
             }
         }
-        .sheet(isPresented: $showFilesPicker) {
+        .sheet(isPresented: $appState.showFilesPicker) {
             DocumentPickerWrapper { images in
                 handlePickedImages(images)
             }
         }
         .sheet(isPresented: Binding(
-            get: { shareItem != nil },
-            set: { if !$0 { shareItem = nil } }
+            get: { appState.shareItem != nil },
+            set: { if !$0 { appState.shareItem = nil } }
         )) {
-            if let url = shareItem {
+            if let url = appState.shareItem {
                 ActivityView(activityItems: [url])
                     .presentationDetents([.medium, .large])
             }
@@ -382,15 +367,15 @@ struct MainView: View {
         .confirmationDialog(
             "Delete this item?",
             isPresented: Binding(
-                get: { itemToDelete != nil },
-                set: { if !$0 { itemToDelete = nil } }
+                get: { appState.itemToDelete != nil },
+                set: { if !$0 { appState.itemToDelete = nil } }
             ),
             titleVisibility: .visible
         ) {
             Button("Delete", role: .destructive) {
-                if let item = itemToDelete {
+                if let item = appState.itemToDelete {
                     handleItemDeleted(item)
-                    itemToDelete = nil
+                    appState.itemToDelete = nil
                 }
             }
         }
@@ -401,19 +386,19 @@ struct MainView: View {
     private var addImagesMenu: some View {
         Menu {
             Button {
-                showPhotosPicker = true
+                appState.showPhotosPicker = true
             } label: {
                 Label("Choose from Photos", systemImage: "photo.on.rectangle")
             }
             Button {
-                showFilesPicker = true
+                appState.showFilesPicker = true
             } label: {
                 Label("Choose from Files", systemImage: "folder")
             }
         } label: {
             Label("Add", systemImage: "plus")
         }
-        .disabled(isImporting || fileSystem.rootURL == nil)
+        .disabled(appState.isImporting || fileSystem.rootURL == nil)
     }
 
     // MARK: - Item Selection
@@ -421,11 +406,11 @@ struct MainView: View {
     private func handleItemSelected(_ item: MediaItem, _ rect: CGRect, _ thumb: UIImage?) {
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
         let visibleItems = currentVisibleItems
-        selectedIndex = visibleItems.firstIndex(where: { $0.id == item.id }) ?? 0
-        selectedItemId = item.id
-        sourceRect = rect
-        thumbnailImage = thumb
-        showOverlay = true
+        appState.selectedIndex = visibleItems.firstIndex(where: { $0.id == item.id }) ?? 0
+        appState.selectedItemId = item.id
+        appState.sourceRect = rect
+        appState.thumbnailImage = thumb
+        appState.showOverlay = true
     }
 
     // MARK: - Space Assignment (Drag & Drop)
@@ -442,36 +427,14 @@ struct MainView: View {
             spaces.first(where: { $0.id == sid })
         }
         item.space = space
-        try? modelContext.save()
+        modelContext.saveOrLog()
 
         // Persist to sidecar JSON for iCloud sync
         if let rootURL = fileSystem.rootURL {
-            writeSidecarSpaceId(for: item, rootURL: rootURL)
+            SidecarWriteService.writeSpaceId(for: item, rootURL: rootURL)
         }
 
         UINotificationFeedbackGenerator().notificationOccurred(.success)
-    }
-
-    private func writeSidecarSpaceId(for item: MediaItem, rootURL: URL) {
-        let sidecarURL = rootURL.appendingPathComponent("metadata/\(item.id).json")
-
-        guard let existingData = try? Data(contentsOf: sidecarURL),
-              var json = try? JSONSerialization.jsonObject(with: existingData) as? [String: Any] else {
-            return
-        }
-
-        if let spaceId = item.space?.id {
-            json["spaceId"] = spaceId
-        } else {
-            json.removeValue(forKey: "spaceId")
-        }
-
-        if let updatedData = try? JSONSerialization.data(
-            withJSONObject: json,
-            options: [.prettyPrinted, .sortedKeys]
-        ) {
-            try? updatedData.write(to: sidecarURL, options: .atomic)
-        }
     }
 
     // MARK: - Item Deletion
@@ -483,7 +446,7 @@ struct MainView: View {
             )
         }
         modelContext.delete(item)
-        try? modelContext.save()
+        modelContext.saveOrLog()
     }
 
     // MARK: - Item Sharing
@@ -495,9 +458,9 @@ struct MainView: View {
         try? FileManager.default.removeItem(at: tempURL)
         do {
             try FileManager.default.copyItem(at: url, to: tempURL)
-            shareItem = tempURL
+            appState.shareItem = tempURL
         } catch {
-            shareItem = url
+            appState.shareItem = url
         }
     }
 
@@ -506,28 +469,10 @@ struct MainView: View {
     private func handleRemoveFromSpace(_ item: MediaItem) {
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
         item.space = nil
-        try? modelContext.save()
+        modelContext.saveOrLog()
 
         if let rootURL = fileSystem.rootURL {
-            updateSidecarSpaceId(for: item, rootURL: rootURL)
-        }
-    }
-
-    private func updateSidecarSpaceId(for item: MediaItem, rootURL: URL) {
-        let metadataDir = rootURL.appendingPathComponent("metadata")
-        let sidecarURL = metadataDir.appendingPathComponent("\(item.id).json")
-
-        guard let existingData = try? Data(contentsOf: sidecarURL) else { return }
-        guard var json = try? JSONSerialization.jsonObject(with: existingData) as? [String: Any] else { return }
-
-        if let space = item.space {
-            json["spaceId"] = space.id
-        } else {
-            json["spaceId"] = NSNull()
-        }
-
-        if let updatedData = try? JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys]) {
-            try? updatedData.write(to: sidecarURL, options: .atomic)
+            SidecarWriteService.writeSpaceId(for: item, rootURL: rootURL)
         }
     }
 
@@ -536,12 +481,12 @@ struct MainView: View {
     private func handlePickedImages(_ images: [UIImage]) {
         guard !images.isEmpty, let rootURL = fileSystem.rootURL else { return }
 
-        isImporting = true
+        appState.isImporting = true
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
 
         Task {
-            let result = await ImageImportService.importImages(images, to: rootURL, spaceId: activeSpaceId)
-            isImporting = false
+            let result = await ImageImportService.importImages(images, to: rootURL, spaceId: appState.activeSpaceId)
+            appState.isImporting = false
 
             if result.successCount > 0 {
                 UINotificationFeedbackGenerator().notificationOccurred(.success)
@@ -557,6 +502,14 @@ struct MainView: View {
     private func loadContent() async {
         let isInitialLoad = isLoading
         error = nil
+
+        // Reset any isAnalyzing flags stuck from a previous crash/kill
+        let stuckDescriptor = FetchDescriptor<MediaItem>(predicate: #Predicate { $0.isAnalyzing == true })
+        if let stuck = try? modelContext.fetch(stuckDescriptor), !stuck.isEmpty {
+            for item in stuck { item.isAnalyzing = false }
+            modelContext.saveOrLog()
+            print("[Cleanup] Reset \(stuck.count) stuck isAnalyzing flags")
+        }
 
         guard let rootURL = fileSystem.rootURL else {
             self.error = "No access to SnapGrid folder"
@@ -577,7 +530,13 @@ struct MainView: View {
         prefetchTask = ThumbnailCache.shared.prefetchThumbnails(for: allItems, targetPixelWidth: columnWidth * 2)
 
         // Analyze unanalyzed items if API keys are available
-        analyzeUnanalyzedItems()
+        analysisCoordinator.analyzeUnanalyzed(
+            keySyncService: keySyncService,
+            fileSystem: fileSystem,
+            modelContext: modelContext,
+            searchService: searchService,
+            allItems: allItems
+        )
 
         // Re-scan if some iCloud files were still downloading
         if skipped > 0 && !hasAttemptedRescan {
@@ -594,204 +553,14 @@ struct MainView: View {
     private func handleRetryAnalysis(_ item: MediaItem) {
         item.analysisError = nil
         item.analysisResult = nil
-        try? modelContext.save()
-        analyzeSingleItem(item)
-    }
-
-    // MARK: - AI Analysis
-
-    private func analyzeUnanalyzedItems() {
-        guard keySyncService.isUnlocked else {
-            print("[Analysis] Skipped — keySyncService not unlocked")
-            return
-        }
-        guard let providerStr = keySyncService.activeProvider,
-              let provider = AIProvider(rawValue: providerStr) else {
-            print("[Analysis] Skipped — no active provider")
-            return
-        }
-        guard let apiKey = keySyncService.activeAPIKey() else {
-            print("[Analysis] Skipped — no API key for provider \(providerStr)")
-            return
-        }
-        guard let rootURL = fileSystem.rootURL else {
-            print("[Analysis] Skipped — no rootURL")
-            return
-        }
-
-        let model = keySyncService.activeModel ?? provider.defaultModel
-        let resolvedModel = (model == "auto") ? provider.defaultModel : model
-
-        // Query model context directly — @Query may not have refreshed yet after sync
-        let descriptor = FetchDescriptor<MediaItem>()
-        let allCurrentItems = (try? modelContext.fetch(descriptor)) ?? []
-        let unanalyzed = allCurrentItems.filter { $0.analysisResult == nil && !$0.isAnalyzing && $0.analysisError == nil }
-        guard !unanalyzed.isEmpty else {
-            print("[Analysis] No unanalyzed items found (total: \(allCurrentItems.count))")
-            return
-        }
-
-        print("[Analysis] Found \(unanalyzed.count) unanalyzed items, starting analysis")
-
-        analysisTask?.cancel()
-        analysisTask = Task {
-            for item in unanalyzed {
-                guard !Task.isCancelled else { break }
-
-                item.isAnalyzing = true
-                do {
-                    let image: UIImage
-                    if item.isVideo {
-                        image = try extractPosterFrame(for: item, rootURL: rootURL)
-                    } else {
-                        image = try loadImage(for: item, rootURL: rootURL)
-                    }
-
-                    // Resolve guidance and space context
-                    var guidance: String?
-                    var spaceContext: String?
-                    if let space = item.space {
-                        spaceContext = "This image belongs to a collection called \"\(space.name)\". Use this as context to inform your analysis."
-                        if space.useCustomPrompt, let custom = space.customPrompt, !custom.isEmpty {
-                            guidance = custom
-                        }
-                    }
-                    // Fall back to all-space guidance if no per-space guidance is set
-                    if guidance == nil, UserDefaults.standard.bool(forKey: "useAllSpacePrompt") {
-                        let allGuidance = UserDefaults.standard.string(forKey: "allSpacePrompt") ?? ""
-                        if !allGuidance.isEmpty {
-                            guidance = allGuidance
-                        }
-                    }
-
-                    let result = try await AIAnalysisService.shared.analyze(
-                        image: image,
-                        provider: provider,
-                        model: resolvedModel,
-                        apiKey: apiKey,
-                        guidance: guidance,
-                        spaceContext: spaceContext
-                    )
-                    item.analysisResult = result
-                    item.isAnalyzing = false
-
-                    // Write back to sidecar JSON so Mac picks up the analysis
-                    writeSidecar(for: item, rootURL: rootURL)
-
-                    // Rebuild search index to include new analysis
-                    searchService.buildIndex(items: allItems)
-
-                    try? modelContext.save()
-                    print("[Analysis] Completed: \(item.id)")
-                } catch {
-                    item.isAnalyzing = false
-                    item.analysisError = error.localizedDescription
-                    print("[Analysis] Failed for \(item.id): \(error.localizedDescription)")
-                }
-            }
-        }
-    }
-
-    private func analyzeSingleItem(_ item: MediaItem) {
-        guard keySyncService.isUnlocked else { return }
-        guard let providerStr = keySyncService.activeProvider,
-              let provider = AIProvider(rawValue: providerStr) else { return }
-        guard let apiKey = keySyncService.activeAPIKey() else { return }
-        guard let rootURL = fileSystem.rootURL else { return }
-
-        let model = keySyncService.activeModel ?? provider.defaultModel
-        let resolvedModel = (model == "auto") ? provider.defaultModel : model
-
-        Task {
-            item.isAnalyzing = true
-            do {
-                let image: UIImage
-                if item.isVideo {
-                    image = try extractPosterFrame(for: item, rootURL: rootURL)
-                } else {
-                    image = try loadImage(for: item, rootURL: rootURL)
-                }
-
-                var guidance: String?
-                var spaceContext: String?
-                if let space = item.space {
-                    spaceContext = "This image belongs to a collection called \"\(space.name)\". Use this as context to inform your analysis."
-                    if space.useCustomPrompt, let custom = space.customPrompt, !custom.isEmpty {
-                        guidance = custom
-                    }
-                }
-                if guidance == nil, UserDefaults.standard.bool(forKey: "useAllSpacePrompt") {
-                    let allGuidance = UserDefaults.standard.string(forKey: "allSpacePrompt") ?? ""
-                    if !allGuidance.isEmpty {
-                        guidance = allGuidance
-                    }
-                }
-
-                let result = try await AIAnalysisService.shared.analyze(
-                    image: image,
-                    provider: provider,
-                    model: resolvedModel,
-                    apiKey: apiKey,
-                    guidance: guidance,
-                    spaceContext: spaceContext
-                )
-                item.analysisResult = result
-                item.isAnalyzing = false
-                item.analysisError = nil
-                writeSidecar(for: item, rootURL: rootURL)
-                searchService.buildIndex(items: allItems)
-                try? modelContext.save()
-                print("[Analysis] Redo completed: \(item.id)")
-            } catch {
-                item.isAnalyzing = false
-                item.analysisError = error.localizedDescription
-                print("[Analysis] Redo failed for \(item.id): \(error.localizedDescription)")
-            }
-        }
-    }
-
-    private func loadImage(for item: MediaItem, rootURL: URL) throws -> UIImage {
-        let imageURL = rootURL.appendingPathComponent("images/\(item.filename)")
-        guard let data = try? Data(contentsOf: imageURL),
-              let image = UIImage(data: data) else {
-            throw AIAnalysisService.AnalysisError.imageConversionFailed
-        }
-        return image
-    }
-
-    private func extractPosterFrame(for item: MediaItem, rootURL: URL) throws -> UIImage {
-        let videoURL = rootURL.appendingPathComponent("images/\(item.filename)")
-        let asset = AVURLAsset(url: videoURL)
-        let generator = AVAssetImageGenerator(asset: asset)
-        generator.appliesPreferredTrackTransform = true
-        generator.maximumSize = CGSize(width: 1280, height: 1280)
-        let cgImage = try generator.copyCGImage(at: CMTime(seconds: 1, preferredTimescale: 600), actualTime: nil)
-        return UIImage(cgImage: cgImage)
-    }
-
-    private func writeSidecar(for item: MediaItem, rootURL: URL) {
-        let metadataDir = rootURL.appendingPathComponent("metadata")
-        let sidecarURL = metadataDir.appendingPathComponent("\(item.id).json")
-
-        // Read existing sidecar to preserve all fields
-        guard let existingData = try? Data(contentsOf: sidecarURL) else { return }
-
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        guard var json = try? JSONSerialization.jsonObject(with: existingData) as? [String: Any] else { return }
-
-        // Add analysis fields
-        if let result = item.analysisResult {
-            json["imageContext"] = result.imageContext
-            json["imageSummary"] = result.imageSummary
-            json["patterns"] = result.patterns.map { ["name": $0.name, "confidence": $0.confidence] }
-        }
-
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-
-        if let updatedData = try? JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys]) {
-            try? updatedData.write(to: sidecarURL, options: .atomic)
-        }
+        modelContext.saveOrLog()
+        analysisCoordinator.analyzeItems(
+            [item],
+            keySyncService: keySyncService,
+            fileSystem: fileSystem,
+            modelContext: modelContext,
+            searchService: searchService,
+            allItems: allItems
+        )
     }
 }


### PR DESCRIPTION
### Why?

Both native apps have grown organically with fragile patterns — 29 `try? save()` calls silently swallowing data loss, a persisted `isAnalyzing` flag that gets stuck forever after crashes, duplicated sidecar write methods with inconsistent null handling (NSNull bug), and an iOS MainView with 30+ @State properties mixing UI and business logic that's impossible to test.

### How?

Decompose iOS MainView into AppState + AnalysisCoordinator + SidecarWriteService, replace all silent saves with a logging wrapper, add launch-time cleanup for stuck flags, centralize scattered file extension definitions, route Mac sidecar writes through MetadataSidecarService, clean orphaned sidecar JSONs on disk, and add View menu zoom controls with glass effect on iOS 26+.

<details>
<summary>Implementation Plan</summary>

# SnapGrid Native Apps — Refactoring Audit

## Context

Both native apps (Mac SwiftUI + iOS) have grown organically with significant code duplication between them (~1000+ duplicated lines), oversized "god views" that mix UI and business logic, and several fragile patterns that silently swallow errors. This audit identifies the highest-impact refactoring opportunities to improve reliability, prevent bugs, and make the codebase easier to build on — prioritized by impact-to-effort ratio.

---

## Phase 1: Extract iOS AppState + Service Layer

**Problem:** iOS `MainView.swift` (797 lines) has 30+ `@State` properties and ALL business logic inline — sync, analysis, sidecar writes, search, drag-and-drop. None of it is testable. The Mac app already has `AppState` as a separate `@Observable` class — iOS should match.

**Changes:**
1. Create `ios/.../App/AppState.swift` — move ~15 UI state properties (`selectedIndex`, `activeSpaceId`, `searchText`, `showOverlay`, etc.) into an `@Observable @MainActor` class
2. Create `ios/.../Services/AnalysisCoordinator.swift` — extract `analyzeUnanalyzedItems` + `analyzeSingleItem` (~150 duplicated lines in MainView become one method with a loop count parameter)
3. Create `ios/.../Services/SidecarWriteService.swift` — extract and **merge** `writeSidecarSpaceId` + `updateSidecarSpaceId` (these differ only in null handling — the `NSNull()` variant is a bug)
4. `MainView` becomes a thin rendering shell

**Key files:** `ios/SnapGrid/SnapGrid/Views/Main/MainView.swift`

**Why first:** Zero cross-platform risk, immediately makes iOS testable, prerequisite for Phase 3.

---

## Phase 2: Fix Silent Save Failures

**Problem:** 29 occurrences of `try? modelContext.save()` across both apps. Every one silently swallows data-loss errors (constraint violations, disk full, iCloud conflicts). Users get no feedback.

**Changes:**
1. Add `ModelContext.saveOrLog()` extension in each app — logs error, fires `assertionFailure` in DEBUG
2. Replace all 29 `try? ...save()` call sites (mechanical find-and-replace)
3. For critical user-facing paths (delete, import, space assignment), surface errors via toast

**Key files:** All service files + ContentView/MainView in both apps

**Why high priority:** Small change, immediate reliability improvement, fully independent.

---

## Phase 3: Extract Shared Swift Package (`SnapGridCore`) — NOT IN THIS PR

**Problem:** 1000+ lines duplicated byte-for-byte between apps. Deferred to a follow-up PR.

---

## Phase 4: Fix Stuck `isAnalyzing` Flag

**Problem:** `isAnalyzing: Bool` is a **persisted** SwiftData property. If the app crashes mid-analysis, it stays `true` forever, permanently blocking re-analysis of that item. Both apps filter with `!$0.isAnalyzing`.

**Quick fix (independent, do now):** Add cleanup on launch in both apps.

**Key files:** `ios/SnapGrid/SnapGrid/Models/MediaItem.swift`, `SnapGrid/SnapGrid/Models/MediaItem.swift`, app entry points

---

## Phase 5: Centralize Supported File Extensions

**Problem:** Supported extensions (`png, jpg, mp4, mov...`) defined in 4+ separate places on Mac. Adding a format requires updating all.

**Changes:**
1. Create `SupportedMedia` enum with `imageExtensions`, `videoExtensions`, `allExtensions`, and `importableContentTypes` (UTType list)
2. Replace all inline extension sets with references to `SupportedMedia`

---

## Phase 6: Consolidate Sidecar Write Paths

**Problem:** Mac has two sidecar writing patterns: proper Codable via `MetadataSidecarService` and manual `JSONSerialization` construction in `ContentView.createSpace`. iOS has its own manual JSON paths with inconsistent null handling (already addressed in Phase 1).

**Changes:**
1. Refactor Mac `ContentView.createSpace`/`deleteSpace` to use `MetadataSidecarService.writeSpaces(context:)` instead of manually constructing sidecar arrays
2. Ensure all sidecar mutations go through the service, not raw JSON in views

---

## Execution Order

```
Independent (do first, quick wins):
  Phase 2 — Fix silent save failures
  Phase 4 — Quick fix for stuck isAnalyzing
  Phase 5 — Centralize file extensions

Sequential (unlocks the rest):
  Phase 1 — iOS AppState extraction
  Phase 3 — Shared Swift package (requires Phase 1) — DEFERRED
  Phase 6 — Sidecar consolidation (requires Phase 1 for iOS)
```

</details>

<sub>Generated with Claude Code</sub>