### PR TITLE
Add light mode support and appearance settings

### DIFF
--- a/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
+++ b/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		34F4BEE7907CD4E3B3A6BCB4 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A1525A6C63DFE52779E656 /* KeychainService.swift */; };
 		394E477C118BA720B2D210FE /* AIAnalysisVideoMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFF444DA9ACFCE3CA0ED5E41 /* AIAnalysisVideoMergeTests.swift */; };
 		3C8305A01967D9D664D9AA3D /* View+DoubleClick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6205D7E807323F142415FE /* View+DoubleClick.swift */; };
+		3D2BE0DF8B994AFDFD7BD472 /* GeneralSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B91561419FB6DD4EEB954BE /* GeneralSettingsTab.swift */; };
 		3E32EEAD58366546174BAAF5 /* TwitterVideoServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B22E27F602D62D0D71F8B81 /* TwitterVideoServiceTests.swift */; };
 		429D34E9222F716D0D0BE26C /* VideoPreviewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F070C831AF60C5AF79237043 /* VideoPreviewManager.swift */; };
 		439744C29794B39D02563DE6 /* ModelDiscoveryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9391B9A3F7CE5C394F263B9C /* ModelDiscoveryService.swift */; };
@@ -50,7 +51,6 @@
 		90E631F7D9C9E3645285E61A /* DeveloperSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0EEC1133F2A0A3770E116D /* DeveloperSettingsTab.swift */; };
 		9101F365F60BDAB8F4E28C3E /* VideoFrameExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5C14CF112B283919BE0F7D /* VideoFrameExtractor.swift */; };
 		93739E5784974939896FFF0D /* AIAnalysisService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8B38057F541288379ABCA2 /* AIAnalysisService.swift */; };
-		954370CE14C8FBFE6ACED486 /* AISettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54E35D95E714B17E2ECD3150 /* AISettingsTab.swift */; };
 		968DDBB08FE3CED44009BC7D /* MediaStorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 963A5601AC378837EA06DF0E /* MediaStorageService.swift */; };
 		998C7D0061E2C761956FC2E3 /* SpaceGuidanceResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1696B4C530053979783AE15 /* SpaceGuidanceResolverTests.swift */; };
 		9C71904E952150ED1955B8A1 /* SpaceMembership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E99DFC078951AD2464BFA00 /* SpaceMembership.swift */; };
