### PR TITLE
Remove duplicate iOS titlebar search field

### DIFF
--- a/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
@@ -215,7 +215,6 @@ struct MainView: View {
                     searchContent(gridWidth: gridWidth)
                 }
             }
-            .searchable(text: $appState.searchText, prompt: "Search patterns, context...")
             .tabViewSearchActivation(.searchTabSelection)
             .tint(.white)
         } else {
@@ -317,6 +316,7 @@ struct MainView: View {
             .navigationTitle("SnapGrid")
             .navigationBarTitleDisplayMode(.inline)
             .toolbarColorScheme(.dark, for: .navigationBar)
+            .searchable(text: $appState.searchText, prompt: "Search patterns, context...")
         }
     }
 


### PR DESCRIPTION
## Summary
- move `.searchable(...)` from the top-level iOS 26 `TabView` to the dedicated search tab content
- prevent the extra search field from appearing below the `All media` title
- preserve the bottom search-tab activation flow as the only search entry point

## Testing
- Not run (not requested)