### PR TITLE
Fix iOS detail view metadata bottom spacing

### DIFF
--- a/ios/SnapGrid/SnapGrid/Views/Detail/DetailMetadataSection.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/DetailMetadataSection.swift
@@ -68,7 +68,6 @@ struct DetailMetadataSection: View {
             }
         }
         .padding(.horizontal, 32)
-        .padding(.bottom, 32)
     }
 
     private func hasDescription(_ result: AnalysisResult) -> Bool {

--- a/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
@@ -511,7 +511,7 @@ struct FullScreenImageOverlay: View {
                     }
                 )
                 .padding(.top, 32)
-                .padding(.bottom, 120)
+                .padding(.bottom, 50)
                 .opacity(deleteStage >= 1 ? 0 : (isZoomed ? 0 : metadataOpacity * metadataDismissOpacity))
                 .offset(y: dismissVisualProgress * 24)
             }


### PR DESCRIPTION
### Why?

The bottom padding below metadata in the iOS detail view was visually inconsistent with the side margins, creating an unbalanced layout.

### How?

Remove the redundant bottom padding from `DetailMetadataSection` (matching the Mac pattern where only horizontal padding is set on the section) and reduce the scroll buffer from 120pt to 50pt (34pt safe area + 16pt breathing room).

<details>
<summary>Implementation Plan</summary>

# Fix iOS Metadata Bottom Spacing

## Context
The iOS detail view's `DetailMetadataSection` has `.padding(.bottom, 32)` that doesn't exist in the Mac version. This creates extra visible space below the metadata that's inconsistent with the side margins. The Mac version only applies `.padding(.horizontal, 16)` — no bottom padding on the section itself.

## Change

**File:** `ios/SnapGrid/SnapGrid/Views/Detail/DetailMetadataSection.swift` (line 80)

Remove `.padding(.bottom, 32)` from the section's body, leaving only `.padding(.horizontal, 32)`:

```swift
// Before (line 79-80):
.padding(.horizontal, 32)
.padding(.bottom, 32)

// After:
.padding(.horizontal, 32)
```

This matches the Mac pattern where `DetailMetadataSection` has horizontal-only padding, and the container (`FullScreenImageOverlay`) handles vertical spacing via `.padding(.top, 32)` and `.padding(.bottom, 120)` (scroll buffer for home indicator overscroll).

## Verification
- Build iOS target in Xcode
- Open detail view for an item with full metadata (title, pills, description, file info)
- Confirm bottom spacing below metadata matches the left/right margins visually

</details>

<sub>Generated with Claude Code</sub>