@@ -121,7 +121,6 @@
 		4946771AF0D1FD96153CD335 /* TestTags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestTags.swift; sourceTree = "<group>"; };
 		4A54C0203E211CB945681AD5 /* ImportServiceIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportServiceIntegrationTests.swift; sourceTree = "<group>"; };
 		50DDD531DF326D845D4CCA67 /* StorageSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageSettingsTab.swift; sourceTree = "<group>"; };
-		54E35D95E714B17E2ECD3150 /* AISettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISettingsTab.swift; sourceTree = "<group>"; };
 		567E56BCED6198606FEE46D4 /* PromptsSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptsSettingsTab.swift; sourceTree = "<group>"; };
 		5AD86EAF0DB32A5991AF004C /* SwiftDataTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataTestSupport.swift; sourceTree = "<group>"; };
 		5EE73C497EBB7A2FE40F9777 /* GuidanceFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceFallbackTests.swift; sourceTree = "<group>"; };
@@ -133,6 +132,7 @@
 		6D68BC12D80D5245328C0704 /* MediaItemContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaItemContextMenu.swift; sourceTree = "<group>"; };
 		736BF8FF80CB87437CBFAB02 /* SyncWatcherIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncWatcherIntegrationTests.swift; sourceTree = "<group>"; };
 		79AADB26603B741C1AC17342 /* SnapGrid.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SnapGrid.entitlements; sourceTree = "<group>"; };
+		7B91561419FB6DD4EEB954BE /* GeneralSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsTab.swift; sourceTree = "<group>"; };
 		7EA5CD58DFE308DF284CE4AE /* ImportServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportServiceTests.swift; sourceTree = "<group>"; };
 		82D1884A0E94D6BC1F407855 /* AnalysisResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisResult.swift; sourceTree = "<group>"; };
 		8698BA9F19DB6BE06979FE75 /* MetadataSidecarIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataSidecarIntegrationTests.swift; sourceTree = "<group>"; };
@@ -342,8 +342,8 @@
 		C53D6B47B446B4DA138608AB /* Settings */ = {
 			isa = PBXGroup;
 			children = (
-				54E35D95E714B17E2ECD3150 /* AISettingsTab.swift */,
 				AB0EEC1133F2A0A3770E116D /* DeveloperSettingsTab.swift */,
+				7B91561419FB6DD4EEB954BE /* GeneralSettingsTab.swift */,
 				567E56BCED6198606FEE46D4 /* PromptsSettingsTab.swift */,
 				9DF384E9543E7A79145F99F8 /* SettingsView.swift */,
 				50DDD531DF326D845D4CCA67 /* StorageSettingsTab.swift */,
@@ -485,7 +485,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				93739E5784974939896FFF0D /* AIAnalysisService.swift in Sources */,
-				954370CE14C8FBFE6ACED486 /* AISettingsTab.swift in Sources */,
 				D9FE517E672AA97AAD667259 /* AnalysisResult.swift in Sources */,
 				8167D57BFF6AAEC5E1CF20E1 /* AnimationTokens.swift in Sources */,
 				071B2A3BF29E5D8C82A0F4DB /* AppState.swift in Sources */,
@@ -500,6 +499,7 @@
 				04949283870877DAA125B2B8 /* EmptyStateView.swift in Sources */,
 				EED812B5100CAE8E3D506AEE /* FloatingVideoLayer.swift in Sources */,
 				572A0BCDDD41A4C5E4D7B75E /* FlowLayout.swift in Sources */,
+				3D2BE0DF8B994AFDFD7BD472 /* GeneralSettingsTab.swift in Sources */,
 				E317897879AD400BF3F5A524 /* GridItemView.swift in Sources */,
 				ED7E6EF1043AE2A69F053E6C /* ImageCacheService.swift in Sources */,
 				BA67E76C4D3CB12E2DF2B9A9 /* ImportService.swift in Sources */,

--- a/SnapGrid/SnapGrid/App/SnapGridApp.swift
+++ b/SnapGrid/SnapGrid/App/SnapGridApp.swift
@@ -3,8 +3,13 @@ import SwiftData
 
 @main
 struct SnapGridApp: App {
+    @AppStorage("appearanceMode") private var appearanceMode: String = AppearanceMode.dark.rawValue
     let container: ModelContainer
     private static let multiSpaceStoreResetKey = "multiSpaceStoreReset_v1"
+
+    private var appearanceColorScheme: ColorScheme? {
+        (AppearanceMode(rawValue: appearanceMode) ?? .dark).colorScheme
+    }
 
     init() {
         NSWindow.allowsAutomaticWindowTabbing = false
@@ -48,6 +53,7 @@ struct SnapGridApp: App {
     var body: some Scene {
         WindowGroup("SnapGrid") {
             ContentView()
+                .preferredColorScheme(appearanceColorScheme)
                 .task { KeySyncService.syncToiCloud() }
         }
         .modelContainer(container)
@@ -148,6 +154,7 @@ struct SnapGridApp: App {
 
         Settings {
             SettingsView()
+                .preferredColorScheme(appearanceColorScheme)
         }
         .modelContainer(container)
     }

--- a/SnapGrid/SnapGrid/Views/Detail/DetailItemView.swift
+++ b/SnapGrid/SnapGrid/Views/Detail/DetailItemView.swift
@@ -44,6 +44,7 @@ struct DetailItemView: View {
 
     @Environment(AppState.self) private var appState
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
 
     @State private var items: [MediaItem]
     @State private var currentIndex: Int
@@ -126,7 +127,7 @@ struct DetailItemView: View {
         ZStack {
             ZStack {
                 Rectangle().fill(.ultraThinMaterial)
-                Color.black.opacity(0.55)
+                (colorScheme == .dark ? Color.black : Color.white).opacity(0.55)
             }
             .opacity(isExpanded ? 1.0 : 0.0)
             .ignoresSafeArea()
@@ -345,8 +346,7 @@ struct DetailItemView: View {
                 .frame(width: max(min(imageFrame.width, 550), 400))
                 .padding(.top, 40)
                 .padding(.bottom, 40)
-                .mask(metadataFadeMask)
-                .opacity(isZoomed ? 0 : 1)
+                .opacity(isZoomed ? 0 : metadataScrollOpacity)
                 .animation(SnapSpring.fast, value: isZoomed)
             }
             .frame(maxWidth: .infinity)
@@ -581,7 +581,7 @@ struct DetailItemView: View {
                 .position(x: windowSize.width / 2, y: windowSize.height / 2)
         } else {
             RoundedRectangle(cornerRadius: 16)
-                .fill(Color.white.opacity(0.05))
+                .fill(Color.primary.opacity(0.05))
                 .frame(width: frame.width, height: frame.height)
                 .position(x: windowSize.width / 2, y: windowSize.height / 2)
         }
@@ -618,14 +618,28 @@ struct DetailItemView: View {
     @ViewBuilder
     private var loadingIndicator: some View {
         if isLoadingFullRes {
-            ProgressView()
+            let base = ProgressView()
                 .controlSize(.small)
-                .tint(.white)
                 .padding(6)
-                .background(.black.opacity(0.4))
-                .clipShape(RoundedRectangle(cornerRadius: 6))
+
+            #if compiler(>=6.3)
+            if #available(macOS 26, *) {
+                base
+                    .glassEffect(.regular, in: .rect(cornerRadius: 6))
+                    .padding(10)
+                    .transition(.opacity)
+            } else {
+                base
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 6))
+                    .padding(10)
+                    .transition(.opacity)
+            }
+            #else
+            base
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 6))
                 .padding(10)
                 .transition(.opacity)
+            #endif
         }
     }
 
@@ -658,16 +672,11 @@ struct DetailItemView: View {
         }
     }
 
-    private var metadataFadeMask: some View {
+    /// Scroll-responsive opacity for metadata: starts partially transparent,
+    /// becomes fully opaque after scrolling ~60pt.
+    private var metadataScrollOpacity: Double {
         let fade = max(0, 1 - scrollOffset / 60)
-        return LinearGradient(
-            colors: [
-                .white.opacity(1 - 0.8 * fade),
-                .white.opacity(1 - 0.4 * fade)
-            ],
-            startPoint: .top,
-            endPoint: .bottom
-        )
+        return 1 - 0.6 * fade
     }
 
     // MARK: - Frame Computation
@@ -787,7 +796,6 @@ struct DetailMetadataSection: View {
                 HStack(spacing: 8) {
                     ProgressView()
                         .controlSize(.small)
-                        .tint(.white)
                     Text("Analyzing...")
                         .font(.callout)
                         .foregroundStyle(.secondary)
@@ -814,7 +822,7 @@ struct DetailMetadataSection: View {
                 }
 
                 if !result.patterns.isEmpty {
-                    FlowLayout(spacing: 6) {
+                    let pillsContent = FlowLayout(spacing: 6) {
                         ForEach(Array(result.patterns.enumerated()), id: \.element.name) { index, pattern in
                             Button {
                                 onSearchPattern?(pattern.name)
@@ -832,6 +840,16 @@ struct DetailMetadataSection: View {
                     }
                     .padding(.leading, -6)
                     .padding(.bottom, 18)
+
+                    #if compiler(>=6.3)
+                    if #available(macOS 26, *) {
+                        GlassEffectContainer(spacing: 6) { pillsContent }
+                    } else {
+                        pillsContent
+                    }
+                    #else
+                    pillsContent
+                    #endif
                 }
 
                 if hasDescription(result) {

--- a/SnapGrid/SnapGrid/Views/Settings/GeneralSettingsTab.swift
+++ b/SnapGrid/SnapGrid/Views/Settings/GeneralSettingsTab.swift
@@ -1,6 +1,35 @@
 import SwiftUI
 
-struct AISettingsTab: View {
+enum AppearanceMode: String, CaseIterable {
+    case dark, light, auto
+
+    var label: String {
+        switch self {
+        case .dark: "Dark"
+        case .light: "Light"
+        case .auto: "Auto"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .dark: "moon.fill"
+        case .light: "sun.max.fill"
+        case .auto: "circle.lefthalf.filled"
+        }
+    }
+
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .dark: .dark
+        case .light: .light
+        case .auto: nil
+        }
+    }
+}
+
+struct GeneralSettingsTab: View {
+    @AppStorage("appearanceMode") private var appearanceMode: String = AppearanceMode.dark.rawValue
     @AppStorage("aiProvider") private var selectedProvider: String = AIProvider.openai.rawValue
     @AppStorage("openaiModel") private var openaiModel: String = ModelDiscoveryService.autoModelValue
     @AppStorage("anthropicModel") private var anthropicModel: String = ModelDiscoveryService.autoModelValue
@@ -38,7 +67,17 @@ struct AISettingsTab: View {
 
     var body: some View {
         Form {
-            Section {
+            Section("Appearance") {
+                Picker("Mode", selection: $appearanceMode) {
+                    ForEach(AppearanceMode.allCases, id: \.rawValue) { mode in
+                        Label(mode.label, systemImage: mode.icon)
+                            .tag(mode.rawValue)
+                    }
+                }
+                .pickerStyle(.inline)
+            }
+
+            Section("AI Analysis") {
                 Picker("Provider", selection: $selectedProvider) {
                     ForEach(AIProvider.allCases, id: \.rawValue) { p in
                         Text(p.displayName).tag(p.rawValue)
@@ -80,9 +119,7 @@ struct AISettingsTab: View {
                         .font(.caption)
                         .foregroundStyle(.red)
                 }
-            }
 
-            Section("Model") {
                 modelPicker
             }
         }

--- a/SnapGrid/SnapGrid/Views/Settings/SettingsView.swift
+++ b/SnapGrid/SnapGrid/Views/Settings/SettingsView.swift
@@ -3,9 +3,9 @@ import SwiftUI
 struct SettingsView: View {
     var body: some View {
         TabView {
-            AISettingsTab()
+            GeneralSettingsTab()
                 .tabItem {
-                    Label("AI", systemImage: "brain")
+                    Label("General", systemImage: "gearshape")
                 }
 
             GuidanceSettingsTab()

--- a/SnapGrid/SnapGrid/Views/Shared/PatternPill.swift
+++ b/SnapGrid/SnapGrid/Views/Shared/PatternPill.swift
@@ -15,24 +15,36 @@ struct PatternPill: View {
     var body: some View {
         let base = Text(name)
             .font(large ? .subheadline : .callout)
-            .foregroundStyle(.white.opacity(0.9))
+            .foregroundStyle(large ? AnyShapeStyle(.primary) : AnyShapeStyle(.white.opacity(0.9)))
             .padding(.horizontal, large ? 10 : 8)
             .padding(.vertical, large ? 5 : 3)
 
         #if compiler(>=6.3)
         if #available(macOS 26, *), useGlass {
-            base
-                .glassEffect(.regular.tint(.black.opacity(0.3)), in: .rect(cornerRadius: cornerRadius))
-                .environment(\.colorScheme, .dark)
+            if large {
+                base.glassEffect(.regular.interactive(), in: .rect(cornerRadius: cornerRadius))
+            } else {
+                base
+                    .glassEffect(.regular.tint(.black.opacity(0.3)), in: .rect(cornerRadius: cornerRadius))
+                    .environment(\.colorScheme, .dark)
+            }
+        } else {
+            if large {
+                base.background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: cornerRadius))
+            } else {
+                base
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: cornerRadius))
+                    .environment(\.colorScheme, .dark)
+            }
+        }
+        #else
+        if large {
+            base.background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: cornerRadius))
         } else {
             base
                 .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: cornerRadius))
                 .environment(\.colorScheme, .dark)
         }
-        #else
-        base
-            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: cornerRadius))
-            .environment(\.colorScheme, .dark)
         #endif
     }
 }


### PR DESCRIPTION
### Why?

The Mac app's detail view was hardcoded for dark mode — the backdrop, loading indicators, and pattern pills all used fixed dark colors that looked broken in light mode. There was also no way for users to choose their preferred appearance.

### How?

Make the detail view adaptive by switching hardcoded colors to colorScheme-aware values and glass/material-based UI elements. Add an appearance setting (dark/light/auto, defaulting to dark) applied via `.preferredColorScheme()` at the app level. Merge the old AI settings tab with appearance into a single General tab.

<details>
<summary>Implementation Plan</summary>

# Mac Detail View: Light Mode Support

## Context

The detail view (lightbox overlay that shows full-size media) uses hardcoded dark-mode colors — `Color.black.opacity(...)` for the backdrop tint, `Color.white` for loading indicators, etc. In light mode, these produce a muddy backdrop and invisible/low-contrast UI elements. The metadata text already uses adaptive `.primary`/`.secondary` styles, so the main issues are the backdrop, loading states, and adjacent-image placeholder.

The app already has an adaptive color system in `Color+Theme.swift` with 7 named colors, but the detail view bypasses it.

## Changes

### 1. DetailItemView.swift — Backdrop tint (line 128-129)

**Current:** `Color.black.opacity(0.55)` layered on `.ultraThinMaterial`
**Fix:** Use colorScheme environment to pick an adaptive tint:
```swift
@Environment(\.colorScheme) private var colorScheme
// ...
(colorScheme == .dark ? Color.black : Color.white).opacity(0.55)
```
The `.ultraThinMaterial` already adapts to light/dark. The tint just needs to darken (dark mode) or lightly dim (light mode) the frosted glass.

### 2. DetailItemView.swift — Adjacent image placeholder (line 584)

**Current:** `Color.white.opacity(0.05)` — invisible on light backgrounds
**Fix:** `Color.primary.opacity(0.05)` — adapts automatically

### 3. DetailItemView.swift — Loading indicator (lines 620-629)

**Current:** `.tint(.white)` + `.background(.black.opacity(0.4))`
**Fix:** Use glass/material approach matching the video controls pattern:
```swift
// macOS 26+: glassEffect
// Fallback: .ultraThinMaterial
```
This overlays media content, so a glass pill is appropriate and adapts automatically.

### 4. DetailItemView.swift — "Analyzing..." progress tint (line 790)

**Current:** `.tint(.white)` — white spinner that's invisible on light backdrop
**Fix:** Remove explicit tint (system default adapts) or use `.tint(.primary)`

### 5. NOT changing (already correct)

- **Metadata text** (lines 793-860): Already uses `.primary`, `.secondary` — adapts
- **Metadata fade mask** (lines 661-671): Used as `.mask()` — alpha-based, color-independent
- **Video controls** (FloatingVideoLayer): Overlay on video content — dark style is intentional and correct for any video brightness
- **PatternPill**: Forces `.environment(\.colorScheme, .dark)` — dark badge aesthetic works on both light and dark backdrops
- **ToastView**: Global component, not detail-specific — out of scope

## Files to modify

1. `/SnapGrid/SnapGrid/Views/Detail/DetailItemView.swift` — 4 changes (backdrop, placeholder, loading indicator, analyzing tint)

## Verification

1. `cd SnapGrid && xcodegen generate && xcodebuild build -project SnapGrid.xcodeproj -scheme SnapGrid -destination 'platform=macOS' 2>&1 | xcbeautify --quiet`
2. Run the app, toggle System Settings > Appearance between Light and Dark
3. Verify: backdrop is frosted-light in light mode, frosted-dark in dark mode
4. Verify: loading spinner is visible in both modes
5. Verify: metadata text is legible in both modes
6. Verify: swipe between items — adjacent placeholder is subtle but visible

</details>

<sub>Generated with Claude Code</sub>