### PR TITLE
Fix video hover preview interfering with selection and UI

### DIFF
--- a/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -26,6 +26,10 @@ struct GridItemView: View {
     @State private var thumbnail: NSImage?
     @State private var globalFrame: CGRect = .zero
     @State private var hoverTask: Task<Void, Never>?
+    /// Suppresses the first `.onHover(false)` after a video preview starts.
+    /// The floating NSView (AVPlayerLayer) causes a spurious exit event
+    /// that macOS never corrects with a re-entry.
+    @State private var suppressHoverExit = false
 
     // Eagerly resolved SwiftData properties — prevents faults on detached backing stores
     // when SwiftUI re-evaluates the body (e.g. for context menu snapshots).
@@ -295,9 +299,17 @@ struct GridItemView: View {
             hoverTask?.cancel()
             if itemIsVideo {
                 if hovering {
+                    // Don't start preview during rubber band selection or drag
+                    guard NSEvent.pressedMouseButtons & 1 == 0 else { return }
+                    suppressHoverExit = false
                     hoverTask = Task {
                         try? await Task.sleep(for: .milliseconds(200))
                         guard !Task.isCancelled else { return }
+                        // Only arm the suppress flag when actually creating a new preview —
+                        // re-entering an already-previewing item won't spawn a new layer.
+                        if videoPreview.activeItemId != item.id {
+                            suppressHoverExit = true
+                        }
                         videoPreview.startPreview(
                             itemId: item.id,
                             url: MediaStorageService.shared.mediaURL(filename: item.filename),
@@ -306,9 +318,12 @@ struct GridItemView: View {
                         )
                     }
                 } else if videoPreview.activeItemId == item.id {
-                    // Floating video layer can cause spurious onHover(false) —
-                    // debounce the stop so effectiveHover keeps UI stable.
-                    // A genuine hover-in (same or different item) cancels this.
+                    // The floating NSView causes one spurious onHover(false) when it
+                    // first appears. Suppress that single exit; subsequent exits are genuine.
+                    if suppressHoverExit {
+                        suppressHoverExit = false
+                        return
+                    }
                     hoverTask = Task {
                         try? await Task.sleep(for: .milliseconds(100))
                         guard !Task.isCancelled else { return }
@@ -380,6 +395,7 @@ struct GridItemView: View {
                 // Fullscreen dismissed — mouse may have moved, so clear stale hover state.
                 // If the cursor is still over this item, .onHover will re-fire true immediately.
                 isHovered = false
+                suppressHoverExit = false
             }
         }
         .contextMenu {

--- a/SnapGrid/SnapGrid/Views/Shared/FloatingVideoLayer.swift
+++ b/SnapGrid/SnapGrid/Views/Shared/FloatingVideoLayer.swift
@@ -141,6 +141,15 @@ struct FloatingVideoLayer: View {
                 }
             .frame(width: videoPreview.currentFrame.width, height: videoPreview.currentFrame.height)
             .clipShape(RoundedRectangle(cornerRadius: videoPreview.cornerRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: videoPreview.cornerRadius)
+                    .strokeBorder(
+                        videoPreview.displayState == .grid
+                            && appState.selectedIds.contains(videoPreview.activeItemId ?? "")
+                            ? Color.accentColor : Color.clear,
+                        lineWidth: 2
+                    )
+            )
             .position(x: videoPreview.currentFrame.midX, y: videoPreview.currentFrame.midY)
             .allowsHitTesting(videoPreview.displayState == .detail)
             .ignoresSafeArea()


### PR DESCRIPTION
### Why?

Video items in the grid had three hover-related bugs: rubber band (marquee) selection would immediately deselect videos, the close/delete button would appear then vanish ~300ms after hovering a video, and the selection border rendered behind the floating video preview layer. All three stem from the floating AVPlayerLayer NSView causing a spurious `onHover(false)` that macOS never corrects with a re-entry event.

### How?

A `suppressHoverExit` flag absorbs the single spurious hover-exit fired when the floating NSView first appears over a grid cell. A `pressedMouseButtons` guard prevents video previews from starting during rubber band drag. The floating layer now mirrors the grid cell's selection border when the item is selected.

<details>
<summary>Implementation Plan</summary>

# Fix: Video hover preview interfering with selection and close button

## Changes Made

**File:** `SnapGrid/SnapGrid/Views/Grid/GridItemView.swift`

### 1. New state: `suppressHoverExit` (line 29-32)
Flag that suppresses the first spurious `.onHover(false)` after a video preview starts.

### 2. Rubber band guard (line 303)
`NSEvent.pressedMouseButtons & 1 == 0` — blocks preview startup when left mouse button is held.

### 3. Suppress flag logic (lines 304-326)
- On hover-in: reset flag, then arm it only when a NEW preview will be created
- On hover-out: if flag is armed, suppress the exit (it's the spurious one from the floating NSView)
- Subsequent exits proceed normally with the 100ms debounced stop

### 4. Reset on detail dismiss (line 398)
Clears `suppressHoverExit` when fullscreen detail view closes.

## Edge Case Walkthrough

| Interaction | Flow | Result |
|---|---|---|
| **Rubber band over video** | hover-in → `pressedMouseButtons` guard blocks → no preview starts → no interference | Selection stays stable |
| **Rubber band + Shift/Cmd** | Same as above — frozen selection preserved, guard blocks preview | Additive selection works |
| **Normal hover** | hover-in → 200ms → preview starts → `suppressHoverExit=true` → spurious exit suppressed | Close button stays visible |
| **Hover then leave** | After spurious exit suppressed → cursor leaves → genuine exit → debounced stop | Preview stops normally |
| **Cmd+click** | hover-in → preview starts → Cmd+click fires `onToggleSelect()` → selection toggled | Toggle works, preview unaffected |
| **Shift+click** | Same as Cmd+click but calls `onShiftSelect()` | Range select works |
| **Click to detail** | Button fires `claimForDetail()` + `onSelect()` → detail opens | Detail transition works |
| **Detail dismiss** | `onChange(detailItem)` resets `isHovered` + `suppressHoverExit` | Clean state for next hover |
| **Re-enter already-previewing item** | `activeItemId == item.id` → flag NOT armed → no spurious suppress | Genuine exits still stop preview |
| **Fast dash-to-click** | If hover-in fires while button held → guard blocks → no preview. Button still fires. | Click works, no preview (intended) |
| **Click empty space** | Background `DragGesture.onEnded` → `onSetSelection([])` | Selection cleared |

</details>

<sub>Generated with Claude Code</sub>