### PR TITLE
Make iOS pattern pill search global instead of space-scoped

### DIFF
--- a/ios/SnapGrid/SnapGrid/App/AppState.swift
+++ b/ios/SnapGrid/SnapGrid/App/AppState.swift
@@ -24,6 +24,7 @@ final class AppState {
     var showOverlay = false
     var pendingSearchActivation = false
     var pendingSearchPattern: String?
+    var pendingGlobalSearch = false
     var activeSpaceId: String? = nil
     var searchSpaceId: String? = nil
     var searchText = ""
@@ -37,10 +38,14 @@ final class AppState {
     func queuePatternSearch(_ pattern: String) {
         pendingSearchPattern = pattern
         pendingSearchActivation = true
+        pendingGlobalSearch = true
     }
 
     func applyPendingSearchIfNeeded(prefersDedicatedSearchTab: Bool) {
-        guard pendingSearchActivation else { return }
+        guard pendingSearchActivation else {
+            pendingGlobalSearch = false
+            return
+        }
 
         if let pendingSearchPattern {
             searchText = pendingSearchPattern

--- a/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
@@ -155,7 +155,12 @@ struct MainView: View {
         }
         .onChange(of: appState.selectedTab) { _, newTab in
             if newTab == .search {
-                appState.searchSpaceId = appState.activeSpaceId
+                if appState.pendingGlobalSearch {
+                    appState.searchSpaceId = nil
+                    appState.pendingGlobalSearch = false
+                } else {
+                    appState.searchSpaceId = appState.activeSpaceId
+                }
             } else {
                 appState.searchSpaceId = nil
             }


### PR DESCRIPTION
### Why?

When tapping a pattern pill from image detail while inside a space, the search is scoped to that space — but it should search globally so you can find matching patterns across your entire library.

### How?

Adds a `pendingGlobalSearch` flag on AppState that `queuePatternSearch` sets to `true`. The `.onChange(of: selectedTab)` handler in MainView checks this flag: if set, it keeps `searchSpaceId = nil` (global) instead of inheriting the active space. Manual tab switches are unaffected.

<details>
<summary>Implementation Plan</summary>

# Plan: Make pattern pill search global (not space-scoped)

## Context

When viewing an image inside a space on iOS, tapping a pattern pill triggers a search. Currently that search is scoped to the active space because the `.onChange(of: selectedTab)` handler always copies `activeSpaceId` → `searchSpaceId` when switching to the search tab. The user wants pill-triggered searches to be **global** while all other search behavior (manual tab switches, etc.) stays space-scoped.

## Key Timing Insight

With SwiftUI's `@Observable`, `.onChange` fires **after** the current synchronous call stack — not inline. So when `applyPendingSearchIfNeeded` sets `selectedTab = .search`, the `.onChange` handler runs later and is the **last writer** of `searchSpaceId`. This means we need a flag that persists until `.onChange` reads it.

## Implementation (3 edits across 2 files)

### 1. Add `pendingGlobalSearch` flag — `AppState.swift`

Add property:
```swift
var pendingGlobalSearch = false
```

### 2. Set flag in `queuePatternSearch` — `AppState.swift`

```swift
func queuePatternSearch(_ pattern: String) {
    pendingSearchPattern = pattern
    pendingSearchActivation = true
    pendingGlobalSearch = true
}
```

Also add safety cleanup in `applyPendingSearchIfNeeded` early return:
```swift
func applyPendingSearchIfNeeded(prefersDedicatedSearchTab: Bool) {
    guard pendingSearchActivation else {
        pendingGlobalSearch = false
        return
    }
    // ... rest unchanged
}
```

### 3. Check flag in `.onChange` handler — `MainView.swift` (lines 156-162)

```swift
.onChange(of: appState.selectedTab) { _, newTab in
    if newTab == .search {
        if appState.pendingGlobalSearch {
            appState.searchSpaceId = nil
            appState.pendingGlobalSearch = false
        } else {
            appState.searchSpaceId = appState.activeSpaceId
        }
    } else {
        appState.searchSpaceId = nil
    }
}
```

## Verification

1. Open a space on iOS, tap an image, tap a pattern pill → search results should include items from ALL spaces
2. Open a space, manually tap the Search tab → search should be scoped to that space (shows "Search in SpaceName...")
3. From the All tab, tap Search tab → search should be global

</details>

<sub>Generated with Claude Code</sub>