### PR TITLE
Remove duplicate title from iOS detail view

### DIFF
--- a/ios/SnapGrid/SnapGrid/Views/Detail/DetailMetadataSection.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/DetailMetadataSection.swift
@@ -29,15 +29,6 @@ struct DetailMetadataSection: View {
                 }
                 .stageReveal(stage: stage, threshold: 1)
             } else if let result = item.analysisResult {
-                if !result.imageSummary.isEmpty {
-                    Text(result.imageSummary)
-                        .font(.title3.weight(.semibold))
-                        .foregroundStyle(.white.opacity(0.9))
-                        .lineLimit(2)
-                        .stageReveal(stage: stage, threshold: 1)
-                        .padding(.bottom, 12)
-                }
-
                 if !result.patterns.isEmpty {
                     patternPillsGrid(result.patterns)
                         .padding(.bottom, 18)


### PR DESCRIPTION
### Why?

The image title (imageSummary) was displayed redundantly — once in the navigation title bar and again as a large text block below the image in the detail metadata section.

### How?

Removed the `imageSummary` text rendering from `DetailMetadataSection`, keeping it only in the navigation bar where it's already visible.

<details>
<summary>Implementation Plan</summary>

# Remove duplicate title from iOS detail view

## Context
The iOS detail view shows the `imageSummary` title in two places:
1. **Navigation title bar** — via `ImageDetailView.swift` line ~119 (`.navigationTitle(detailTitle)`)
2. **Below the image** — via `DetailMetadataSection.swift` lines 32-39 (a `Text(result.imageSummary)` block)

The user wants to remove the duplicate below the image since the title bar already shows it.

## Change

**File:** `ios/SnapGrid/SnapGrid/Views/Detail/DetailMetadataSection.swift`

Remove lines 32-39 (the `imageSummary` text block).

No other files need changes. The navigation title in `ImageDetailView.swift` stays as-is.

</details>

<sub>Generated with Claude Code</sub>