### PR TITLE
Fix iOS dismiss animation targeting wrong grid cell after swiping

### DIFF
--- a/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
@@ -1030,7 +1030,7 @@ struct FullScreenImageOverlay: View {
         if let targetRect {
             // Grid cell is visible — hero animation back to it
             var correctedRect = targetRect
-            if !isSearchDismiss {
+            if !isSearchDismiss && !hasNavigated {
                 // Apply correction: sourceRect is ground truth for the original item.
                 // Preference-based rects may have a systematic offset (e.g. from
                 // off-screen TabView pages), so anchor to sourceRect.


### PR DESCRIPTION
### Why?

When swiping between images in the iOS detail overlay and then dismissing, the close animation flies back to the originally-opened image's grid position instead of the currently-displayed image's position.

### How?

Skip the `sourceRect` coordinate correction when the user has navigated to a different image — the correction is only valid for the originally-opened item. After swiping, the raw grid preference rect is used directly as the animation target.

<details>
<summary>Implementation Plan</summary>

# Fix iOS dismiss animation targeting wrong grid cell after swiping

## Context

When a user opens an image from the grid, swipes to a different image in the detail overlay, then dismisses — the close animation flies back to the **original** image's grid position instead of the **current** image's position.

## Root cause

In `FullScreenImageOverlay.swift` lines 1039-1049, the close animation applies a coordinate correction based on the **originally opened item** (`startIndex` / `sourceRect`). This correction compensates for systematic offsets in preference-based grid rects (e.g. from off-screen TabView pages).

The problem: after swiping to a different image, the code still computes the correction delta from the original item's `sourceRect` vs its current grid rect, then applies that delta to the **new** item's grid rect. Since the two items are at different grid positions, the correction is wrong.

## Fix

**Skip the correction when the user has navigated to a different image.** The `hasNavigated` flag already tracks this. When `hasNavigated` is true, the `sourceRect` (captured at tap time for the original item) is irrelevant to the current item — use the raw grid preference rect directly.

### Change (lines 1033-1049)

Add `&& !hasNavigated` to the correction condition so:
- **No swipe** — correction applied (original behavior, handles TabView offset)
- **After swipe** — raw grid rect used (correct target, no stale correction)
- **Search dismiss** — raw grid rect used (existing behavior unchanged)

## Verification

1. Open image from grid then dismiss — should animate back to correct cell (unchanged)
2. Open image, swipe to different image, dismiss — should animate back to the **current** image's cell (bug fix)
3. Open image, swipe several times, dismiss — correct cell
4. Search-triggered dismiss — unchanged behavior

</details>

<sub>Generated with Claude Code</sub>