### PR TITLE
Fix Mac share panel position to appear below button

### DIFF
--- a/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
+++ b/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
@@ -46,13 +46,14 @@
 		7EC7FDEF2B1AB437602F7CBA /* SidecarCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6F116E4024331E85284A3D /* SidecarCodableTests.swift */; };
 		8167D57BFF6AAEC5E1CF20E1 /* AnimationTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 468F744BF11C8965B74EF95F /* AnimationTokens.swift */; };
 		8350DC604AC401431E9CD255 /* Space.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6477AAD40C3308F596D68729 /* Space.swift */; };
-		83A4E1B2C3D4E5F60718293A /* SpaceMembership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A4E1B2C3D4E5F60718293A /* SpaceMembership.swift */; };
 		8F71F68AF462303D3E8EFF3F /* MasonryGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AD67C6232580C3B0D9E982 /* MasonryGridView.swift */; };
 		90E631F7D9C9E3645285E61A /* DeveloperSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0EEC1133F2A0A3770E116D /* DeveloperSettingsTab.swift */; };
 		9101F365F60BDAB8F4E28C3E /* VideoFrameExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5C14CF112B283919BE0F7D /* VideoFrameExtractor.swift */; };
 		93739E5784974939896FFF0D /* AIAnalysisService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8B38057F541288379ABCA2 /* AIAnalysisService.swift */; };
 		954370CE14C8FBFE6ACED486 /* AISettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54E35D95E714B17E2ECD3150 /* AISettingsTab.swift */; };
 		968DDBB08FE3CED44009BC7D /* MediaStorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 963A5601AC378837EA06DF0E /* MediaStorageService.swift */; };
+		998C7D0061E2C761956FC2E3 /* SpaceGuidanceResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1696B4C530053979783AE15 /* SpaceGuidanceResolverTests.swift */; };
+		9C71904E952150ED1955B8A1 /* SpaceMembership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E99DFC078951AD2464BFA00 /* SpaceMembership.swift */; };
 		9C85488C4998238102951235 /* AIAnalysisParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F5C8EE662A5F61686B9D75F /* AIAnalysisParsingTests.swift */; };
 		A1DD9F32448B920AC6E63BB2 /* SyncWatcherIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736BF8FF80CB87437CBFAB02 /* SyncWatcherIntegrationTests.swift */; };
 		A49356A43DA978FCC2C0536C /* IntegrationTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E1F6F29AC12B68F7CEE44A /* IntegrationTestSupport.swift */; };
@@ -78,7 +79,6 @@
 		E3CF37F05242E8078AC2B79B /* KeySyncCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998B3A855E657D80396A9CD7 /* KeySyncCryptoTests.swift */; };
 		ED7E6EF1043AE2A69F053E6C /* ImageCacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB57D4AB7F12528E5ECD77DF /* ImageCacheService.swift */; };
 		EDFCACF450DFF848F52E6103 /* ModelRelationshipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1455E0958E33E6A111BD604E /* ModelRelationshipTests.swift */; };
-		EFACBD1234567890ABCDEF12 /* SpaceGuidanceResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFACBD1234567890ABCDEF12 /* SpaceGuidanceResolverTests.swift */; };
 		EED812B5100CAE8E3D506AEE /* FloatingVideoLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE02953B123E7318BEBBA18 /* FloatingVideoLayer.swift */; };
 		F84D4B0142262DA02D0EF60D /* MetadataSidecarService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB5003E05FB3CAF53FEDBCA5 /* MetadataSidecarService.swift */; };
 		FA711149840B9BFF157A8239 /* StorageSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50DDD531DF326D845D4CCA67 /* StorageSettingsTab.swift */; };
