### PR TITLE
Fix grid hover button glass effect flickering

### DIFF
--- a/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -457,21 +457,16 @@ struct GridItemView: View {
         }
     }
 
-    /// Circular hover-action button icon with glass on macOS 26+.
-    @ViewBuilder
+    /// Circular hover-action button icon with a static dark background.
+    /// Glass effect was removed because it adapts to the underlying image,
+    /// causing a visible dark→transparent shift when the button appears on hover.
     private func hoverButtonIcon(_ systemName: String, size: CGFloat) -> some View {
-        let base = Image(systemName: systemName)
+        Image(systemName: systemName)
             .font(.system(size: size, weight: .bold))
             .foregroundStyle(.white)
             .frame(width: 24, height: 24)
-
-        if #available(macOS 26, *) {
-            base.glassEffect(.regular.interactive(), in: .circle)
-        } else {
-            base
-                .background(.black.opacity(0.6))
-                .clipShape(Circle())
-        }
+            .background(.ultraThinMaterial, in: Circle())
+            .environment(\.colorScheme, .dark)
     }
 
     /// Retry analysis badge with red-tinted glass on macOS 26+.


### PR DESCRIPTION
### Why?

Grid item hover buttons (close, remove-from-space) use Liquid Glass which adapts to underlying image content, causing a visible dark-to-transparent color shift when the buttons appear on hover.

### How?

Replaced `.glassEffect()` with `.ultraThinMaterial` in a forced dark color scheme on `hoverButtonIcon()`. The static material background renders instantly with a consistent frosted-dark look, eliminating the flicker.

<details>
<summary>Implementation Plan</summary>

# Fix close button glass effect inconsistency

## Context
The grid item hover buttons (close/xmark, remove-from-space) use `.glassEffect(.regular.interactive(), in: .circle)` with no tint and no forced dark color scheme. This causes the Liquid Glass to adapt to the underlying image content, sometimes appearing dark and then switching to white — a jarring visual artifact.

The pattern pills already solve this by using `.tint(.black.opacity(0.3))` and `.environment(\.colorScheme, .dark)`, which gives a consistent dark-tinted appearance regardless of underlying content.

## Change

**File:** `SnapGrid/SnapGrid/Views/Grid/GridItemView.swift` — `hoverButtonIcon()` method (lines 462–475)

Current (macOS 26+ branch):
```swift
base.glassEffect(.regular.interactive(), in: .circle)
```

Change to:
```swift
base
    .glassEffect(.regular.tint(.black.opacity(0.3)).interactive(), in: .circle)
    .environment(\.colorScheme, .dark)
```

This matches the PatternPill styling: a subtle black tint locks in a consistent dark glass look, and forcing the dark color scheme prevents the system from flipping the glass appearance based on content underneath.

## Verification
1. `cd SnapGrid && xcodegen generate && xcodebuild build -project SnapGrid.xcodeproj -scheme SnapGrid -destination 'platform=macOS'`
2. Run the app, hover over grid items with both light and dark images — the close button should always appear as a consistent dark-tinted glass circle, matching the pill aesthetic.

</details>

<sub>Generated with Claude Code</sub>