### PR TITLE
Minimize iOS tab bar on scroll down

### DIFF
--- a/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
@@ -235,6 +235,7 @@ struct MainView: View {
                     searchContent(gridWidth: gridWidth)
                 }
             }
+            .tabBarMinimizeBehavior(.onScrollDown)
             .tabViewSearchActivation(.searchTabSelection)
             .tint(.white)
         } else {


### PR DESCRIPTION
### Why?

The tab bar occupies fixed screen space while browsing the grid, reducing the viewable area for media content on iPhone.

### How?

Adds the native iOS 26 `.tabBarMinimizeBehavior(.onScrollDown)` modifier to the TabView, which automatically shrinks the tab bar when scrolling down and restores it on scroll-up.

<details>
<summary>Implementation Plan</summary>

# Shrink tabs and search on scroll (iOS)

## Context
When the user scrolls down through the masonry grid on iOS, the tab bar (All / Spaces / Search) stays at full size, consuming space. iOS 26 introduced `.tabBarMinimizeBehavior(.onScrollDown)` which automatically minimizes the tab bar when scrolling down, and restores it on scroll-up — exactly matching this request.

## Plan

**File:** `ios/SnapGrid/SnapGrid/Views/Main/MainView.swift` (line ~238)

Add `.tabBarMinimizeBehavior(.onScrollDown)` to the iOS 26+ `TabView`:

```swift
TabView(selection: $appState.selectedTab) {
    // ... tabs ...
}
.tabBarMinimizeBehavior(.onScrollDown)  // ← add this
.tabViewSearchActivation(.searchTabSelection)
.tint(.white)
```

This is a single-line change. The modifier is iOS 26+ only, which aligns with the `if #available(iOS 26, *)` guard already in place. No changes needed for the iOS < 26 path (it doesn't have the search tab either).

## Verification
- Build the iOS app and run on iPhone simulator
- Scroll down on the All Items grid → tab bar should shrink/minimize
- Scroll up → tab bar should restore
- Check Spaces tab and Space detail views also minimize
- Verify search tab still activates correctly when tapped while minimized

</details>

<sub>Generated with Claude Code</sub>