### PR TITLE
Refine metadata typography and spacing on Mac and iOS

### DIFF
--- a/SnapGrid/SnapGrid/Views/Detail/HeroDetailOverlay.swift
+++ b/SnapGrid/SnapGrid/Views/Detail/HeroDetailOverlay.swift
@@ -590,7 +590,7 @@ struct HeroDetailOverlay: View {
                         }
                     }
                 }
-                .frame(width: max(min(finalFrame.width, 500), 400))
+                .frame(width: max(min(finalFrame.width, 550), 400))
                 .padding(.top, 40)
                 .padding(.bottom, 40)
                 .mask(metadataFadeMask)
@@ -837,7 +837,7 @@ private struct DetailMetadataSection: View {
             } else if let result = item.analysisResult {
                 if !result.imageSummary.isEmpty {
                     Text(result.imageSummary)
-                        .font(.body.weight(.semibold))
+                        .font(.title3.weight(.semibold))
                         .foregroundStyle(.white.opacity(0.85))
                         .lineLimit(2)
                         .stageReveal(stage: stage, threshold: 1)
@@ -858,13 +858,13 @@ private struct DetailMetadataSection: View {
                         }
                     }
                     .padding(.leading, -6)
-                    .padding(.bottom, 12)
+                    .padding(.bottom, 18)
                 }
 
                 if hasDescription(result) {
                     Text(result.imageContext)
-                        .font(.caption)
-                        .foregroundStyle(.white.opacity(0.4))
+                        .font(.footnote)
+                        .foregroundStyle(.white.opacity(0.55))
                         .lineSpacing(2)
                         .stageReveal(stage: stage, threshold: 3)
                 }
@@ -884,7 +884,7 @@ private struct DetailMetadataSection: View {
             .font(.caption.monospaced())
             .foregroundStyle(.white.opacity(0.25))
             .stageReveal(stage: stage, threshold: 4)
-            .padding(.top, 12)
+            .padding(.top, 16)
 
             if let urlString = item.sourceURL, let url = URL(string: urlString) {
                 SourceLinkButton(url: url)

--- a/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
@@ -1243,7 +1243,7 @@ private struct DetailMetadataSection: View {
             } else if let result = item.analysisResult {
                 if !result.imageSummary.isEmpty {
                     Text(result.imageSummary)
-                        .font(.system(size: 16, weight: .semibold))
+                        .font(.title3.weight(.semibold))
                         .foregroundStyle(.white.opacity(0.9))
                         .lineLimit(2)
                         .stageReveal(stage: stage, threshold: 1)
@@ -1252,13 +1252,13 @@ private struct DetailMetadataSection: View {
 
                 if !result.patterns.isEmpty {
                     patternPillsGrid(result.patterns)
-                        .padding(.bottom, 14)
+                        .padding(.bottom, 18)
                 }
 
                 if hasDescription(result) {
                     Text(result.imageContext)
-                        .font(.system(size: 14))
-                        .foregroundStyle(.white.opacity(0.5))
+                        .font(.footnote)
+                        .foregroundStyle(.white.opacity(0.55))
                         .lineSpacing(3)
                         .fixedSize(horizontal: false, vertical: true)
                         .opacity(stage >= 3 ? 1 : 0)
@@ -1277,10 +1277,10 @@ private struct DetailMetadataSection: View {
                     Text(formatDuration(duration))
                 }
             }
-            .font(.system(size: 12, design: .monospaced))
-            .foregroundStyle(.white.opacity(0.3))
+            .font(.caption.monospaced())
+            .foregroundStyle(.white.opacity(0.25))
             .stageReveal(stage: stage, threshold: 4)
-            .padding(.top, 14)
+            .padding(.top, 16)
 
             if let urlString = item.sourceURL, let url = URL(string: urlString) {
                 SourceLinkButton(url: url)
@@ -1316,10 +1316,10 @@ private struct DetailMetadataSection: View {
     @ViewBuilder
     private func patternPill(pattern: PatternTag, index: Int) -> some View {
         let base = Text(pattern.name)
-            .font(.caption)
+            .font(.subheadline)
             .foregroundStyle(.white.opacity(0.9))
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
 
         if #available(iOS 26.0, *) {
             base


### PR DESCRIPTION
### Why?

The metadata text in the image detail overlay was too small and lacked clear typographic hierarchy — the title, pattern pills, and description all sat at similar visual weights, making the metadata block feel flat and hard to scan.

### How?

Establish a consistent four-level type scale across both Mac and iOS: title (`.title3`) > pills (`.subheadline`) > description (`.footnote`) > file info (`.caption`). Improve section spacing, bump description opacity for readability, and widen the Mac metadata container. On iOS, replace hardcoded `.system(size:)` fonts with semantic styles for Dynamic Type support and tighten pill padding for better proportions.

<sub>Generated with Claude Code</sub>