### PR TITLE
Update grid hover icons for clarity

### DIFF
--- a/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -233,7 +233,7 @@ struct GridItemView: View {
         .overlay(alignment: .topTrailing) {
             if effectiveHover {
                 Button(action: onDelete) {
-                    hoverButtonIcon("xmark", size: 10)
+                    hoverButtonIcon("trash", size: 10)
                 }
                 .buttonStyle(.plain)
                 .padding(8)
@@ -244,7 +244,7 @@ struct GridItemView: View {
         .overlay(alignment: .topLeading) {
             if effectiveHover && activeSpaceId != nil {
                 Button { onAssignToSpace(nil) } label: {
-                    hoverButtonIcon("arrow.uturn.backward", size: 9)
+                    hoverButtonIcon("folder.badge.minus", size: 10)
                 }
                 .buttonStyle(.plain)
                 .padding(8)


### PR DESCRIPTION
### Why?

The existing hover icons on grid items were ambiguous — `xmark` could mean close or dismiss, and `arrow.uturn.backward` suggests undo rather than removal. This made the hover actions harder to understand at a glance.

### How?

Swap to semantically clearer SF Symbols: `trash` for the delete action and `folder.badge.minus` for removing an item from a space.

<sub>Generated with Claude Code</sub>