@@ -136,7 +136,6 @@
 		7EA5CD58DFE308DF284CE4AE /* ImportServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportServiceTests.swift; sourceTree = "<group>"; };
 		82D1884A0E94D6BC1F407855 /* AnalysisResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisResult.swift; sourceTree = "<group>"; };
 		8698BA9F19DB6BE06979FE75 /* MetadataSidecarIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataSidecarIntegrationTests.swift; sourceTree = "<group>"; };
-		93A4E1B2C3D4E5F60718293A /* SpaceMembership.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceMembership.swift; sourceTree = "<group>"; };
 		8F5C8EE662A5F61686B9D75F /* AIAnalysisParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIAnalysisParsingTests.swift; sourceTree = "<group>"; };
 		91A0CC2831F5CB94D1AF02D9 /* DataCleanupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCleanupService.swift; sourceTree = "<group>"; };
 		9391B9A3F7CE5C394F263B9C /* ModelDiscoveryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDiscoveryService.swift; sourceTree = "<group>"; };
@@ -148,6 +147,7 @@
 		9CF36B9F264117143DF32A8E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		9DB5BFB2BC5A94B434803361 /* ElectronImportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElectronImportView.swift; sourceTree = "<group>"; };
 		9DF384E9543E7A79145F99F8 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		9E99DFC078951AD2464BFA00 /* SpaceMembership.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceMembership.swift; sourceTree = "<group>"; };
 		A2D061099D3271418E045006 /* SnapGridTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SnapGridTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A85F7B01B695649752ABBABE /* SpaceSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceSidebarView.swift; sourceTree = "<group>"; };
 		A89F00709738612D0D756F5B /* ErrorDescriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorDescriptionTests.swift; sourceTree = "<group>"; };
@@ -162,6 +162,7 @@
 		CA997027ED4E74CD029CFE3C /* DragThumbnailPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragThumbnailPreview.swift; sourceTree = "<group>"; };
 		CD33117D036F9A35077E816E /* SearchIndexServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchIndexServiceTests.swift; sourceTree = "<group>"; };
 		CF20E3B5FA0802105388A2AC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		D1696B4C530053979783AE15 /* SpaceGuidanceResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceGuidanceResolverTests.swift; sourceTree = "<group>"; };
 		D58AA24928C394F528447938 /* DetailItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailItemView.swift; sourceTree = "<group>"; };
 		D5AD67C6232580C3B0D9E982 /* MasonryGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasonryGridView.swift; sourceTree = "<group>"; };
 		D5F15FD60A40A9E4169DC73A /* SnapGrid.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SnapGrid.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -173,7 +174,6 @@
 		EB5003E05FB3CAF53FEDBCA5 /* MetadataSidecarService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataSidecarService.swift; sourceTree = "<group>"; };
 		F070C831AF60C5AF79237043 /* VideoPreviewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPreviewManager.swift; sourceTree = "<group>"; };
 		F583D33C78C0944D437A1356 /* ModelDiscoveryScoringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDiscoveryScoringTests.swift; sourceTree = "<group>"; };
-		FFACBD1234567890ABCDEF12 /* SpaceGuidanceResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceGuidanceResolverTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -195,8 +195,8 @@
 			children = (
 				82D1884A0E94D6BC1F407855 /* AnalysisResult.swift */,
 				3BA6AB7DC0A84E670681EB6C /* MediaItem.swift */,
-				93A4E1B2C3D4E5F60718293A /* SpaceMembership.swift */,
 				6477AAD40C3308F596D68729 /* Space.swift */,
+				9E99DFC078951AD2464BFA00 /* SpaceMembership.swift */,
 				99FFBFE4624B0A09BB339F3A /* SupportedMedia.swift */,
 			);
 			path = Models;
@@ -230,7 +230,7 @@
 				1455E0958E33E6A111BD604E /* ModelRelationshipTests.swift */,
 				CD33117D036F9A35077E816E /* SearchIndexServiceTests.swift */,
 				0C6F116E4024331E85284A3D /* SidecarCodableTests.swift */,
