### PR TITLE
Add App Store compliance: privacy manifests, sandbox, and AI consent

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,57 @@
+# SnapGrid Privacy Policy
+
+**Last updated:** April 11, 2026
+
+SnapGrid is a local-first media library app. Your privacy is fundamental to how SnapGrid is built.
+
+## Data Storage
+
+All your media files, metadata, and thumbnails are stored locally on your device and in your personal iCloud Drive. SnapGrid does not operate any servers and has no access to your data.
+
+- **Media files** are stored in `~/Documents/SnapGrid/` (Mac) or your iCloud Drive container (iOS).
+- **App preferences** are stored locally using UserDefaults on your device.
+- **API keys** you provide are stored locally on your Mac and optionally synced to your iOS device via your iCloud Drive using AES-GCM encryption.
+
+## AI Analysis (Optional)
+
+If you choose to enable AI analysis by providing your own API key, SnapGrid sends your images directly to the AI provider you selected:
+
+- **OpenAI** (api.openai.com)
+- **Anthropic** (api.anthropic.com)
+- **Google Gemini** (generativelanguage.googleapis.com)
+- **OpenRouter** (openrouter.ai)
+
+Image data is sent directly from your device to the provider's API using your personal API key. SnapGrid does not proxy, store, or have access to this data in transit. Each provider's own privacy policy governs how they handle your data.
+
+You can disable AI analysis at any time by removing your API key in Settings.
+
+## Data Collection
+
+SnapGrid collects **no analytics, telemetry, or usage data**. There are:
+
+- No crash reporting SDKs
+- No analytics frameworks
+- No advertising identifiers
+- No user tracking of any kind
+
+## Third-Party Services
+
+SnapGrid does not include any third-party SDKs. All network requests are made using Apple's built-in frameworks (URLSession) directly to the services listed above, only when you explicitly configure them.
+
+When importing media from X/Twitter URLs, SnapGrid accesses Twitter's public syndication API to retrieve the media you requested.
+
+## iCloud Sync
+
+SnapGrid uses your personal iCloud Drive to sync media and settings between your Mac and iOS devices. This sync happens entirely through Apple's iCloud infrastructure using your Apple Account. SnapGrid has no server-side component and cannot access your iCloud data.
+
+## Children's Privacy
+
+SnapGrid is not directed at children under 13 and does not knowingly collect personal information from children.
+
+## Changes
+
+We may update this policy from time to time. The latest version will always be available at [snapgrid.app/privacy](https://snapgrid.app/privacy).
+
+## Contact
+
+If you have questions about this privacy policy, contact us at privacy@snapgrid.app.

--- a/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
+++ b/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		998C7D0061E2C761956FC2E3 /* SpaceGuidanceResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1696B4C530053979783AE15 /* SpaceGuidanceResolverTests.swift */; };
 		9C71904E952150ED1955B8A1 /* SpaceMembership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E99DFC078951AD2464BFA00 /* SpaceMembership.swift */; };
 		9C85488C4998238102951235 /* AIAnalysisParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F5C8EE662A5F61686B9D75F /* AIAnalysisParsingTests.swift */; };
+		9CC80955417BF9D4404DA60F /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 5DF868B1AA1D445C4A7FDB30 /* PrivacyInfo.xcprivacy */; };
 		A1DD9F32448B920AC6E63BB2 /* SyncWatcherIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736BF8FF80CB87437CBFAB02 /* SyncWatcherIntegrationTests.swift */; };
 		A49356A43DA978FCC2C0536C /* IntegrationTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E1F6F29AC12B68F7CEE44A /* IntegrationTestSupport.swift */; };
 		ACD5CD7D34819BB6E99CACD5 /* SyncWatcherDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6598B587FE431314D84564BF /* SyncWatcherDataTests.swift */; };
@@ -123,6 +124,7 @@
 		50DDD531DF326D845D4CCA67 /* StorageSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageSettingsTab.swift; sourceTree = "<group>"; };
 		567E56BCED6198606FEE46D4 /* PromptsSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptsSettingsTab.swift; sourceTree = "<group>"; };
 		5AD86EAF0DB32A5991AF004C /* SwiftDataTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataTestSupport.swift; sourceTree = "<group>"; };
+		5DF868B1AA1D445C4A7FDB30 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		5EE73C497EBB7A2FE40F9777 /* GuidanceFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceFallbackTests.swift; sourceTree = "<group>"; };
 		6242DCFA059749F058CC6487 /* ElectronImportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElectronImportService.swift; sourceTree = "<group>"; };
 		6477AAD40C3308F596D68729 /* Space.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Space.swift; sourceTree = "<group>"; };
@@ -303,6 +305,7 @@
 			children = (
 				1A8584DB6A15E23CD509BC39 /* Assets.xcassets */,
 				9CF36B9F264117143DF32A8E /* Info.plist */,
