### PR TITLE
Use alert instead of confirmation dialog for iOS delete

### DIFF
--- a/ios/SnapGrid/SnapGrid/Views/Detail/ImageDetailView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/ImageDetailView.swift
@@ -146,10 +146,11 @@ struct MediaDetailModal: View {
                             }
                         }
                         .toolbarColorScheme(.dark, for: .navigationBar)
-                        .confirmationDialog("Delete this item?", isPresented: $showDeleteConfirmation, titleVisibility: .visible) {
+                        .alert("Delete this item?", isPresented: $showDeleteConfirmation) {
                             Button("Delete", role: .destructive) {
                                 deleteRequestID += 1
                             }
+                            Button("Cancel", role: .cancel) {}
                         }
                 }
             }

--- a/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
@@ -184,20 +184,17 @@ struct MainView: View {
                     .presentationDetents([.medium, .large])
             }
         }
-        .confirmationDialog(
-            "Delete this item?",
-            isPresented: Binding(
-                get: { appState.itemToDelete != nil },
-                set: { if !$0 { appState.itemToDelete = nil } }
-            ),
-            titleVisibility: .visible
-        ) {
+        .alert("Delete this item?", isPresented: Binding(
+            get: { appState.itemToDelete != nil },
+            set: { if !$0 { appState.itemToDelete = nil } }
+        )) {
             Button("Delete", role: .destructive) {
                 if let item = appState.itemToDelete {
                     handleItemDeleted(item)
                     appState.itemToDelete = nil
                 }
             }
+            Button("Cancel", role: .cancel) {}
         }
         .alert("New Space", isPresented: $showNewSpaceAlert) {
             TextField("Space name", text: $newSpaceName)


### PR DESCRIPTION
### Why?

The iOS delete confirmation uses `.confirmationDialog()`, which renders as a popover with a caret on iPad. The caret points at the wrong element because the modifier is attached high in the view hierarchy, making the interaction confusing.

### How?

Switched both delete confirmation sites (grid view and detail view) from `.confirmationDialog()` to `.alert()`, which renders as a centered modal dialog with no anchor/caret.

<details>
<summary>Implementation Plan</summary>

# Replace iOS delete confirmation popover with alert

## Context
On iOS (especially iPad), `.confirmationDialog()` renders as a popover with a caret/arrow that points at the source view. The caret is anchoring to the wrong element, making the UX confusing. Switching to `.alert()` gives a centered modal dialog with no caret — cleaner and more predictable.

## Changes

### 1. `ios/SnapGrid/SnapGrid/Views/Main/MainView.swift` (lines 187-201)
Replace `.confirmationDialog(...)` with `.alert(...)`:
```swift
.alert("Delete this item?", isPresented: Binding(
    get: { appState.itemToDelete != nil },
    set: { if !$0 { appState.itemToDelete = nil } }
)) {
    Button("Delete", role: .destructive) {
        if let item = appState.itemToDelete {
            handleItemDeleted(item)
            appState.itemToDelete = nil
        }
    }
    Button("Cancel", role: .cancel) {}
}
```

### 2. `ios/SnapGrid/SnapGrid/Views/Detail/ImageDetailView.swift` (line 149-153)
Replace `.confirmationDialog(...)` with `.alert(...)`:
```swift
.alert("Delete this item?", isPresented: $showDeleteConfirmation) {
    Button("Delete", role: .destructive) {
        deleteRequestID += 1
    }
    Button("Cancel", role: .cancel) {}
}
```

## Notes
- `.alert()` automatically includes a Cancel button even without explicit one, but adding it explicitly for clarity
- No changes needed to state management — same `isPresented` bindings work for both modifiers
- `titleVisibility` parameter drops off since `.alert()` always shows its title

</details>

<sub>Generated with Claude Code</sub>