-				FFACBD1234567890ABCDEF12 /* SpaceGuidanceResolverTests.swift */,
+				D1696B4C530053979783AE15 /* SpaceGuidanceResolverTests.swift */,
 				6598B587FE431314D84564BF /* SyncWatcherDataTests.swift */,
 				736BF8FF80CB87437CBFAB02 /* SyncWatcherIntegrationTests.swift */,
 				2B22E27F602D62D0D71F8B81 /* TwitterVideoServiceTests.swift */,
@@ -522,7 +522,7 @@
 				D016DE668FB1A40FFB11BD0D /* SettingsView.swift in Sources */,
 				52559E4B91F49A6CEDD07719 /* SnapGridApp.swift in Sources */,
 				8350DC604AC401431E9CD255 /* Space.swift in Sources */,
-				83A4E1B2C3D4E5F60718293A /* SpaceMembership.swift in Sources */,
+				9C71904E952150ED1955B8A1 /* SpaceMembership.swift in Sources */,
 				45E1AAE8DB57B9F1B1E02F58 /* SpaceSidebarView.swift in Sources */,
 				FA711149840B9BFF157A8239 /* StorageSettingsTab.swift in Sources */,
 				67C13EA251A2A6E0FBDD4FC0 /* SupportedMedia.swift in Sources */,
@@ -559,7 +559,7 @@
 				EDFCACF450DFF848F52E6103 /* ModelRelationshipTests.swift in Sources */,
 				08DAE144678E84619184D186 /* SearchIndexServiceTests.swift in Sources */,
 				7EC7FDEF2B1AB437602F7CBA /* SidecarCodableTests.swift in Sources */,
-				EFACBD1234567890ABCDEF12 /* SpaceGuidanceResolverTests.swift in Sources */,
+				998C7D0061E2C761956FC2E3 /* SpaceGuidanceResolverTests.swift in Sources */,
 				BEA03F6A0BE41527598D7E81 /* SwiftDataTestSupport.swift in Sources */,
 				ACD5CD7D34819BB6E99CACD5 /* SyncWatcherDataTests.swift in Sources */,
 				A1DD9F32448B920AC6E63BB2 /* SyncWatcherIntegrationTests.swift in Sources */,