+				5DF868B1AA1D445C4A7FDB30 /* PrivacyInfo.xcprivacy */,
 				79AADB26603B741C1AC17342 /* SnapGrid.entitlements */,
 			);
 			path = Resources;
@@ -474,6 +477,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				45D276D4D94785E34DC0F0C4 /* Assets.xcassets in Resources */,
+				9CC80955417BF9D4404DA60F /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SnapGrid/SnapGrid/Resources/PrivacyInfo.xcprivacy
+++ b/SnapGrid/SnapGrid/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/SnapGrid/SnapGrid/Resources/SnapGrid.entitlements
+++ b/SnapGrid/SnapGrid/Resources/SnapGrid.entitlements
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 	<key>com.apple.developer.ubiquity-container-identifiers</key>
 	<array>
 		<string>iCloud.com.SnapGrid</string>

--- a/SnapGrid/SnapGrid/Services/ImportService.swift
+++ b/SnapGrid/SnapGrid/Services/ImportService.swift
@@ -160,6 +160,14 @@ final class ImportService {
             return
         }
 
+        // First-time consent: confirm user understands images are sent to external AI provider
+        if !UserDefaults.standard.bool(forKey: "aiAnalysisConsentGiven") {
+            let confirmed = await MainActor.run {
+                showAnalysisConsentAlert(provider: provider)
+            }
+            guard confirmed else { return }
+        }
+
         let storedModel = UserDefaults.standard.string(forKey: "\(provider.rawValue)Model") ?? ModelDiscoveryService.autoModelValue
         let model: String
         if storedModel == ModelDiscoveryService.autoModelValue {
@@ -262,6 +270,25 @@ final class ImportService {
 
         if let ext = urlPathExtension, SupportedMedia.allExtensions.contains(ext) { return ext }
         return nil
+    }
+
+    /// Shows a one-time consent alert explaining that images will be sent to an external AI provider.
+    /// Returns `true` if the user consented, `false` if they declined.
+    @MainActor
+    private func showAnalysisConsentAlert(provider: AIProvider) -> Bool {
+        let alert = NSAlert()
+        alert.messageText = "Enable AI Analysis?"
+        alert.informativeText = "Your images will be sent to \(provider.displayName)'s API for analysis using your API key. Image data is transmitted directly to the provider and is subject to their privacy policy.\n\nYou can change or remove your API key in Settings at any time."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Enable")
+        alert.addButton(withTitle: "Not Now")
+
+        let response = alert.runModal()
+        if response == .alertFirstButtonReturn {
+            UserDefaults.standard.set(true, forKey: "aiAnalysisConsentGiven")
+            return true
+        }
+        return false
     }
 
     enum ImportError: LocalizedError {

--- a/SnapGrid/SnapGrid/Views/Settings/GeneralSettingsTab.swift
+++ b/SnapGrid/SnapGrid/Views/Settings/GeneralSettingsTab.swift
@@ -65,6 +65,9 @@ struct GeneralSettingsTab: View {
         }
     }
 
+    private let privacyPolicyURL = URL(string: "https://snapgrid.app/privacy")!
+    private let supportURL = URL(string: "https://snapgrid.app/support")!
+
     var body: some View {
         Form {
             Section("Appearance") {
@@ -121,6 +124,15 @@ struct GeneralSettingsTab: View {
                 }
 
                 modelPicker
+            }
+
+            Section("About") {
+                Link(destination: privacyPolicyURL) {
+                    Label("Privacy Policy", systemImage: "hand.raised")
+                }
+                Link(destination: supportURL) {
+                    Label("Support", systemImage: "questionmark.circle")
+                }
             }
         }
         .formStyle(.grouped)

--- a/SnapGrid/project.yml
+++ b/SnapGrid/project.yml
@@ -52,6 +52,9 @@ targets:
     entitlements:
       path: SnapGrid/Resources/SnapGrid.entitlements
       properties:
+        com.apple.security.app-sandbox: true
+        com.apple.security.network.client: true
+        com.apple.security.files.user-selected.read-write: true
         com.apple.developer.ubiquity-container-identifiers:
           - iCloud.com.SnapGrid
 

--- a/ios/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
+++ b/ios/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A100000060 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = B100000060 /* PrivacyInfo.xcprivacy */; };
 		00B9B3A1CE6741B63334035B /* AIAnalysisParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD0DAB918AE6C43203687B1 /* AIAnalysisParsingTests.swift */; };
 		11C0F4AB839DF43E22D65B9A /* KeySyncCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D2D2CB68835763A39B0B88 /* KeySyncCryptoTests.swift */; };
 		2D5F5E408DB2900D5E4EB16A /* GuidanceFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2E6651487D0EFEE5E52932 /* GuidanceFallbackTests.swift */; };
