### PR TITLE
Remove forced unified toolbar style on macOS

### DIFF
--- a/SnapGrid/SnapGrid/App/SnapGridApp.swift
+++ b/SnapGrid/SnapGrid/App/SnapGridApp.swift
@@ -51,7 +51,6 @@ struct SnapGridApp: App {
                 .task { KeySyncService.syncToiCloud() }
         }
         .modelContainer(container)
-        .windowToolbarStyle(.unified)
         .defaultSize(width: 1280, height: 800)
         .windowResizability(.contentMinSize)
         .defaultPosition(.center)

--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -151,7 +151,7 @@ struct ContentView: View {
                         .ignoresSafeArea()
                         .allowsHitTesting(false)
                         .transition(.opacity)
-                }
+                    }
             }
         }
         .frame(minWidth: 720, minHeight: 400)
@@ -830,6 +830,7 @@ struct ContentView: View {
     }
 
 }
+
 
 // MARK: - Notification Modifier
 // Extracted to reduce body complexity and avoid Swift type-checker timeouts.


### PR DESCRIPTION
## Summary
- remove the explicit `.windowToolbarStyle(.unified)` from the macOS app scene
- restore the system-managed titlebar appearance so the transparent toolbar and native scroll-edge behavior can return
- include only minor formatting cleanup in `ContentView.swift`

## Testing
- `xcodebuild -project SnapGrid/SnapGrid.xcodeproj -scheme SnapGrid -sdk macosx -derivedDataPath /tmp/snapgrid-mac-derived CODE_SIGNING_ALLOWED=NO build`