### PR TITLE
Scope iOS search to active space

### DIFF
--- a/ios/SnapGrid/SnapGrid/App/AppState.swift
+++ b/ios/SnapGrid/SnapGrid/App/AppState.swift
@@ -25,6 +25,7 @@ final class AppState {
     var pendingSearchActivation = false
     var pendingSearchPattern: String?
     var activeSpaceId: String? = nil
+    var searchSpaceId: String? = nil
     var searchText = ""
     var searchScores: [String: Double] = [:]
     var showPhotosPicker = false

--- a/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
@@ -27,25 +27,33 @@ struct MainView: View {
 
     // MARK: - Filtering
 
+    private var searchBaseItems: [MediaItem] {
+        if let spaceId = appState.searchSpaceId {
+            return allItems.filter { $0.belongs(to: spaceId) }
+        }
+        return Array(allItems)
+    }
+
     private var searchResultItems: [MediaItem] {
         let scores = appState.searchScores
         let query = appState.searchText.lowercased().trimmingCharacters(in: .whitespaces)
+        let base = searchBaseItems
 
         guard !query.isEmpty else { return [] }
 
-        if query == "vid" { return allItems.filter { $0.isVideo } }
-        if query == "img" { return allItems.filter { !$0.isVideo } }
+        if query == "vid" { return base.filter { $0.isVideo } }
+        if query == "img" { return base.filter { !$0.isVideo } }
 
         guard !scores.isEmpty else { return [] }
 
-        return allItems
+        return base
             .filter { scores[$0.id] != nil }
             .sorted { (scores[$0.id] ?? 0) > (scores[$1.id] ?? 0) }
     }
 
     private var searchContentItems: [MediaItem] {
         let query = appState.searchText.trimmingCharacters(in: .whitespaces)
-        guard !query.isEmpty else { return Array(allItems) }
+        guard !query.isEmpty else { return searchBaseItems }
         return searchResultItems
     }
 
@@ -143,6 +151,13 @@ struct MainView: View {
                     ShareImportService.importPendingItems(to: rootURL)
                 }
                 Task { await loadContent() }
+            }
+        }
+        .onChange(of: appState.selectedTab) { _, newTab in
+            if newTab == .search {
+                appState.searchSpaceId = appState.activeSpaceId
+            } else {
+                appState.searchSpaceId = nil
             }
         }
         .sheet(isPresented: $appState.showPhotosPicker) {
@@ -282,6 +297,7 @@ struct MainView: View {
     private func searchContent(gridWidth: CGFloat) -> some View {
         @Bindable var appState = appState
         let items = searchContentItems
+        let scopedSpaceName = appState.searchSpaceId.flatMap { id in spaces.first { $0.id == id }?.name }
 
         NavigationStack {
             ZStack {
@@ -313,10 +329,13 @@ struct MainView: View {
                     .scrollDismissesKeyboard(.interactively)
                 }
             }
-            .navigationTitle("SnapGrid")
+            .navigationTitle(scopedSpaceName ?? "SnapGrid")
             .navigationBarTitleDisplayMode(.inline)
             .toolbarColorScheme(.dark, for: .navigationBar)
-            .searchable(text: $appState.searchText, prompt: "Search patterns, context...")
+            .searchable(
+                text: $appState.searchText,
+                prompt: scopedSpaceName.map { "Search in \($0)..." } ?? "Search patterns, context..."
+            )
         }
     }
 


### PR DESCRIPTION
### Why?

Tapping search while viewing a space on iOS searches globally across all items, rather than scoping results to the current space.

### How?

When the search tab activates, the active space ID is captured into a `searchSpaceId` on `AppState`. The search filtering pipeline (`searchBaseItems` → `searchResultItems` → `searchContentItems`) uses this to scope results to items in that space. The search prompt and nav title update to show the space name. Switching away from search clears the scope.

<details>
<summary>Implementation Plan</summary>

# Plan: Space-scoped search on iOS

## Context

When a user is viewing a space on iOS and taps the search bar, the search currently operates globally across all items. The user expects searching within a space to only return results from that space's items.

Currently, `SpaceDetailView` has no `.searchable` modifier at all — on iOS 26+, tapping search activates the global search tab via `.tabViewSearchActivation(.searchTabSelection)`. The fix is to add an in-context search bar to `SpaceDetailView` that filters only the space's items.

## Approach

Add local search state and a `.searchable` modifier to `SpaceDetailView`. Pass a search closure from MainView (via SpacesTab) so SpaceDetailView can use the existing BM25 search index without owning it directly.

### Files to modify

1. **`ios/SnapGrid/SnapGrid/Views/Spaces/SpaceDetailView.swift`** — Core change
   - Add `@State private var searchText = ""`
   - Add `@State private var searchScores: [String: Double] = [:]`
   - Add `@State private var debounceTask: Task<Void, Never>?`
   - Accept a new `onSearch: (String) -> [SearchResult]` closure parameter
   - Add `.searchable(text: $searchText, prompt: "Search in space...")` to the view
   - Add `.onChange(of: searchText)` with debounced BM25 search (same pattern as MainView lines 110-131)
   - Update `spaceItems` to filter by search scores when search text is non-empty
   - Support the `vid`/`img` shortcut filters scoped to space items
   - Show `SearchEmptyStateView` when search has no results

2. **`ios/SnapGrid/SnapGrid/Views/Main/SpacesTab.swift`** — Thread the closure through
   - Add `onSearch: @escaping (String) -> [SearchResult]` parameter
   - Pass it to `SpaceDetailView` in the `.navigationDestination` block (line 99)

3. **`ios/SnapGrid/SnapGrid/Views/Main/MainView.swift`** — Provide the closure
   - Pass `onSearch: { searchService.search(query: $0) }` to `SpacesTab` in `spacesContent()` (line 262)

### Filtering logic in SpaceDetailView

```swift
private var filteredSpaceItems: [MediaItem] {
    let query = searchText.trimmingCharacters(in: .whitespaces)
    guard !query.isEmpty else { return spaceItems }

    let lowered = query.lowercased()
    if lowered == "vid" { return spaceItems.filter { $0.isVideo } }
    if lowered == "img" { return spaceItems.filter { !$0.isVideo } }

    guard !searchScores.isEmpty else { return [] }

    return spaceItems
        .filter { searchScores[$0.id] != nil }
        .sorted { (searchScores[$0.id] ?? 0) > (searchScores[$1.id] ?? 0) }
}
```

This reuses the global BM25 index (already built on all items), but intersects results with `spaceItems` — only items belonging to the space are returned.

## Verification

1. Build: `cd ios/SnapGrid && xcodebuild build -project SnapGrid.xcodeproj -scheme SnapGrid -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | xcbeautify --quiet`
2. Manual test: Open a space, tap search, verify results are scoped to space items only
3. Verify global search (All tab, Search tab) still works unchanged

</details>

<sub>Generated with Claude Code</sub>