@@ -140,6 +141,7 @@
 		B100000022 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 		B100000023 /* SnapGrid.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SnapGrid.entitlements; sourceTree = "<group>"; };
 		B100000024 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B100000060 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		B100000025 /* ShareImportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareImportService.swift; sourceTree = "<group>"; };
 		B100000030 /* AnimationTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationTokens.swift; sourceTree = "<group>"; };
 		B100000031 /* ImageImportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageImportService.swift; sourceTree = "<group>"; };
@@ -361,6 +363,7 @@
 				B100000022 /* AppIcon.icon */,
 				B100000023 /* SnapGrid.entitlements */,
 				B100000024 /* Info.plist */,
+				B100000060 /* PrivacyInfo.xcprivacy */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -554,6 +557,7 @@
 			files = (
 				A100000019 /* Assets.xcassets in Resources */,
 				A100000022 /* AppIcon.icon in Resources */,
+				A100000060 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/SnapGrid/SnapGrid/Resources/PrivacyInfo.xcprivacy
+++ b/ios/SnapGrid/SnapGrid/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/ios/SnapGrid/SnapGrid/Services/AnalysisCoordinator.swift
+++ b/ios/SnapGrid/SnapGrid/Services/AnalysisCoordinator.swift
@@ -8,6 +8,35 @@ import UIKit
 final class AnalysisCoordinator {
     private var analysisTask: Task<Void, Never>?
 
+    /// Set to `true` when analysis needs user consent. View layer shows the alert.
+    var needsConsentPrompt = false
+    /// Pending items waiting for consent before analysis can proceed.
+    private var pendingConsentItems: [MediaItem] = []
+    private var pendingConsentAllItems: [MediaItem] = []
+
+    /// Whether the user has granted consent for AI analysis.
+    static var hasConsent: Bool {
+        UserDefaults.standard.bool(forKey: "aiAnalysisConsentGiven")
+    }
+
+    /// Call from view layer after user confirms the consent alert.
+    func grantConsent() {
+        UserDefaults.standard.set(true, forKey: "aiAnalysisConsentGiven")
+        needsConsentPrompt = false
+        let items = pendingConsentItems
+        let allItems = pendingConsentAllItems
+        pendingConsentItems = []
+        pendingConsentAllItems = []
+        analyzeItems(items, allItems: allItems)
+    }
+
+    /// Call from view layer if user declines.
+    func declineConsent() {
+        needsConsentPrompt = false
+        pendingConsentItems = []
+        pendingConsentAllItems = []
+    }
+
     // Dependencies — set once via configure(), used by all analysis methods.
     private var keySyncService: KeySyncService?
     private var fileSystem: FileSystemManager?
@@ -33,6 +62,15 @@ final class AnalysisCoordinator {
             print("[Analysis] Skipped — coordinator not configured")
             return
         }
+
+        // First-time consent check
+        if !Self.hasConsent {
+            pendingConsentItems = items
+            pendingConsentAllItems = allItems
+            needsConsentPrompt = true
+            return
+        }
+
         guard keySyncService.isUnlocked else {
             print("[Analysis] Skipped — keySyncService not unlocked")
             return

--- a/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
@@ -217,6 +217,12 @@ struct MainView: View {
             }
             Button("Cancel", role: .cancel) {}
         }
+        .alert("Enable AI Analysis?", isPresented: $analysisCoordinator.needsConsentPrompt) {
+            Button("Enable") { analysisCoordinator.grantConsent() }
+            Button("Not Now", role: .cancel) { analysisCoordinator.declineConsent() }
+        } message: {
+            Text("Your images will be sent to your configured AI provider's API for analysis. Image data is transmitted directly to the provider and is subject to their privacy policy.")
+        }
     }
 
     // MARK: - Tab Content

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,11 @@
 {
   "version": 1,
   "skills": {
+    "apple-appstore-reviewer": {
+      "source": "github/awesome-copilot",
+      "sourceType": "github",
+      "computedHash": "848a1946f838e1b36f4af8b65caeea9e5bfa486d6059325520bb6124c05b0526"
+    },
     "apple-hig-designer": {
       "source": "jamesrochabrun/skills",
       "sourceType": "github",


### PR DESCRIPTION
### Why?

Both the iOS and Mac apps need to pass App Store Review. An audit identified several compliance gaps that would likely cause rejection: missing privacy manifests (required since Spring 2024), no App Sandbox on the Mac app (mandatory for Mac App Store), no user consent before sending images to external AI providers, and no privacy policy link.

### How?

Adds `PrivacyInfo.xcprivacy` to both targets declaring no tracking and required-reason API usage, enables App Sandbox on Mac with network and user-selected file entitlements, and introduces a one-time consent dialog on both platforms before images are first sent to AI providers. Also adds privacy policy/support links to Mac Settings and a draft privacy policy document.

<sub>Generated with Claude Code</sub>