### PR TITLE
Fix iOS zoom clipping and add focal-point pinch-to-zoom

### DIFF
--- a/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
@@ -405,16 +405,17 @@ struct FullScreenImageOverlay: View {
         let metadataTopY = finalFrame.maxY + 32
 
         ZStack {
-            // Image — centered at finalFrame, scrolls up with content
+            // Image — centered at finalFrame, zoomed by frame size (not scaleEffect)
+            // so that clipShape/mask boundaries grow with the content.
             Group {
                 if item.isVideo, let player {
                     VideoPlayer(player: player)
-                        .frame(width: finalFrame.width, height: finalFrame.height)
+                        .frame(width: finalFrame.width * zoomScale, height: finalFrame.height * zoomScale)
                 } else if let displayImage {
                     Image(uiImage: displayImage)
                         .resizable()
                         .aspectRatio(contentMode: .fill)
-                        .frame(width: finalFrame.width, height: finalFrame.height)
+                        .frame(width: finalFrame.width * zoomScale, height: finalFrame.height * zoomScale)
                         .clipped()
                 } else {
                     Rectangle()
@@ -431,14 +432,13 @@ struct FullScreenImageOverlay: View {
             .mask {
                 let maskH = deleteStage >= 1
                     ? finalFrame.height * DeleteAnimation.crushedScaleY
-                    : finalFrame.height
+                    : finalFrame.height * zoomScale
                 let maskW = deleteStage >= 2
                     ? finalFrame.width * DeleteAnimation.crushedScaleX
-                    : finalFrame.width
+                    : finalFrame.width * zoomScale
                 RoundedRectangle(cornerRadius: zoomedCornerRadius)
                     .frame(width: maskW, height: maskH)
             }
-            .scaleEffect(zoomScale)
             .offset(effectiveZoomPanOffset)
             .opacity(deleteStage >= 2 ? 0 : 1)
             .position(x: finalFrame.midX, y: finalFrame.midY)
@@ -854,12 +854,49 @@ struct FullScreenImageOverlay: View {
         MagnifyGesture()
             .onChanged { value in
                 let raw = zoomLastScale * value.magnification
-                zoomScale = rubberBand(raw, min: minZoomScale, max: maxZoomScale)
+                let prevZoom = zoomScale
+                let newZoom = rubberBand(raw, min: minZoomScale, max: maxZoomScale)
+
+                // Focal-point zoom: adjust pan so the pinch center stays fixed.
+                // Convert startAnchor (UnitPoint 0–1) to screen coordinates.
+                if prevZoom > 0 && newZoom != prevZoom {
+                    let screen = UIScreen.main.bounds
+                    let anchor = CGPoint(
+                        x: value.startAnchor.x * screen.width,
+                        y: value.startAnchor.y * screen.height
+                    )
+                    let finalFrame = computeFinalFrame(for: item)
+                    let currentOffset = effectiveZoomPanOffset
+                    let imageCenterX = finalFrame.midX + currentOffset.width
+                    let imageCenterY = finalFrame.midY + currentOffset.height
+                    let ratio = newZoom / prevZoom
+                    let dx = -(anchor.x - imageCenterX) * (ratio - 1)
+                    let dy = -(anchor.y - imageCenterY) * (ratio - 1)
+                    zoomPanOffset.width += dx
+                    zoomPanOffset.height += dy
+                    zoomPanLastOffset.width += dx
+                    zoomPanLastOffset.height += dy
+                }
+
+                zoomScale = newZoom
                 let wasZoomed = isZoomed
                 isZoomed = zoomScale > minZoomScale
-                if isZoomed && !wasZoomed && contentOffset > 0 {
-                    withAnimation(SnapSpring.resolvedFast) { contentOffset = 0 }
-                    contentOffsetAtGestureStart = 0
+                if isZoomed && !wasZoomed {
+                    // Upgrade simultaneous drag to zoomPan so two-finger
+                    // panning works during the same gesture that started the zoom.
+                    if gestureActive && gestureMode != .zoomPan {
+                        gestureMode = .zoomPan
+                        // Subtract accumulated translation for a seamless handoff
+                        zoomPanLastOffset = CGSize(
+                            width: zoomPanOffset.width - gestureDrag.translation.width,
+                            height: zoomPanOffset.height - gestureDrag.translation.height
+                        )
+                        dismissOffset = 0
+                    }
+                    if contentOffset > 0 {
+                        withAnimation(SnapSpring.resolvedFast) { contentOffset = 0 }
+                        contentOffsetAtGestureStart = 0
+                    }
                 }
             }
             .onEnded { _ in


### PR DESCRIPTION
### Why?

Zoomed images in the iOS fullscreen overlay were clipped to the original frame bounds instead of filling the viewport like Apple Photos. The previous fix (PR #142) moved `scaleEffect()` outside the clip chain, but Core Animation masks don't reliably scale with layer transforms — so `clipShape`/`mask` stayed at the unzoomed size. Additionally, pinch-to-zoom was anchored to the image center rather than the pinch location, and two-finger panning didn't work during the initial pinch gesture.

### How?

Replace `scaleEffect(zoomScale)` with frame-based zoom — the image/video frame and mask dimensions are multiplied by `zoomScale` directly, so clip and mask boundaries grow naturally with the content. The pinch gesture now computes incremental pan offset adjustments to keep the pinch center stationary (focal-point zoom), and upgrades the simultaneous drag gesture to `.zoomPan` mode mid-pinch for simultaneous pan + zoom.

<details>
<summary>Implementation Plan</summary>

# Fix iOS Zoom Clipping in FullScreen Overlay

## Context

When zooming images in the iOS fullscreen overlay, content gets clipped to the original frame bounds instead of filling the viewport like Apple Photos. PR #142 moved `.scaleEffect()` outside the clip chain, but this relies on Core Animation masks scaling with layer transforms — which doesn't work reliably across iOS versions. The `.mask{}` and `.clipShape()` stay at `finalFrame` size while `.scaleEffect()` tries to scale beyond them.

## Approach: Frame-Based Zoom

Replace `scaleEffect(zoomScale)` with rendering the image at the zoomed frame size directly. This eliminates the transform-mask interaction entirely.

## File

`ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift` — only the `settledContentView()` function (~lines 407-445)

## Changes

### 1. Image/Video frame: multiply by zoomScale

```swift
// Before:
.frame(width: finalFrame.width, height: finalFrame.height)

// After:
.frame(width: finalFrame.width * zoomScale, height: finalFrame.height * zoomScale)
```

Apply to both the Image branch (line 417) and VideoPlayer branch (line 412). Keep placeholder at `finalFrame` size (unreachable when zoomed).

### 2. Mask dimensions: use zoomed size when not deleting

```swift
// Before:
let maskH = deleteStage >= 1
    ? finalFrame.height * DeleteAnimation.crushedScaleY
    : finalFrame.height

// After:
let maskH = deleteStage >= 1
    ? finalFrame.height * DeleteAnimation.crushedScaleY
    : finalFrame.height * zoomScale
```

Same for maskW. Delete animation is unaffected because `handleDelete()` resets zoomScale to 1.0 before starting.

### 3. Remove `.scaleEffect(zoomScale)` (line 441)

No longer needed — zoom is baked into the frame.

### No changes needed elsewhere

- **Pan bounds** (`clampedZoomPanOffset`, `rubberBandZoomPanOffset`): formula `finalFrame.width * zoomScale - screen.width` is the same
- **Double-tap** (`handleDoubleTap`): formula `(center - tap) * (zoom - 1)` is mathematically identical for both approaches
- **Delete**: zoom resets to 1.0 first, so frame = finalFrame during crush
- **Pinch gesture**: sets `zoomScale` continuously — frame resizes smoothly
- **Adjacent views**: not zoomed, unaffected

## Verification

1. Open image fullscreen, pinch to zoom — should fill viewport edge-to-edge
2. Pan while zoomed — should reach image edges with rubber-band at bounds
3. Double-tap to zoom/unzoom — should center on tap location
4. Delete while zoomed — should reset zoom then play crush animation
5. Swipe between images at 1x — should work normally
6. Test with video content — verify no flicker during zoom

</details>

<sub>Generated with Claude Code</sub>