### PR TITLE
Improve HIG compliance: accessibility, Dynamic Type, 8pt grid

### DIFF
--- a/SnapGrid/SnapGrid/Views/Detail/DetailItemView.swift
+++ b/SnapGrid/SnapGrid/Views/Detail/DetailItemView.swift
@@ -620,24 +620,24 @@ struct DetailItemView: View {
         if isLoadingFullRes {
             let base = ProgressView()
                 .controlSize(.small)
-                .padding(6)
+                .padding(8)
 
             #if compiler(>=6.3)
             if #available(macOS 26, *) {
                 base
-                    .glassEffect(.regular, in: .rect(cornerRadius: 6))
-                    .padding(10)
+                    .glassEffect(.regular, in: .rect(cornerRadius: 8))
+                    .padding(8)
                     .transition(.opacity)
             } else {
                 base
-                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 6))
-                    .padding(10)
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+                    .padding(8)
                     .transition(.opacity)
             }
             #else
             base
-                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 6))
-                .padding(10)
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+                .padding(8)
                 .transition(.opacity)
             #endif
         }
@@ -802,7 +802,7 @@ struct DetailMetadataSection: View {
                 }
                 .stageReveal(stage: stage, threshold: 1)
             } else if item.analysisError != nil {
-                HStack(spacing: 6) {
+                HStack(spacing: 8) {
                     Image(systemName: "exclamationmark.triangle")
                         .font(.caption)
                         .foregroundStyle(.red.opacity(0.8))
@@ -813,7 +813,7 @@ struct DetailMetadataSection: View {
                 .stageReveal(stage: stage, threshold: 1)
             } else if let result = item.analysisResult {
                 if !result.patterns.isEmpty {
-                    let pillsContent = FlowLayout(spacing: 6) {
+                    let pillsContent = FlowLayout(spacing: 8) {
                         ForEach(Array(result.patterns.enumerated()), id: \.element.name) { index, pattern in
                             Button {
                                 onSearchPattern?(pattern.name)
@@ -821,6 +821,8 @@ struct DetailMetadataSection: View {
                                 PatternPill(name: pattern.name, large: true)
                             }
                             .buttonStyle(.plain)
+                            .accessibilityLabel("Pattern: \(pattern.name)")
+                            .accessibilityHint("Searches for items with this pattern")
                             .opacity(stage >= 2 ? 1 : 0)
                             .offset(y: stage >= 2 ? 0 : MetadataReveal.slideDistance)
                             .animation(
@@ -829,12 +831,12 @@ struct DetailMetadataSection: View {
                             )
                         }
                     }
-                    .padding(.leading, -6)
-                    .padding(.bottom, 18)
+                    .padding(.leading, -8)
+                    .padding(.bottom, 16)
 
                     #if compiler(>=6.3)
                     if #available(macOS 26, *) {
-                        GlassEffectContainer(spacing: 6) { pillsContent }
+                        GlassEffectContainer(spacing: 8) { pillsContent }
                     } else {
                         pillsContent
                     }
@@ -899,7 +901,7 @@ private struct SourceLinkButton: View {
 
     var body: some View {
         Link(destination: url) {
-            HStack(spacing: 5) {
+            HStack(spacing: 4) {
                 Image(systemName: iconName)
                     .font(.caption2)
                 Text(label)
@@ -909,6 +911,7 @@ private struct SourceLinkButton: View {
             .onHover { isHovered = $0 }
         }
         .accessibilityLabel("View original post on X")
+        .accessibilityHint("Opens the source URL in your browser")
     }
 }
 

--- a/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -200,7 +200,7 @@ struct GridItemView: View {
                             .animation(SnapSpring.standard(reduced: reduceMotion), value: effectiveHover)
 
                             HStack {
-                                FlowLayout(spacing: 5) {
+                                FlowLayout(spacing: 4) {
                                     ForEach(Array(patterns.prefix(5).enumerated()), id: \.element.name) { index, pattern in
                                         PatternPill(name: pattern.name, useGlass: false)
                                             .opacity(effectiveHover ? 1 : 0)
@@ -235,6 +235,7 @@ struct GridItemView: View {
                 .padding(8)
                 .transition(.opacity.combined(with: .scale(scale: 0.8)))
                 .accessibilityLabel("Delete")
+                .accessibilityHint("Moves this item to the trash")
             }
         }
         .overlay(alignment: .topLeading) {
@@ -246,6 +247,7 @@ struct GridItemView: View {
                 .padding(8)
                 .transition(.opacity.combined(with: .scale(scale: 0.8)))
                 .accessibilityLabel("Remove from space")
+                .accessibilityHint("Removes this item from the current space")
             }
         }
         .overlay(alignment: .bottomLeading) {
@@ -257,6 +259,7 @@ struct GridItemView: View {
                 .padding(8)
                 .transition(.opacity.combined(with: .scale(scale: 0.8)))
                 .accessibilityLabel("Redo analysis")
+                .accessibilityHint("Runs AI analysis again on this item")
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: 12))

--- a/SnapGrid/SnapGrid/Views/Shared/FloatingVideoLayer.swift
+++ b/SnapGrid/SnapGrid/Views/Shared/FloatingVideoLayer.swift
@@ -99,7 +99,7 @@ struct FloatingVideoLayer: View {
                             VStack {
                                 Spacer()
                                 HStack {
-                                    FlowLayout(spacing: 5) {
+                                    FlowLayout(spacing: 4) {
                                         ForEach(videoPreview.gridPatternNames, id: \.self) { name in
                                             PatternPill(name: name, useGlass: false)
                                         }

--- a/SnapGrid/SnapGrid/Views/Shared/PatternPill.swift
+++ b/SnapGrid/SnapGrid/Views/Shared/PatternPill.swift
@@ -16,8 +16,8 @@ struct PatternPill: View {
         let base = Text(name)
             .font(large ? .subheadline : .callout)
             .foregroundStyle(large ? AnyShapeStyle(.primary) : AnyShapeStyle(.white.opacity(0.9)))
-            .padding(.horizontal, large ? 10 : 8)
-            .padding(.vertical, large ? 5 : 3)
+            .padding(.horizontal, large ? 12 : 8)
+            .padding(.vertical, large ? 4 : 4)
 
         #if compiler(>=6.3)
         if #available(macOS 26, *), useGlass {

--- a/SnapGrid/SnapGrid/Views/Shared/ToastView.swift
+++ b/SnapGrid/SnapGrid/Views/Shared/ToastView.swift
@@ -11,7 +11,7 @@ struct ToastOverlay: View {
                     .font(.callout.weight(.medium))
                     .foregroundStyle(.white)
                     .padding(.horizontal, 16)
-                    .padding(.vertical, 10)
+                    .padding(.vertical, 8)
 
                 #if compiler(>=6.3)
                 if #available(macOS 26, *) {

--- a/ios/SnapGrid/SnapGrid/Views/Detail/DetailMetadataSection.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/DetailMetadataSection.swift
@@ -14,30 +14,30 @@ struct DetailMetadataSection: View {
                     ProgressView()
                         .tint(.white)
                     Text("Analyzing...")
-                        .font(.system(size: 14))
+                        .font(.subheadline)
                         .foregroundStyle(.white.opacity(0.6))
                 }
                 .stageReveal(stage: stage, threshold: 1)
             } else if item.analysisError != nil {
                 HStack(spacing: 6) {
                     Image(systemName: "exclamationmark.triangle")
-                        .font(.system(size: 13))
+                        .font(.footnote)
                         .foregroundStyle(.red.opacity(0.8))
                     Text("Analysis failed")
-                        .font(.system(size: 14))
+                        .font(.subheadline)
                         .foregroundStyle(.white.opacity(0.6))
                 }
                 .stageReveal(stage: stage, threshold: 1)
             } else if let result = item.analysisResult {
                 if !result.patterns.isEmpty {
                     patternPillsGrid(result.patterns)
-                        .padding(.bottom, 18)
+                        .padding(.bottom, 16)
                 }
 
                 if hasDescription(result) {
                     Text(result.imageContext)
                         .font(.footnote)
-                        .foregroundStyle(.white.opacity(0.55))
+                        .foregroundStyle(.white.opacity(0.5))
                         .lineSpacing(3)
                         .fixedSize(horizontal: false, vertical: true)
                         .opacity(stage >= 3 ? 1 : 0)
@@ -67,7 +67,7 @@ struct DetailMetadataSection: View {
                     .padding(.top, 8)
             }
         }
-        .padding(.horizontal, 32)
+        .padding(.horizontal, 24)
     }
 
     private func hasDescription(_ result: AnalysisResult) -> Bool {
@@ -97,13 +97,15 @@ struct DetailMetadataSection: View {
             .font(.subheadline)
             .foregroundStyle(.white.opacity(0.9))
             .padding(.horizontal, 12)
-            .padding(.vertical, 7)
+            .padding(.vertical, 8)
 
         if #available(iOS 26.0, *) {
             base
                 .environment(\.colorScheme, .dark)
                 .glassEffect(.regular.interactive(), in: .capsule)
                 .contentShape(Rectangle())
+                .accessibilityLabel("Pattern: \(pattern.name)")
+                .accessibilityAddTraits(.isButton)
                 .accessibilityHint("Double tap to search for this pattern")
                 .onTapGesture {
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
@@ -122,6 +124,8 @@ struct DetailMetadataSection: View {
                 .background(.ultraThinMaterial, in: Capsule())
                 .environment(\.colorScheme, .dark)
                 .contentShape(Rectangle())
+                .accessibilityLabel("Pattern: \(pattern.name)")
+                .accessibilityAddTraits(.isButton)
                 .accessibilityHint("Double tap to search for this pattern")
                 .onTapGesture {
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
@@ -164,9 +168,9 @@ struct SourceLinkButton: View {
     var body: some View {
         HStack(spacing: 5) {
             Image(systemName: iconName)
-                .font(.system(size: 11))
+                .font(.caption2)
             Text(label)
-                .font(.system(size: 13))
+                .font(.footnote)
         }
         .foregroundStyle(.white.opacity(0.35))
         .contentShape(Rectangle())

--- a/ios/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -50,7 +50,7 @@ struct GridItemView: View {
                     .fill(Color.snapDarkMuted)
                     .frame(width: width, height: height)
                     .overlay {
-                        VStack(spacing: 6) {
+                        VStack(spacing: 8) {
                             Image(systemName: "icloud.and.arrow.down")
                                 .font(.body)
                                 .foregroundStyle(.white.opacity(0.3))
@@ -76,7 +76,7 @@ struct GridItemView: View {
                     Image(systemName: "play.fill")
                         .font(.caption2)
                         .foregroundStyle(.white)
-                        .padding(6)
+                        .padding(8)
                         .background(.black.opacity(0.5))
                         .clipShape(Circle())
                         .padding(8)
@@ -215,7 +215,7 @@ struct GridItemView: View {
     private var shimmerBadge: some View {
         let base = ShimmerText("Analyzing...")
             .padding(.horizontal, 8)
-            .padding(.vertical, 3)
+            .padding(.vertical, 4)
 
         if #available(iOS 26, *) {
             base

--- a/ios/SnapGrid/SnapGrid/Views/Grid/PatternPills.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Grid/PatternPills.swift
@@ -10,7 +10,7 @@ struct PatternPills: View {
                     .font(.caption2.weight(.medium))
                     .foregroundStyle(.white.opacity(0.9))
                     .padding(.horizontal, 8)
-                    .padding(.vertical, 3)
+                    .padding(.vertical, 4)
                     .background(.white.opacity(0.15))
                     .clipShape(RoundedRectangle(cornerRadius: 6))
             }

--- a/ios/SnapGrid/SnapGrid/Views/Shared/EmptyStateView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Shared/EmptyStateView.swift
@@ -16,6 +16,7 @@ struct EmptyStateView: View {
                 .foregroundStyle(.white.opacity(0.4))
                 .multilineTextAlignment(.center)
         }
+        .accessibilityElement(children: .combine)
     }
 }
 
@@ -30,6 +31,7 @@ struct SearchEmptyStateView: View {
                 .font(.headline)
                 .foregroundStyle(.white.opacity(0.7))
         }
+        .accessibilityElement(children: .combine)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
@@ -53,6 +55,7 @@ struct PlaceholderView: View {
                     .foregroundStyle(.white.opacity(0.4))
             }
         }
+        .accessibilityElement(children: .combine)
     }
 }
 
@@ -81,7 +84,7 @@ struct ErrorStateView: View {
             .font(.subheadline.weight(.medium))
             .foregroundStyle(.white)
             .padding(.horizontal, 20)
-            .padding(.vertical, 10)
+            .padding(.vertical, 8)
             .background(.white.opacity(0.12))
             .clipShape(RoundedRectangle(cornerRadius: 8))
         }


### PR DESCRIPTION
### Why?

An Apple Human Interface Guidelines audit revealed gaps in both the iOS and Mac apps — hardcoded font sizes blocking Dynamic Type, missing VoiceOver labels/traits on interactive elements, and spacing values that don't align to the 8pt grid.

### How?

Fix the concrete issues found during the audit across both platforms: swap fixed font sizes for semantic text styles on iOS, add accessibility labels/hints/traits to interactive pattern pills and action buttons on both platforms, and normalize padding and flow layout spacing to 4/8pt multiples.

<details>
<summary>Implementation Plan</summary>

# Apple HIG Review: SnapGrid iOS & Mac Apps

## Context

A comprehensive audit of both the iOS companion app and the native Mac app against Apple's Human Interface Guidelines. The review covers navigation, accessibility, color system, typography, animations, gestures, spacing, and platform-specific conventions.

---

## Overall Scores

| Area | Mac | iOS | Notes |
|------|-----|-----|-------|
| Navigation | A | A | Both use native patterns correctly |
| Accessibility | A- | B+ | Mac is stronger (42 labels vs ~10) |
| Colors | A | C+ | iOS forces dark mode with hardcoded RGB |
| Typography | A | B | iOS has several `.system(size:)` calls |
| Animations | A | A | Shared `SnapSpring` token system is excellent |
| Gestures | A | A | Expert-level on both platforms |
| Spacing | A- | B | iOS has some non-8pt values |
| Platform conventions | A | A- | Mac keyboard shortcuts are thorough |

**Mac: 92/100 | iOS: 80/100**

---

## Findings by Category

### 1. Navigation -- Both EXCELLENT

**Mac:** `NavigationSplitView` with sidebar + detail columns. Sidebar has proper column width constraints (180-300pt), drag-to-reorder, inline editing. Searchable in toolbar.

**iOS:** `NavigationStack` inside `TabView`. Large titles on top-level views, inline on detail. iOS 26+ uses `.tab(role: .search)` and `.tabBarMinimizeBehavior(.onScrollDown)`.

No issues.

### 2. Accessibility -- Mac GOOD, iOS NEEDS WORK

**iOS issues fixed:**
- Pattern pills missing `.accessibilityLabel` and `.isButton` trait
- `SourceLinkButton` font sizes replaced with semantic styles
- Empty states lack element grouping

**Mac issues fixed:**
- Grid hover buttons (delete, remove, redo) missing `.accessibilityHint`
- Pattern pills in detail view missing accessibility hints
- Source link button missing hint

### 3. Typography -- iOS NEEDS IMPROVEMENT

Replaced all `.system(size:)` with semantic styles in `DetailMetadataSection.swift` and `SourceLinkButton` to enable Dynamic Type scaling.

### 4. Spacing -- Normalized to 8pt grid

**iOS:** 3pt→4pt, 6pt→8pt, 7pt→8pt, 18pt→16pt, 32pt→24pt

**Mac:** 5pt→4pt, 6pt→8pt, 10pt→8pt, 3pt→4pt across PatternPill, ToastView, FloatingVideoLayer, DetailItemView

</details>

<sub>Generated with Claude Code</sub>