### PR TITLE
Replace iOS detail back chevron with close X icon

### DIFF
--- a/ios/SnapGrid/SnapGrid/Views/Detail/ImageDetailView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/ImageDetailView.swift
@@ -125,7 +125,7 @@ struct MediaDetailModal: View {
                                 Button {
                                     closeRequestID += 1
                                 } label: {
-                                    Label("Back", systemImage: "chevron.left")
+                                    Label("Close", systemImage: "xmark")
                                 }
                             }
 


### PR DESCRIPTION
### Why?

The iOS detail view is a custom overlay dismissal, not a navigation stack pop. The back chevron (`chevron.left`) misrepresents the interaction — an X icon (`xmark`) is the correct affordance for closing an overlay.

### How?

Swap the SF Symbol from `chevron.left` to `xmark` and update the accessibility label from "Back" to "Close".

<sub>Generated with Claude Code</sub>