### PR TITLE
Show space name in Mac app title bar

### DIFF
--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -63,13 +63,17 @@ struct ContentView: View {
     }
 
     private var detailNavigationTitle: String {
-        guard let detailId = appState.detailItem,
-              let item = allItems.first(where: { $0.id == detailId }),
-              let summary = item.analysisResult?.imageSummary,
-              !summary.isEmpty else {
-            return "SnapGrid"
+        if let detailId = appState.detailItem,
+           let item = allItems.first(where: { $0.id == detailId }),
+           let summary = item.analysisResult?.imageSummary,
+           !summary.isEmpty {
+            return summary
         }
-        return summary
+        if let spaceId = appState.activeSpaceId,
+           let space = spaces.first(where: { $0.id == spaceId }) {
+            return space.name
+        }
+        return "All media"
     }
 
     var body: some View {


### PR DESCRIPTION
### Why?

The iOS app shows the current space name in the navigation title, but the Mac app always showed a static title. This inconsistency makes the Mac app feel less context-aware when switching between spaces.

### How?

Updated the `detailNavigationTitle` computed property to check the active space and return its name. Falls back to "All media" when viewing the full library.

<details>
<summary>Implementation Plan</summary>

# Plan: Show space name in Mac app title bar

## Context
The Mac app's window title always shows "SnapGrid" (or an AI summary when viewing a detail item). The iOS app already shows the space name in its navigation title when viewing a specific space. We want the Mac app to match this behavior.

## Change

**File:** `SnapGrid/SnapGrid/Views/ContentView/ContentView.swift`

Update the `detailNavigationTitle` computed property (lines 65–73) to include the active space name when no detail item is open:

```swift
private var detailNavigationTitle: String {
    if let detailId = appState.detailItem,
       let item = allItems.first(where: { $0.id == detailId }),
       let summary = item.analysisResult?.imageSummary,
       !summary.isEmpty {
        return summary
    }
    if let spaceId = appState.activeSpaceId,
       let space = spaces.first(where: { $0.id == spaceId }) {
        return space.name
    }
    return "All media"
}
```

**Behavior:**
- Viewing detail item with AI summary → show the summary (unchanged)
- Space selected, no detail → show space name (new)
- "All" selected, no detail → show "All media" (matches iOS)

No other files need changes — `spaces` is already queried at line 9 and `appState.activeSpaceId` is already available.

</details>

<sub>Generated with Claude Code</sub>