### PR TITLE
Match Mac detail view darker backdrop tint on iOS

### DIFF
--- a/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
@@ -121,6 +121,8 @@ struct FullScreenImageOverlay: View {
     var onSearchPattern: ((String) -> Void)?
     var onDelete: ((MediaItem) -> Void)?
 
+    @Environment(\.colorScheme) private var colorScheme
+
     /// Captured at open time — stays stable even when parent re-filters.
     @State private var items: [MediaItem]
     @State private var currentIndex: Int
@@ -375,7 +377,7 @@ struct FullScreenImageOverlay: View {
             ZStack {
                 Rectangle().fill(.ultraThinMaterial)
                     .opacity(blurOpacity)
-                Color.black.opacity(0.3)
+                (colorScheme == .dark ? Color.black : Color.white).opacity(0.55)
                     .opacity(backdropOpacity)
             }
             .ignoresSafeArea()


### PR DESCRIPTION
### Why?

The iOS detail view uses a lighter backdrop overlay (30% black, always dark) compared to the Mac app (55% opacity, color-scheme-aware). This makes the two platforms feel inconsistent when viewing images in detail.

### How?

Aligns the iOS `FullScreenImageOverlay` backdrop with the Mac's `DetailItemView` — increased tint opacity from 0.3 to 0.55 and made it color-scheme-aware (black in dark mode, white in light mode).

<details>
<summary>Implementation Plan</summary>

# iOS Detail View — Match Mac's Darker Backdrop Tint

## Context
The Mac detail view uses a darker, color-scheme-aware backdrop overlay (`0.55` opacity, black in dark mode / white in light mode). The iOS detail view currently uses a lighter, always-black overlay (`0.3` opacity). We need to align iOS with the Mac reference.

## Change

**File:** `ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift`

1. Add `@Environment(\.colorScheme) private var colorScheme` to the view's properties
2. Update the backdrop tint layer from:
   ```swift
   Color.black.opacity(0.3)
   ```
   to:
   ```swift
   (colorScheme == .dark ? Color.black : Color.white).opacity(0.55)
   ```

This matches the Mac implementation at `SnapGrid/Views/Detail/DetailItemView.swift:130`.

## Verification
- Build the iOS app
- Open an image in the detail view in both dark and light appearance
- Confirm the backdrop is noticeably darker/more opaque than before, matching the Mac app

</details>

<sub>Generated with Claude Code</sub>