### PR TITLE
Remove duplicate title from Mac detail view

### DIFF
--- a/SnapGrid/SnapGrid/Views/Detail/DetailItemView.swift
+++ b/SnapGrid/SnapGrid/Views/Detail/DetailItemView.swift
@@ -812,15 +812,6 @@ struct DetailMetadataSection: View {
                 }
                 .stageReveal(stage: stage, threshold: 1)
             } else if let result = item.analysisResult {
-                if !result.imageSummary.isEmpty {
-                    Text(result.imageSummary)
-                        .font(.title3.weight(.semibold))
-                        .foregroundStyle(.primary)
-                        .lineLimit(2)
-                        .stageReveal(stage: stage, threshold: 1)
-                        .padding(.bottom, 10)
-                }
-
                 if !result.patterns.isEmpty {
                     let pillsContent = FlowLayout(spacing: 6) {
                         ForEach(Array(result.patterns.enumerated()), id: \.element.name) { index, pattern in


### PR DESCRIPTION
### Why?

The detail view shows the image summary title in both the window titlebar and below the image in the metadata section — redundant information.

### How?

Remove the inline imageSummary text from DetailMetadataSection, keeping only the titlebar version. Same approach as a914792 which fixed this on iOS.

<details>
<summary>Implementation Plan</summary>

# Remove duplicate title from Mac detail view

## Context
The Mac app's detail view shows the imageSummary (title) in two places: the window titlebar (via .navigationTitle) and as a Text element below the image in the metadata section. This is redundant — remove the one below the image.

## Change

**File:** SnapGrid/SnapGrid/Views/Detail/DetailItemView.swift (lines 815–822)

Remove the imageSummary text block inside DetailMetadataSection. The titlebar title remains untouched — it's set in ContentView.swift via .navigationTitle(detailNavigationTitle).

## Verification
1. Build the Mac app and verify it compiles
2. Visually confirm the title no longer appears below the image, but still shows in the titlebar.

</details>

<sub>Generated with Claude Code</sub>