### PR TITLE
Fix cross-platform sync bugs and iOS thumbnail loading

### DIFF
--- a/SnapGrid/SnapGrid/Services/MetadataSidecarService.swift
+++ b/SnapGrid/SnapGrid/Services/MetadataSidecarService.swift
@@ -15,6 +15,7 @@ struct SidecarMetadata: Codable, Sendable {
     let imageSummary: String?
     let patterns: [SidecarPattern]?
     let sourceURL: String?
+    let analyzedAt: Date?
 }
 
 struct SidecarPattern: Codable, Sendable {
@@ -74,7 +75,8 @@ final class MetadataSidecarService: Sendable {
             imageContext: item.analysisResult?.imageContext,
             imageSummary: item.analysisResult?.imageSummary,
             patterns: item.analysisResult?.patterns.map { SidecarPattern(name: $0.name, confidence: $0.confidence) },
-            sourceURL: item.sourceURL
+            sourceURL: item.sourceURL,
+            analyzedAt: item.analysisResult?.analyzedAt
         )
 
         let url = storage.metadataDir.appendingPathComponent("\(item.id).json")

--- a/SnapGrid/SnapGrid/Services/SyncWatcher.swift
+++ b/SnapGrid/SnapGrid/Services/SyncWatcher.swift
@@ -38,11 +38,15 @@ final class SyncWatcher {
         let needsThumbnail: Bool
     }
 
-    /// Lightweight update for existing items whose sidecar changed (e.g. space assignment, source URL).
+    /// Update for existing items whose sidecar changed (e.g. space assignment, analysis, source URL).
     private struct SidecarUpdateData: Sendable {
         let id: String
         let spaceId: String?
         let sourceURL: String?
+        let imageContext: String?
+        let imageSummary: String?
+        let patterns: [SidecarPattern]?
+        let analyzedAt: Date?
     }
 
     // MARK: - Public API
@@ -203,7 +207,15 @@ final class SyncWatcher {
             var updates: [SidecarUpdateData] = []
             for id in modifiedIds {
                 if let sidecar = MetadataSidecarService.shared.readSidecar(id: id) {
-                    updates.append(SidecarUpdateData(id: id, spaceId: sidecar.spaceId, sourceURL: sidecar.sourceURL))
+                    updates.append(SidecarUpdateData(
+                        id: id,
+                        spaceId: sidecar.spaceId,
+                        sourceURL: sidecar.sourceURL,
+                        imageContext: sidecar.imageContext,
+                        imageSummary: sidecar.imageSummary,
+                        patterns: sidecar.patterns,
+                        analyzedAt: sidecar.analyzedAt
+                    ))
                 }
             }
 
@@ -242,7 +254,7 @@ final class SyncWatcher {
                 applyImport(data)
                 count += 1
                 if count % 20 == 0 {
-                    try? context?.save()
+                    context?.saveOrLog()
                     await Task.yield()
                 }
             }
@@ -253,7 +265,7 @@ final class SyncWatcher {
             applySpaceUpdate(update)
         }
 
-        try? context?.save()
+        context?.saveOrLog()
     }
 
     /// Ongoing sync — triggered by DispatchSource after debounce.
@@ -280,7 +292,7 @@ final class SyncWatcher {
         }
 
         if !changes.newItems.isEmpty || !changes.updates.isEmpty || !changes.deletedIds.isEmpty {
-            try? context?.save()
+            context?.saveOrLog()
         }
 
         if !unanalyzedIds.isEmpty {
@@ -336,6 +348,7 @@ final class SyncWatcher {
                 imageContext: imageContext,
                 imageSummary: data.sidecar.imageSummary ?? "",
                 patterns: patterns,
+                analyzedAt: data.sidecar.analyzedAt ?? .now,
                 provider: "synced",
                 model: "icloud-sync"
             )
@@ -370,7 +383,7 @@ final class SyncWatcher {
         print("[SyncWatcher] Removed \(id) (sidecar deleted on other device)")
     }
 
-    /// Update space assignment and source URL on an existing item. No file I/O.
+    /// Update space assignment, analysis, and source URL on an existing item. No file I/O.
     private func applySpaceUpdate(_ update: SidecarUpdateData) {
         guard let context else { return }
 
@@ -393,6 +406,33 @@ final class SyncWatcher {
             item.sourceURL = sourceURL
             print("[SyncWatcher] Updated sourceURL for \(update.id)")
         }
+
+        // Sync analysis results if the remote sidecar has newer or missing-locally analysis
+        if let imageContext = update.imageContext, !imageContext.isEmpty {
+            let shouldSync: Bool
+            if item.analysisResult == nil {
+                shouldSync = true
+            } else if let remoteDate = update.analyzedAt,
+                      let localDate = item.analysisResult?.analyzedAt,
+                      remoteDate > localDate {
+                shouldSync = true
+            } else {
+                shouldSync = false
+            }
+
+            if shouldSync {
+                let patterns = (update.patterns ?? []).map { PatternTag(name: $0.name, confidence: $0.confidence) }
+                item.analysisResult = AnalysisResult(
+                    imageContext: imageContext,
+                    imageSummary: update.imageSummary ?? "",
+                    patterns: patterns,
+                    analyzedAt: update.analyzedAt ?? .now,
+                    provider: "synced",
+                    model: "icloud-sync"
+                )
+                print("[SyncWatcher] Synced analysis result for \(update.id)")
+            }
+        }
     }
 
     // MARK: - Spaces Sync
@@ -407,7 +447,6 @@ final class SyncWatcher {
         }.value
 
         let sidecarSpaces = spacesFile.spaces
-        guard !sidecarSpaces.isEmpty else { return }
 
         // Phase 2: Sync all-space guidance to UserDefaults
         if let allGuidance = spacesFile.allSpaceGuidance {
@@ -441,6 +480,10 @@ final class SyncWatcher {
                 if space.order != sidecar.order { space.order = sidecar.order }
                 if space.customPrompt != sidecar.customPrompt { space.customPrompt = sidecar.customPrompt }
                 if space.useCustomPrompt != sidecar.useCustomPrompt { space.useCustomPrompt = sidecar.useCustomPrompt }
+            } else {
+                // Space was deleted on the other device
+                context.delete(space)
+                print("[SyncWatcher] Removed space \(space.name) (deleted on other device)")
             }
         }
 

--- a/SnapGrid/SnapGridTests/SidecarCodableTests.swift
+++ b/SnapGrid/SnapGridTests/SidecarCodableTests.swift
@@ -36,7 +36,8 @@ struct SidecarCodableTests {
                 SidecarPattern(name: "Mountain", confidence: 0.95),
                 SidecarPattern(name: "Sky", confidence: 0.88)
             ],
-            sourceURL: "https://x.com/user/status/123"
+            sourceURL: "https://x.com/user/status/123",
+            analyzedAt: Date(timeIntervalSince1970: 1700000100)
         )
 
         let data = try Self.encoder.encode(original)
@@ -67,7 +68,8 @@ struct SidecarCodableTests {
             imageContext: nil,
             imageSummary: nil,
             patterns: nil,
-            sourceURL: nil
+            sourceURL: nil,
+            analyzedAt: nil
         )
 
         let data = try Self.encoder.encode(original)
@@ -96,7 +98,8 @@ struct SidecarCodableTests {
             imageContext: nil,
             imageSummary: nil,
             patterns: nil,
-            sourceURL: "https://x.com/user/status/1234567890"
+            sourceURL: "https://x.com/user/status/1234567890",
+            analyzedAt: nil
         )
 
         let data = try Self.encoder.encode(original)

--- a/ios/SnapGrid/SnapGrid/Services/AIAnalysisService.swift
+++ b/ios/SnapGrid/SnapGrid/Services/AIAnalysisService.swift
@@ -94,6 +94,56 @@ final class AIAnalysisService: Sendable {
         throw lastError!
     }
 
+    func analyzeVideo(frames: [UIImage], provider: AIProvider, model: String, apiKey: String, guidance: String? = nil, spaceContext: String? = nil) async throws -> AnalysisResult {
+        // Analyze each frame and merge results
+        var allPatterns: [String: [Double]] = [:]
+        var contexts: [String] = []
+        var summaries: [String] = []
+
+        for frame in frames {
+            let result = try await analyze(image: frame, provider: provider, model: model, apiKey: apiKey, guidance: guidance, spaceContext: spaceContext)
+            contexts.append(result.imageContext)
+            summaries.append(result.imageSummary)
+
+            for pattern in result.patterns {
+                allPatterns[pattern.name, default: []].append(pattern.confidence)
+            }
+        }
+
+        return Self.mergeFrameResults(
+            allPatterns: allPatterns,
+            contexts: contexts,
+            summaries: summaries,
+            provider: provider.rawValue,
+            model: model
+        )
+    }
+
+    /// Merge analysis results from multiple video frames. Averages confidence per pattern,
+    /// filters below 0.7, caps at 10, sorts descending.
+    static func mergeFrameResults(
+        allPatterns: [String: [Double]],
+        contexts: [String],
+        summaries: [String],
+        provider: String,
+        model: String
+    ) -> AnalysisResult {
+        let mergedPatterns = allPatterns.map { name, confidences in
+            PatternTag(name: name, confidence: confidences.reduce(0, +) / Double(confidences.count))
+        }
+        .filter { $0.confidence >= 0.7 }
+        .sorted { $0.confidence > $1.confidence }
+        .prefix(10)
+
+        return AnalysisResult(
+            imageContext: contexts.joined(separator: "\n\n"),
+            imageSummary: summaries.first ?? "Video",
+            patterns: Array(mergedPatterns),
+            provider: provider,
+            model: model
+        )
+    }
+
     func isRetryable(_ error: Error) -> Bool {
         let nsError = error as NSError
         if nsError.domain == NSURLErrorDomain {

--- a/ios/SnapGrid/SnapGrid/Services/AnalysisCoordinator.swift
+++ b/ios/SnapGrid/SnapGrid/Services/AnalysisCoordinator.swift
@@ -52,18 +52,30 @@ final class AnalysisCoordinator {
 
                 item.isAnalyzing = true
                 do {
-                    let image = try loadImage(for: item, rootURL: rootURL)
-
                     let (guidance, spaceContext) = resolveGuidance(for: item)
 
-                    let result = try await AIAnalysisService.shared.analyze(
-                        image: image,
-                        provider: provider,
-                        model: resolvedModel,
-                        apiKey: apiKey,
-                        guidance: guidance,
-                        spaceContext: spaceContext
-                    )
+                    let result: AnalysisResult
+                    if item.isVideo {
+                        let frames = try extractVideoFrames(for: item, rootURL: rootURL)
+                        result = try await AIAnalysisService.shared.analyzeVideo(
+                            frames: frames,
+                            provider: provider,
+                            model: resolvedModel,
+                            apiKey: apiKey,
+                            guidance: guidance,
+                            spaceContext: spaceContext
+                        )
+                    } else {
+                        let image = try loadImage(for: item, rootURL: rootURL)
+                        result = try await AIAnalysisService.shared.analyze(
+                            image: image,
+                            provider: provider,
+                            model: resolvedModel,
+                            apiKey: apiKey,
+                            guidance: guidance,
+                            spaceContext: spaceContext
+                        )
+                    }
                     item.analysisResult = result
                     item.isAnalyzing = false
                     item.analysisError = nil
@@ -109,20 +121,37 @@ final class AnalysisCoordinator {
 
     private func loadImage(for item: MediaItem, rootURL: URL) throws -> UIImage {
         let fileURL = rootURL.appendingPathComponent("images/\(item.filename)")
-        if item.isVideo {
-            let asset = AVURLAsset(url: fileURL)
-            let generator = AVAssetImageGenerator(asset: asset)
-            generator.appliesPreferredTrackTransform = true
-            generator.maximumSize = CGSize(width: 1280, height: 1280)
-            let cgImage = try generator.copyCGImage(at: CMTime(seconds: 1, preferredTimescale: 600), actualTime: nil)
-            return UIImage(cgImage: cgImage)
-        } else {
-            guard let data = try? Data(contentsOf: fileURL),
-                  let image = UIImage(data: data) else {
-                throw AIAnalysisService.AnalysisError.imageConversionFailed
-            }
-            return image
+        guard let data = try? Data(contentsOf: fileURL),
+              let image = UIImage(data: data) else {
+            throw AIAnalysisService.AnalysisError.imageConversionFailed
         }
+        return image
+    }
+
+    /// Extract frames at 33% and 66% of video duration for multi-frame analysis,
+    /// matching the Mac app's VideoFrameExtractor.extractAnalysisFrames behavior.
+    private func extractVideoFrames(for item: MediaItem, rootURL: URL) throws -> [UIImage] {
+        let fileURL = rootURL.appendingPathComponent("images/\(item.filename)")
+        let asset = AVURLAsset(url: fileURL)
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        generator.maximumSize = CGSize(width: 1280, height: 1280)
+
+        let duration = CMTimeGetSeconds(asset.duration)
+        guard duration > 0 else {
+            // Fall back to first frame for very short or broken videos
+            let cgImage = try generator.copyCGImage(at: .zero, actualTime: nil)
+            return [UIImage(cgImage: cgImage)]
+        }
+
+        let fractions = [0.33, 0.66]
+        var frames: [UIImage] = []
+        for fraction in fractions {
+            let time = CMTime(seconds: duration * fraction, preferredTimescale: 600)
+            let cgImage = try generator.copyCGImage(at: time, actualTime: nil)
+            frames.append(UIImage(cgImage: cgImage))
+        }
+        return frames
     }
 
     private func resolveGuidance(for item: MediaItem) -> (guidance: String?, spaceContext: String?) {

--- a/ios/SnapGrid/SnapGrid/Services/ImageImportService.swift
+++ b/ios/SnapGrid/SnapGrid/Services/ImageImportService.swift
@@ -30,10 +30,7 @@ enum ImageImportService {
 
         for image in images {
             let ok = autoreleasepool { () -> Bool in
-                let timestamp = Int(Date().timeIntervalSince1970 * 1000)
-                let chars = "abcdefghijklmnopqrstuvwxyz0123456789"
-                let random = String((0..<7).map { _ in chars.randomElement()! })
-                let id = "img_\(timestamp)_\(random)"
+                let id = UUID().uuidString
 
                 guard let pngData = image.pngData() else { return false }
 
@@ -63,7 +60,8 @@ enum ImageImportService {
                     imageContext: nil,
                     imageSummary: nil,
                     patterns: nil,
-                    sourceURL: nil
+                    sourceURL: nil,
+                    analyzedAt: nil
                 )
 
                 guard let jsonData = try? encoder.encode(sidecar) else { return false }

--- a/ios/SnapGrid/SnapGrid/Services/MediaDeleteService.swift
+++ b/ios/SnapGrid/SnapGrid/Services/MediaDeleteService.swift
@@ -50,4 +50,31 @@ enum MediaDeleteService {
             throw error
         }
     }
+
+    /// Delete trash files older than the given interval (default 30 days).
+    /// Matches the Mac app's `MediaStorageService.emptyOldTrash` behavior.
+    static func emptyOldTrash(rootURL: URL, olderThan interval: TimeInterval = 30 * 24 * 3600) {
+        let fm = FileManager.default
+        let cutoff = Date().addingTimeInterval(-interval)
+
+        let trashDirs = [
+            rootURL.appendingPathComponent(".trash/images"),
+            rootURL.appendingPathComponent(".trash/metadata"),
+            rootURL.appendingPathComponent(".trash/thumbnails")
+        ]
+
+        for dir in trashDirs {
+            guard let files = try? fm.contentsOfDirectory(
+                at: dir,
+                includingPropertiesForKeys: [.contentModificationDateKey]
+            ) else { continue }
+
+            for file in files {
+                guard let attrs = try? fm.attributesOfItem(atPath: file.path),
+                      let modified = attrs[.modificationDate] as? Date,
+                      modified < cutoff else { continue }
+                try? fm.removeItem(at: file)
+            }
+        }
+    }
 }

--- a/ios/SnapGrid/SnapGrid/Services/SidecarWriteService.swift
+++ b/ios/SnapGrid/SnapGrid/Services/SidecarWriteService.swift
@@ -1,53 +1,92 @@
 import Foundation
 
 /// Centralizes all sidecar JSON write operations for the iOS app.
-/// Merges the previously duplicated writeSidecarSpaceId and updateSidecarSpaceId methods.
+/// Uses a merge strategy when the sidecar exists, or creates a complete
+/// sidecar from model data when the file hasn't downloaded from iCloud yet.
 enum SidecarWriteService {
+
+    private static let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .iso8601
+        e.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return e
+    }()
 
     /// Update the spaceId field in a media item's sidecar JSON.
     /// Removes the key when spaceId is nil (not NSNull — that was a bug).
+    /// Falls back to writing a complete sidecar if the file doesn't exist yet.
     static func writeSpaceId(for item: MediaItem, rootURL: URL) {
         let sidecarURL = rootURL.appendingPathComponent("metadata/\(item.id).json")
 
-        guard let existingData = try? Data(contentsOf: sidecarURL),
-              var json = try? JSONSerialization.jsonObject(with: existingData) as? [String: Any] else {
-            return
-        }
+        if let existingData = try? Data(contentsOf: sidecarURL),
+           var json = try? JSONSerialization.jsonObject(with: existingData) as? [String: Any] {
+            // Merge into existing sidecar
+            if let spaceId = item.space?.id {
+                json["spaceId"] = spaceId
+            } else {
+                json.removeValue(forKey: "spaceId")
+            }
 
-        if let spaceId = item.space?.id {
-            json["spaceId"] = spaceId
+            if let updatedData = try? JSONSerialization.data(
+                withJSONObject: json,
+                options: [.prettyPrinted, .sortedKeys]
+            ) {
+                try? updatedData.write(to: sidecarURL, options: .atomic)
+            }
         } else {
-            json.removeValue(forKey: "spaceId")
-        }
-
-        if let updatedData = try? JSONSerialization.data(
-            withJSONObject: json,
-            options: [.prettyPrinted, .sortedKeys]
-        ) {
-            try? updatedData.write(to: sidecarURL, options: .atomic)
+            // File not downloaded yet — write a complete sidecar from model data
+            writeFullSidecar(for: item, to: sidecarURL)
         }
     }
 
     /// Write analysis results back to a media item's sidecar JSON.
+    /// Falls back to writing a complete sidecar if the file doesn't exist yet.
     static func writeAnalysis(for item: MediaItem, rootURL: URL) {
         let sidecarURL = rootURL.appendingPathComponent("metadata/\(item.id).json")
 
-        guard let existingData = try? Data(contentsOf: sidecarURL),
-              var json = try? JSONSerialization.jsonObject(with: existingData) as? [String: Any] else {
-            return
-        }
+        if let existingData = try? Data(contentsOf: sidecarURL),
+           var json = try? JSONSerialization.jsonObject(with: existingData) as? [String: Any] {
+            // Merge into existing sidecar
+            if let result = item.analysisResult {
+                json["imageContext"] = result.imageContext
+                json["imageSummary"] = result.imageSummary
+                json["patterns"] = result.patterns.map { ["name": $0.name, "confidence": $0.confidence] }
+                let formatter = ISO8601DateFormatter()
+                json["analyzedAt"] = formatter.string(from: result.analyzedAt)
+            }
 
-        if let result = item.analysisResult {
-            json["imageContext"] = result.imageContext
-            json["imageSummary"] = result.imageSummary
-            json["patterns"] = result.patterns.map { ["name": $0.name, "confidence": $0.confidence] }
+            if let updatedData = try? JSONSerialization.data(
+                withJSONObject: json,
+                options: [.prettyPrinted, .sortedKeys]
+            ) {
+                try? updatedData.write(to: sidecarURL, options: .atomic)
+            }
+        } else {
+            // File not downloaded yet — write a complete sidecar from model data
+            writeFullSidecar(for: item, to: sidecarURL)
         }
+    }
 
-        if let updatedData = try? JSONSerialization.data(
-            withJSONObject: json,
-            options: [.prettyPrinted, .sortedKeys]
-        ) {
-            try? updatedData.write(to: sidecarURL, options: .atomic)
+    /// Construct and write a complete sidecar JSON from the MediaItem model.
+    /// Used as a fallback when the existing sidecar hasn't downloaded from iCloud.
+    private static func writeFullSidecar(for item: MediaItem, to url: URL) {
+        let sidecar = SidecarMetadata(
+            id: item.id,
+            type: item.mediaType.rawValue,
+            width: item.width,
+            height: item.height,
+            createdAt: item.createdAt,
+            duration: item.duration,
+            spaceId: item.space?.id,
+            imageContext: item.analysisResult?.imageContext,
+            imageSummary: item.analysisResult?.imageSummary,
+            patterns: item.analysisResult?.patterns.map { SidecarPattern(name: $0.name, confidence: $0.confidence) },
+            sourceURL: item.sourceURL,
+            analyzedAt: item.analysisResult?.analyzedAt
+        )
+
+        if let data = try? encoder.encode(sidecar) {
+            try? data.write(to: url, options: .atomic)
         }
     }
 }

--- a/ios/SnapGrid/SnapGrid/Services/SyncService.swift
+++ b/ios/SnapGrid/SnapGrid/Services/SyncService.swift
@@ -15,6 +15,7 @@ struct SidecarMetadata: Codable, Sendable {
     let imageSummary: String?
     let patterns: [SidecarPattern]?
     let sourceURL: String?
+    let analyzedAt: Date?
 }
 
 struct SidecarPattern: Codable, Sendable {
@@ -170,6 +171,7 @@ final class SyncService {
                         imageContext: imageContext,
                         imageSummary: sidecar.imageSummary ?? "",
                         patterns: patterns,
+                        analyzedAt: sidecar.analyzedAt ?? .now,
                         provider: "synced",
                         model: "icloud-sync"
                     )
@@ -267,17 +269,31 @@ final class SyncService {
             item.sourceURL = sourceURL
         }
 
-        // Update analysis if it was added/changed
+        // Update analysis if the remote sidecar has newer or missing-locally analysis
         let hasAnalysis = sidecar.imageContext != nil && !(sidecar.imageContext?.isEmpty ?? true)
-        if hasAnalysis && item.analysisResult == nil {
-            let patterns = (sidecar.patterns ?? []).map { PatternTag(name: $0.name, confidence: $0.confidence) }
-            item.analysisResult = AnalysisResult(
-                imageContext: sidecar.imageContext!,
-                imageSummary: sidecar.imageSummary ?? "",
-                patterns: patterns,
-                provider: "synced",
-                model: "icloud-sync"
-            )
+        if hasAnalysis {
+            let shouldSync: Bool
+            if item.analysisResult == nil {
+                shouldSync = true
+            } else if let remoteDate = sidecar.analyzedAt,
+                      let localDate = item.analysisResult?.analyzedAt,
+                      remoteDate > localDate {
+                shouldSync = true
+            } else {
+                shouldSync = false
+            }
+
+            if shouldSync {
+                let patterns = (sidecar.patterns ?? []).map { PatternTag(name: $0.name, confidence: $0.confidence) }
+                item.analysisResult = AnalysisResult(
+                    imageContext: sidecar.imageContext!,
+                    imageSummary: sidecar.imageSummary ?? "",
+                    patterns: patterns,
+                    analyzedAt: sidecar.analyzedAt ?? .now,
+                    provider: "synced",
+                    model: "icloud-sync"
+                )
+            }
         }
     }
 }

--- a/ios/SnapGrid/SnapGrid/Services/iCloudDownloadMonitor.swift
+++ b/ios/SnapGrid/SnapGrid/Services/iCloudDownloadMonitor.swift
@@ -30,8 +30,11 @@ class iCloudDownloadMonitor {
     }
 
     /// Check if a file is currently downloaded/local.
+    /// Clears cached resource values first to get fresh iCloud status.
     func isDownloaded(_ url: URL) -> Bool {
-        guard let values = try? url.resourceValues(
+        var freshURL = url
+        freshURL.removeAllCachedResourceValues()
+        guard let values = try? freshURL.resourceValues(
             forKeys: [.ubiquitousItemDownloadingStatusKey]
         ) else {
             // Can't read resource values — assume local file

--- a/ios/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -194,6 +194,13 @@ struct GridItemView: View {
         .task {
             await loadThumbnail()
         }
+        .onChange(of: isSelected) { wasSelected, isNowSelected in
+            // Retry thumbnail load after returning from full-screen overlay
+            // if the iCloud file has since downloaded
+            if wasSelected && !isNowSelected && thumbnail == nil {
+                Task { await loadThumbnail() }
+            }
+        }
     }
 
     // MARK: - Thumbnail Loading
@@ -215,7 +222,7 @@ struct GridItemView: View {
         }
     }
 
-    private func loadThumbnail() async {
+    private func loadThumbnail(isRetry: Bool = false) async {
         let cache = ThumbnailCache.shared
 
         // Try thumbnail first (fast, no wait)
@@ -248,7 +255,15 @@ struct GridItemView: View {
             }
         }
 
-        loadFailed = true
+        // Auto-retry once after a short delay — iCloud files may arrive
+        // just after the initial load attempt
+        if !isRetry {
+            try? await Task.sleep(for: .seconds(3))
+            guard !Task.isCancelled else { return }
+            await loadThumbnail(isRetry: true)
+        } else {
+            loadFailed = true
+        }
     }
 }
 

--- a/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
@@ -517,6 +517,11 @@ struct MainView: View {
             return
         }
 
+        // Clean up old trash (30+ days), matching Mac behavior
+        if isInitialLoad {
+            MediaDeleteService.emptyOldTrash(rootURL: rootURL)
+        }
+
         let skipped = await syncService.sync(rootURL: rootURL, context: modelContext)
         isLoading = false
 

--- a/ios/SnapGrid/SnapGridTests/SidecarCodableTests.swift
+++ b/ios/SnapGrid/SnapGridTests/SidecarCodableTests.swift
@@ -36,7 +36,8 @@ struct SidecarCodableTests {
                 SidecarPattern(name: "Mountain", confidence: 0.95),
                 SidecarPattern(name: "Sky", confidence: 0.88)
             ],
-            sourceURL: "https://x.com/user/status/123"
+            sourceURL: "https://x.com/user/status/123",
+            analyzedAt: Date(timeIntervalSince1970: 1700000100)
         )
 
         let data = try Self.encoder.encode(original)
@@ -67,7 +68,8 @@ struct SidecarCodableTests {
             imageContext: nil,
             imageSummary: nil,
             patterns: nil,
-            sourceURL: nil
+            sourceURL: nil,
+            analyzedAt: nil
         )
 
         let data = try Self.encoder.encode(original)
@@ -96,7 +98,8 @@ struct SidecarCodableTests {
             imageContext: nil,
             imageSummary: nil,
             patterns: nil,
-            sourceURL: "https://x.com/user/status/1234567890"
+            sourceURL: "https://x.com/user/status/1234567890",
+            analyzedAt: nil
         )
 
         let data = try Self.encoder.encode(original)


### PR DESCRIPTION
### Why?

Cross-platform audit of the Mac and iOS apps revealed several sync bugs where data written by one platform was silently dropped or ignored by the other. Analysis results from iOS never reached the Mac, re-analysis was permanently siloed, deleting all spaces didn't sync, and iOS silently lost sidecar writes when iCloud files hadn't downloaded yet. Additionally, iOS thumbnails showed as grey boxes for recently synced items because the iCloud download monitor used stale cached URL resource values.

### How?

Expanded the Mac SyncWatcher's update path to carry and sync analysis results (not just spaceId), added `analyzedAt` to the sidecar format for timestamp-based re-analysis sync, and fixed the empty-spaces early-return that prevented deletion sync. On iOS, SidecarWriteService now falls back to writing a complete sidecar from model data when the iCloud file hasn't downloaded. Also ported multi-frame video analysis to iOS, added 30-day trash cleanup, fixed ImageImportService ID format, and fixed iCloudDownloadMonitor to clear stale cached resource values so polling detects completed downloads.

<details>
<summary>Implementation Plan</summary>

# Cross-Platform Audit: Mac + iOS SnapGrid Apps

## Context

Both native apps share the same iCloud storage (images/, metadata/, thumbnails/, spaces.json) and are meant to be companion apps that work identically. This audit reveals several sync bugs where data written by one platform is silently dropped or ignored by the other, plus behavioral gaps between the two apps.

---

## Tier 1: Critical Sync Data Loss

### Bug 1: Mac SyncWatcher drops analysis results synced from iOS

**Files:** `SnapGrid/Services/SyncWatcher.swift:42-46, 203-207, 374-396`

When the Mac detects a *modified* sidecar (file mod date changed), it creates a `SidecarUpdateData` carrying only `spaceId` and `sourceURL`. The `imageContext`, `imageSummary`, and `patterns` fields are completely ignored. So if iOS runs AI analysis and writes results to the sidecar JSON, the Mac never picks them up.

The `applyImport` path (for *new* items) correctly handles analysis — it's only the *update* path that's broken.

**Fix:** Expand `SidecarUpdateData` to include analysis fields (or read the full sidecar), and have `applySpaceUpdate` sync analysis when the sidecar has results that the local item lacks.

---

### Bug 2: Re-analysis never syncs in either direction

**Files:** `ios/SnapGrid/Services/SyncService.swift:272`, `SnapGrid/Services/SyncWatcher.swift:203-207`

iOS's `updateIfNeeded` only syncs analysis when `item.analysisResult == nil`. If a user re-analyzes on Mac with a different model, iOS ignores it because it already has a result. Mac's SyncWatcher ignores analysis in modified sidecars entirely (Bug 1). So re-analysis is permanently siloed.

**Fix:** Compare `analyzedAt` dates (or provider/model) to detect newer analysis. Sync when the remote sidecar has a more recent result. Note: `analyzedAt` is NOT currently persisted in the sidecar JSON — it would need to be added to the sidecar format.

---

### Bug 3: Mac SyncWatcher can't delete all spaces

**File:** `SnapGrid/Services/SyncWatcher.swift:410`

If the user deletes all spaces on one device, spaces.json contains `{ "spaces": [] }`. The Mac SyncWatcher early-returns and never removes the orphaned Space records from SwiftData. iOS's `SyncService.syncSpaces` handles this correctly.

**Fix:** Remove the early return, or move it after the orphan-deletion loop.

---

### Bug 4: iOS SidecarWriteService silently loses data when sidecar not yet downloaded

**File:** `ios/SnapGrid/Services/SidecarWriteService.swift:12-13, 35-36`

Both write methods use a merge pattern: read existing JSON, update fields, write back. If the sidecar file hasn't downloaded from iCloud yet, the `guard` fails silently and the write is lost. Space assignments and analysis results are permanently discarded.

**Fix:** When the existing sidecar can't be read, either (a) construct a complete sidecar from the MediaItem model data (like Mac does), or (b) queue the write and retry after iCloud download completes.

---

## Tier 2: Functional Gaps

### Bug 5: iOS never cleans up old trash

Mac calls `emptyOldTrash(olderThan: 30 days)` on startup. iOS only has `MediaDeleteService.moveToTrash()` — no cleanup ever happens. Trash accumulates indefinitely in the shared iCloud container, consuming storage.

**Fix:** Add trash cleanup to iOS MainView's `loadContent()` or `onAppear`, matching the Mac's 30-day threshold.

---

### Bug 6: iOS video analysis uses single frame vs Mac's multi-frame

Mac extracts frames at 33% and 66% of video duration, analyzes both, and merges results (averaging pattern confidence). iOS extracts a single frame at 1 second and runs standard single-image analysis.

**Fix:** Port `analyzeVideo(frames:)` and `mergeFrameResults` to iOS's `AIAnalysisService`, and update `AnalysisCoordinator.loadImage` to extract multiple frames for videos.

---

### Bug 7: iOS ImageImportService uses non-UUID IDs

Generates `img_{timestamp}_{random7chars}` while every other import path across both platforms uses `UUID().uuidString`.

**Fix:** Switch to `UUID().uuidString` to match the Mac and the iOS Share Extension's SyncService path.

</details>

<sub>Generated with Claude Code</sub>