### PR TITLE
Disable native macOS tab bar in SnapGrid

### DIFF
--- a/SnapGrid/SnapGrid/App/SnapGridApp.swift
+++ b/SnapGrid/SnapGrid/App/SnapGridApp.swift
@@ -6,6 +6,8 @@ struct SnapGridApp: App {
     let container: ModelContainer
 
     init() {
+        NSWindow.allowsAutomaticWindowTabbing = false
+
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         let snapGridDir = appSupport.appendingPathComponent("SnapGrid", isDirectory: true)
         try? FileManager.default.createDirectory(at: snapGridDir, withIntermediateDirectories: true)


### PR DESCRIPTION
### Why?

SnapGrid is a single-window app with its own Spaces sidebar navigation. The native macOS "Show Tab Bar" and "Show All Tabs" items in the View menu are unnecessary and potentially confusing.

### How?

Sets `NSWindow.allowsAutomaticWindowTabbing = false` in the app's `init()`, which suppresses the automatic window tabbing menu items before any windows are created.

<details>
<summary>Implementation Plan</summary>

# Remove native macOS tab bar from SnapGrid

## Context
The macOS View menu shows "Show Tab Bar" and "Show All Tabs" — automatic window tabbing features that are unnecessary for this single-window app. These need to be removed.

## Change
**File:** `SnapGrid/SnapGrid/App/SnapGridApp.swift`

Add one line at the top of `init()`:
```swift
NSWindow.allowsAutomaticWindowTabbing = false
```

This is a class-level property on NSWindow. Setting it before any windows are created suppresses both menu items system-wide for the app. No AppDelegate or new files needed — the app already uses NSWindow/NSApp symbols elsewhere.

## Verification
1. Build with `xcodegen generate && xcodebuild build`
2. Run the app, open View menu — "Show Tab Bar" and "Show All Tabs" should be gone
3. Zoom In/Out should still appear (they come from a separate `CommandGroup(replacing: .toolbar)`)

</details>

<sub>Generated with Claude Code</sub>