--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -23,6 +23,7 @@ struct ContentView: View {
     @State private var searchScores: [String: Double] = [:]
     @State private var isSearchActive = false
     @State private var isSearchFieldPresented = false
+    @State private var shareAnchorView: NSView?
 
     #if DEBUG
     @AppStorage("debugSimulateEmptyState") private var debugSimulateEmptyState = false
@@ -173,17 +174,13 @@ struct ContentView: View {
             if let detailId = appState.detailItem {
                 ToolbarItem(placement: .primaryAction) {
                     Button {
-                        if let window = NSApp.keyWindow {
-                            let frame = CGRect(
-                                x: window.frame.width - 100,
-                                y: window.frame.height - 50,
-                                width: 40, height: 40
-                            )
-                            shareItems(Set([detailId]), sourceFrame: frame)
+                        if let anchor = shareAnchorView {
+                            shareItems(Set([detailId]), anchorView: anchor)
                         }
                     } label: {
                         Label("Share", systemImage: "square.and.arrow.up")
                     }
+                    .background(ShareAnchorView(nsView: $shareAnchorView))
                 }
             }
         }
@@ -806,11 +803,22 @@ struct ContentView: View {
     }
 
     private func shareItems(_ ids: Set<String>, sourceFrame: CGRect) {
+        guard let tempURLs = prepareShareURLs(for: ids), !tempURLs.isEmpty else { return }
+        showPicker(items: tempURLs, sourceFrame: sourceFrame)
+    }
+
+    private func shareItems(_ ids: Set<String>, anchorView: NSView) {
+        guard let tempURLs = prepareShareURLs(for: ids), !tempURLs.isEmpty else { return }
+        let picker = NSSharingServicePicker(items: tempURLs)
+        picker.show(relativeTo: anchorView.bounds, of: anchorView, preferredEdge: .maxY)
+    }
+
+    private func prepareShareURLs(for ids: Set<String>) -> [URL]? {
         let urls = allItems
             .filter { ids.contains($0.id) }
             .map { MediaStorageService.shared.mediaURL(filename: $0.filename) }
             .filter { FileManager.default.fileExists(atPath: $0.path) }
-        guard !urls.isEmpty else { return }
+        guard !urls.isEmpty else { return nil }
 
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("SnapGridShare")
         try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -820,9 +828,11 @@ struct ContentView: View {
             try? FileManager.default.copyItem(at: url, to: dest)
             return dest
         }
-        guard !tempURLs.isEmpty else { return }
+        return tempURLs.isEmpty ? nil : tempURLs
+    }
 
-        let picker = NSSharingServicePicker(items: tempURLs)
+    private func showPicker(items: [URL], sourceFrame: CGRect) {
+        let picker = NSSharingServicePicker(items: items)
         if let window = NSApp.keyWindow,
            let contentView = window.contentView {
             let rect = contentView.convert(sourceFrame, from: nil)
@@ -832,6 +842,22 @@ struct ContentView: View {
 
 }
 
+
+// MARK: - Share Anchor
+
+/// Invisible NSViewRepresentable that captures the underlying NSView so we can
+/// anchor an NSSharingServicePicker to the exact toolbar button position.
+private struct ShareAnchorView: NSViewRepresentable {
+    @Binding var nsView: NSView?
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async { self.nsView = view }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+}
 
 // MARK: - Notification Modifier
 // Extracted to reduce body complexity and avoid Swift type-checker timeouts.


### PR DESCRIPTION
### Why?

The share panel in the detail view toolbar appears to the right of the share button instead of beneath it, because the button position is approximated with a hardcoded CGRect offset from the window frame.

### How?

Replace the hardcoded position estimate with an NSViewRepresentable anchor that captures the actual toolbar button's NSView, so `NSSharingServicePicker` can position itself directly relative to the real button frame.

<details>
<summary>Implementation Plan</summary>

# Fix share panel position — show below button, not to the right

## Context

The share button in the Mac app's detail view toolbar uses a **hardcoded CGRect** to approximate the button's position, then passes it to `NSSharingServicePicker.show(relativeTo:of:preferredEdge:)`. This is fragile — the estimated coordinates don't accurately reflect the real button position, causing macOS to place the picker to the right instead of below.

## File to modify

`SnapGrid/SnapGrid/Views/ContentView/ContentView.swift`

## Approach

Replace the hardcoded frame hack with a proper **NSView anchor** pattern:

1. **Add a small `NSViewRepresentable`** (e.g., `ShareButtonAnchor`) that exposes its underlying `NSView`. Place it as a `.background()` on the share button so it occupies the same frame.

2. **Store the anchor view** in a `@State` property on `ContentView`.

3. **In `shareItems()`**, use the captured `NSView` directly:
   ```swift
   picker.show(relativeTo: anchorView.bounds, of: anchorView, preferredEdge: .maxY)
   ```
   - `anchorView.bounds` is the exact button rect  
   - `.maxY` = below in AppKit's bottom-left coordinate system

4. **Remove the `sourceFrame` parameter** from `shareItems()` since we no longer need it.

## Why this works

The current code guesses the button position with `CGRect(x: window.frame.width - 100, y: window.frame.height - 50, ...)` and converts coordinates between systems — a fragile chain that breaks depending on window size, toolbar layout, etc. By anchoring to the actual NSView behind the SwiftUI button, the picker always appears directly below it regardless of layout.

## Verification

1. `cd SnapGrid && xcodegen generate && xcodebuild build -project SnapGrid.xcodeproj -scheme SnapGrid -destination 'platform=macOS'`
2. Run the app, open a detail view, click Share — picker should appear below the button

</details>

<sub>Generated with Claude Code</sub>