### PR TITLE
Fix iOS detail pattern pill crash during search handoff

### DIFF
--- a/ios/SnapGrid/SnapGrid/App/AppState.swift
+++ b/ios/SnapGrid/SnapGrid/App/AppState.swift
@@ -23,6 +23,7 @@ final class AppState {
     var thumbnailImage: UIImage?
     var showOverlay = false
     var pendingSearchActivation = false
+    var pendingSearchPattern: String?
     var activeSpaceId: String? = nil
     var searchText = ""
     var searchScores: [String: Double] = [:]
@@ -31,4 +32,21 @@ final class AppState {
     var isImporting = false
     var itemToDelete: MediaItem?
     var shareItem: URL?
+
+    func queuePatternSearch(_ pattern: String) {
+        pendingSearchPattern = pattern
+        pendingSearchActivation = true
+    }
+
+    func applyPendingSearchIfNeeded(prefersDedicatedSearchTab: Bool) {
+        guard pendingSearchActivation else { return }
+
+        if let pendingSearchPattern {
+            searchText = pendingSearchPattern
+        }
+
+        selectedTab = prefersDedicatedSearchTab ? .search : .all
+        pendingSearchPattern = nil
+        pendingSearchActivation = false
+    }
 }

--- a/ios/SnapGrid/SnapGrid/Views/Detail/ImageDetailView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/ImageDetailView.swift
@@ -68,6 +68,16 @@ struct MediaDetailModal: View {
         return items[selectedIndex]
     }
 
+    private var resolvedStartIndex: Int? {
+        if let selectedItemId,
+           let matchedIndex = items.firstIndex(where: { $0.id == selectedItemId }) {
+            return matchedIndex
+        }
+
+        guard let selectedIndex, !items.isEmpty else { return nil }
+        return min(max(selectedIndex, 0), items.count - 1)
+    }
+
     var body: some View {
         GeometryReader { geo in
             let overlaySize = CGSize(
@@ -76,7 +86,7 @@ struct MediaDetailModal: View {
             )
             let topReservedInset = DetailChrome.reservedTopInset(safeAreaTop: geo.safeAreaInsets.top)
 
-            if let startIndex = selectedIndex {
+            if let startIndex = resolvedStartIndex {
                 NavigationStack {
                     Color.clear
                         .background(TransparentNavigationContainer())

--- a/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
@@ -204,14 +204,14 @@ struct MainView: View {
     @ViewBuilder
     private func tabContent(gridWidth: CGFloat) -> some View {
         if #available(iOS 26, *) {
-            TabView {
-                Tab("All", systemImage: "square.grid.2x2") {
+            TabView(selection: $appState.selectedTab) {
+                Tab("All", systemImage: "square.grid.2x2", value: AppTab.all) {
                     allItemsContent(gridWidth: gridWidth)
                 }
-                Tab("Spaces", systemImage: "folder") {
+                Tab("Spaces", systemImage: "folder", value: AppTab.spaces) {
                     spacesContent(gridWidth: gridWidth)
                 }
-                Tab(role: .search) {
+                Tab(value: AppTab.search, role: .search) {
                     searchContent(gridWidth: gridWidth)
                 }
             }
@@ -355,15 +355,18 @@ struct MainView: View {
 
     private func handleOverlayClosed() {
         appState.detailHost = nil
-        if appState.pendingSearchActivation {
-            appState.selectedTab = .search
-            appState.pendingSearchActivation = false
-        }
+        appState.applyPendingSearchIfNeeded(prefersDedicatedSearchTab: supportsDedicatedSearchTab)
     }
 
     private func handleSearchPattern(_ pattern: String) {
-        appState.searchText = pattern
-        appState.pendingSearchActivation = true
+        appState.queuePatternSearch(pattern)
+    }
+
+    private var supportsDedicatedSearchTab: Bool {
+        if #available(iOS 26, *) {
+            return true
+        }
+        return false
     }
 
     // MARK: - Space Creation

--- a/ios/SnapGrid/SnapGridTests/AppStateTests.swift
+++ b/ios/SnapGrid/SnapGridTests/AppStateTests.swift
@@ -1,0 +1,47 @@
+import Testing
+@testable import SnapGrid
+
+@Suite("AppState", .tags(.model))
+@MainActor
+struct AppStateTests {
+
+    @Test("Pattern search is queued until overlay close")
+    func queuePatternSearchDefersMutation() {
+        let state = AppState()
+        state.searchText = "existing"
+
+        state.queuePatternSearch("Button")
+
+        #expect(state.searchText == "existing")
+        #expect(state.pendingSearchActivation)
+        #expect(state.pendingSearchPattern == "Button")
+    }
+
+    @Test("Queued pattern search falls back to all tab before iOS 26")
+    func applyPendingSearchFallsBackToAllTab() {
+        let state = AppState()
+        state.selectedTab = .spaces
+        state.queuePatternSearch("Button")
+
+        state.applyPendingSearchIfNeeded(prefersDedicatedSearchTab: false)
+
+        #expect(state.searchText == "Button")
+        #expect(state.selectedTab == .all)
+        #expect(!state.pendingSearchActivation)
+        #expect(state.pendingSearchPattern == nil)
+    }
+
+    @Test("Queued pattern search can activate dedicated search tab")
+    func applyPendingSearchActivatesSearchTab() {
+        let state = AppState()
+        state.selectedTab = .all
+        state.queuePatternSearch("Chart")
+
+        state.applyPendingSearchIfNeeded(prefersDedicatedSearchTab: true)
+
+        #expect(state.searchText == "Chart")
+        #expect(state.selectedTab == .search)
+        #expect(!state.pendingSearchActivation)
+        #expect(state.pendingSearchPattern == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- defer pattern-pill search updates until the detail overlay finishes closing
- preserve a pending search pattern in app state and apply it to the appropriate tab after dismissal
- resolve the detail modal start index defensively from `selectedItemId` and clamp fallback index values
- add regression tests for queued pattern-search behavior and tab selection

## Testing
- `xcodebuild` iOS simulator build
- `xcodebuild` test run for `SnapGridTests/AppStateTests`