### PR TITLE
Add iOS Settings.bundle for standalone API key config with bidirectional sync

### DIFF
--- a/SnapGrid/SnapGrid/App/SnapGridApp.swift
+++ b/SnapGrid/SnapGrid/App/SnapGridApp.swift
@@ -54,7 +54,10 @@ struct SnapGridApp: App {
         WindowGroup("SnapGrid") {
             ContentView()
                 .preferredColorScheme(appearanceColorScheme)
-                .task { KeySyncService.syncToiCloud() }
+                .task {
+                    KeySyncService.syncFromiCloud()
+                    KeySyncService.syncToiCloud()
+                }
         }
         .modelContainer(container)
         .defaultSize(width: 1280, height: 800)

--- a/SnapGrid/SnapGrid/Services/KeySyncService.swift
+++ b/SnapGrid/SnapGrid/Services/KeySyncService.swift
@@ -1,19 +1,17 @@
 import Foundation
 
-/// Encrypts API key configuration and writes it to the shared iCloud container
-/// so the iOS companion app can perform its own AI analysis.
 enum KeySyncService {
 
     private static let fileName = ".apikeys.encrypted"
+    private static let lastImportedAtKey = "keySyncLastImportedAt"
 
-    /// Encrypt current key state and write to iCloud.
-    /// Called automatically after every key save/remove and provider/model change.
+    // MARK: - Write local keys to iCloud
+
     static func syncToiCloud() {
         guard MediaStorageService.shared.isUsingiCloud else { return }
 
         let url = MediaStorageService.shared.baseURL.appendingPathComponent(fileName)
 
-        // Gather all configured keys
         var keys: [String: String] = [:]
         for provider in AIProvider.allCases {
             if let key = try? KeychainService.get(service: provider.keychainService), !key.isEmpty {
@@ -38,13 +36,65 @@ enum KeySyncService {
             let plaintext = try encoder.encode(payload)
             let encrypted = try KeySyncCrypto.encrypt(plaintext)
             try encrypted.write(to: url, options: .atomic)
+            UserDefaults.standard.set(Date.now.timeIntervalSince1970, forKey: lastImportedAtKey)
             print("[KeySync] Wrote encrypted keys to iCloud")
         } catch {
             print("[KeySync] Failed to sync: \(error.localizedDescription)")
         }
     }
 
-    /// Remove the encrypted file from iCloud (e.g. when user wants to revoke iOS access).
+    // MARK: - Read keys from iCloud (written by iOS or another Mac)
+
+    static func syncFromiCloud() {
+        guard MediaStorageService.shared.isUsingiCloud else { return }
+
+        let url = MediaStorageService.shared.baseURL.appendingPathComponent(fileName)
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+
+        do {
+            let encrypted = try Data(contentsOf: url)
+            let decrypted = try KeySyncCrypto.decrypt(encrypted)
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            let payload = try decoder.decode(KeySyncPayload.self, from: decrypted)
+
+            let lastImported = UserDefaults.standard.double(forKey: lastImportedAtKey)
+            let payloadTimestamp = payload.updatedAt.timeIntervalSince1970
+
+            guard payloadTimestamp > lastImported else {
+                print("[KeySync] iCloud file not newer than last import, skipping")
+                return
+            }
+
+            if payload.provider == "none" {
+                for provider in AIProvider.allCases {
+                    try? KeychainService.delete(service: provider.keychainService)
+                }
+                UserDefaults.standard.set(payloadTimestamp, forKey: lastImportedAtKey)
+                NotificationCenter.default.post(name: .apiKeySaved, object: nil)
+                print("[KeySync] Imported key removal from iCloud")
+                return
+            }
+
+            for (providerRaw, key) in payload.keys where !key.isEmpty {
+                try KeychainService.set(key: key, forService: providerRaw)
+            }
+
+            UserDefaults.standard.set(payload.provider, forKey: "aiProvider")
+            let modelKey = "\(payload.provider)Model"
+            UserDefaults.standard.set(payload.model, forKey: modelKey)
+
+            UserDefaults.standard.set(payloadTimestamp, forKey: lastImportedAtKey)
+
+            NotificationCenter.default.post(name: .apiKeySaved, object: nil)
+            print("[KeySync] Imported keys from iCloud — provider: \(payload.provider)")
+        } catch {
+            print("[KeySync] Failed to read from iCloud: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Remove sync file
+
     static func removeSyncFile() {
         guard MediaStorageService.shared.isUsingiCloud else { return }
         let url = MediaStorageService.shared.baseURL.appendingPathComponent(fileName)

--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -312,6 +312,7 @@ struct ContentView: View {
         .task {
             // Re-sync when app regains focus (picks up iCloud changes from other devices).
             for await _ in NotificationCenter.default.notifications(named: NSApplication.didBecomeActiveNotification) {
+                KeySyncService.syncFromiCloud()
                 await syncWatcher.resyncFromDisk()
                 await importService.analyzeUnanalyzedItems(from: allItems, context: modelContext)
             }

--- a/ios/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
+++ b/ios/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		A100000060 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = B100000060 /* PrivacyInfo.xcprivacy */; };
+		A100000070 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = B100000070 /* Settings.bundle */; };
 		00B9B3A1CE6741B63334035B /* AIAnalysisParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD0DAB918AE6C43203687B1 /* AIAnalysisParsingTests.swift */; };
 		11C0F4AB839DF43E22D65B9A /* KeySyncCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D2D2CB68835763A39B0B88 /* KeySyncCryptoTests.swift */; };
 		2D5F5E408DB2900D5E4EB16A /* GuidanceFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2E6651487D0EFEE5E52932 /* GuidanceFallbackTests.swift */; };
@@ -141,6 +142,7 @@
 		B100000023 /* SnapGrid.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SnapGrid.entitlements; sourceTree = "<group>"; };
 		B100000024 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B100000060 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		B100000070 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		B100000025 /* ShareImportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareImportService.swift; sourceTree = "<group>"; };
 		B100000030 /* AnimationTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationTokens.swift; sourceTree = "<group>"; };
 		B100000031 /* ImageImportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageImportService.swift; sourceTree = "<group>"; };
@@ -364,6 +366,7 @@
 				B100000023 /* SnapGrid.entitlements */,
 				B100000024 /* Info.plist */,
 				B100000060 /* PrivacyInfo.xcprivacy */,
+				B100000070 /* Settings.bundle */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -550,6 +553,7 @@
 				A100000019 /* Assets.xcassets in Resources */,
 				A100000022 /* AppIcon.icon in Resources */,
 				A100000060 /* PrivacyInfo.xcprivacy in Resources */,
+				A100000070 /* Settings.bundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/SnapGrid/SnapGrid/App/ContentView.swift
+++ b/ios/SnapGrid/SnapGrid/App/ContentView.swift
@@ -25,10 +25,11 @@ struct ContentView: View {
             fileSystem.restoreAccess()
         }
         .task {
-            // Wait for access to be granted, then check for synced API keys
             for await granted in fileSystem.$isAccessGranted.values where granted {
-                if fileSystem.isUsingiCloud, let rootURL = fileSystem.rootURL {
+                if let rootURL = fileSystem.rootURL {
                     keySyncService.checkForKeys(rootURL: rootURL)
+                } else {
+                    keySyncService.checkForSettingsKeys()
                 }
                 break
             }
@@ -38,17 +39,17 @@ struct ContentView: View {
                 if !fileSystem.isAccessGranted {
                     fileSystem.restoreAccess()
                 }
-                // Silently check for iCloud availability when in local mode
                 if !fileSystem.isUsingiCloud {
                     fileSystem.checkAndMigrateToiCloud(context: modelContext)
                 }
-                if fileSystem.isUsingiCloud, let rootURL = fileSystem.rootURL {
+                if let rootURL = fileSystem.rootURL {
                     keySyncService.checkForKeys(rootURL: rootURL)
+                } else {
+                    keySyncService.checkForSettingsKeys()
                 }
             }
         }
         .onChange(of: fileSystem.isUsingiCloud) { _, usingiCloud in
-            // When we switch to iCloud (after migration), sync keys
             if usingiCloud, let rootURL = fileSystem.rootURL {
                 keySyncService.checkForKeys(rootURL: rootURL)
             }

--- a/ios/SnapGrid/SnapGrid/App/SnapGridApp.swift
+++ b/ios/SnapGrid/SnapGrid/App/SnapGridApp.swift
@@ -9,6 +9,12 @@ struct SnapGridApp: App {
     private static let multiSpaceStoreResetKey = "multiSpaceStoreReset_v1"
 
     init() {
+        UserDefaults.standard.register(defaults: [
+            "settings_provider": "anthropic",
+            "settings_apiKey": "",
+            "settings_model": ""
+        ])
+
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         let snapGridDir = appSupport.appendingPathComponent("SnapGrid", isDirectory: true)
         try? FileManager.default.createDirectory(at: snapGridDir, withIntermediateDirectories: true)

--- a/ios/SnapGrid/SnapGrid/Resources/Settings.bundle/Root.plist
+++ b/ios/SnapGrid/SnapGrid/Resources/Settings.bundle/Root.plist
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>StringsTable</key>
+	<string>Root</string>
+	<key>PreferenceSpecifiers</key>
+	<array>
+		<dict>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+			<key>Title</key>
+			<string>AI Provider</string>
+			<key>FooterText</key>
+			<string>Configure your AI provider to enable image analysis without the Mac app. Keys sync automatically between devices via iCloud.</string>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Title</key>
+			<string>Provider</string>
+			<key>Key</key>
+			<string>settings_provider</string>
+			<key>DefaultValue</key>
+			<string>anthropic</string>
+			<key>Titles</key>
+			<array>
+				<string>None</string>
+				<string>OpenAI</string>
+				<string>Anthropic Claude</string>
+				<string>Google Gemini</string>
+				<string>OpenRouter</string>
+			</array>
+			<key>Values</key>
+			<array>
+				<string>none</string>
+				<string>openai</string>
+				<string>anthropic</string>
+				<string>gemini</string>
+				<string>openrouter</string>
+			</array>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSTextFieldSpecifier</string>
+			<key>Title</key>
+			<string>API Key</string>
+			<key>Key</key>
+			<string>settings_apiKey</string>
+			<key>DefaultValue</key>
+			<string></string>
+			<key>IsSecure</key>
+			<true/>
+			<key>KeyboardType</key>
+			<string>Alphabet</string>
+			<key>AutocapitalizationType</key>
+			<string>None</string>
+			<key>AutocorrectionType</key>
+			<string>No</string>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSTextFieldSpecifier</string>
+			<key>Title</key>
+			<string>Model</string>
+			<key>Key</key>
+			<string>settings_model</string>
+			<key>DefaultValue</key>
+			<string></string>
+			<key>KeyboardType</key>
+			<string>Alphabet</string>
+			<key>AutocapitalizationType</key>
+			<string>None</string>
+			<key>AutocorrectionType</key>
+			<string>No</string>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+			<key>FooterText</key>
+			<string>Leave Model empty to use the default for your provider. Changes sync to the Mac app via iCloud.</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/ios/SnapGrid/SnapGrid/Services/KeySyncService.swift
+++ b/ios/SnapGrid/SnapGrid/Services/KeySyncService.swift
@@ -1,7 +1,11 @@
 import Foundation
 
-/// Reads the encrypted API key file from iCloud and decrypts it automatically.
-/// Keys are held in memory only — never persisted to disk on iOS.
+enum KeySource: String {
+    case settingsBundle
+    case iCloudSync
+    case none
+}
+
 @MainActor
 final class KeySyncService: ObservableObject {
 
@@ -10,91 +14,182 @@ final class KeySyncService: ObservableObject {
     @Published private(set) var isUnlocked = false
     @Published private(set) var activeProvider: String?
     @Published private(set) var activeModel: String?
+    @Published private(set) var keySource: KeySource = .none
 
     private var decryptedKeys: [String: String] = [:]
     private let fileName = ".apikeys.encrypted"
 
     private init() {}
 
-    /// Check for the encrypted key file and decrypt if found.
-    /// Called on launch (when iCloud access is granted) and on every foreground transition.
-    /// Skips entirely in local mode — encrypted key file only exists in iCloud.
-    func checkForKeys(rootURL: URL) {
-        guard FileSystemManager.shared?.isUsingiCloud == true else { return }
+    // MARK: - Main sync entry point
 
+    func checkForKeys(rootURL: URL) {
+        let defaults = UserDefaults.standard
+        let sbApiKey = (defaults.string(forKey: "settings_apiKey") ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let sbProvider = defaults.string(forKey: "settings_provider") ?? "anthropic"
+        let sbModel = (defaults.string(forKey: "settings_model") ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let lastSyncedKey = defaults.string(forKey: "settings_lastSyncedApiKey") ?? ""
+
+        let providerIsNone = sbProvider == "none"
+        let settingsBundleHasKey = !sbApiKey.isEmpty && !providerIsNone
+        let settingsBundleChanged = settingsBundleHasKey && sbApiKey != lastSyncedKey
+        let settingsBundleCleared = providerIsNone && lastSyncedKey != ""
+
+        if settingsBundleCleared {
+            defaults.set("", forKey: "settings_lastSyncedApiKey")
+            defaults.set("", forKey: "settings_apiKey")
+            if FileSystemManager.shared?.isUsingiCloud == true {
+                writeToiCloud(rootURL: rootURL, provider: "none", model: "", keys: [:])
+            }
+            applyNoKeys()
+            return
+        }
+
+        if settingsBundleChanged {
+            guard AIProvider(rawValue: sbProvider) != nil else {
+                print("[KeySync] Settings.bundle has unknown provider: \(sbProvider)")
+                applyNoKeys()
+                return
+            }
+
+            applyKeys(provider: sbProvider, model: sbModel.isEmpty ? nil : sbModel, keys: [sbProvider: sbApiKey], source: .settingsBundle)
+            defaults.set(sbApiKey, forKey: "settings_lastSyncedApiKey")
+
+            if FileSystemManager.shared?.isUsingiCloud == true {
+                writeToiCloud(rootURL: rootURL, provider: sbProvider, model: sbModel, keys: [sbProvider: sbApiKey])
+            }
+            return
+        }
+
+        if let payload = readiCloudPayload(rootURL: rootURL) {
+            let iCloudActiveKey = payload.keys[payload.provider] ?? ""
+
+            if payload.provider == "none" || iCloudActiveKey.isEmpty {
+                if lastSyncedKey != "" {
+                    defaults.set("", forKey: "settings_lastSyncedApiKey")
+                    defaults.set("", forKey: "settings_apiKey")
+                    defaults.set("none", forKey: "settings_provider")
+                }
+                applyNoKeys()
+                return
+            }
+
+            if iCloudActiveKey != lastSyncedKey {
+                applyKeys(provider: payload.provider, model: payload.model, keys: payload.keys, source: .iCloudSync)
+                defaults.set(iCloudActiveKey, forKey: "settings_lastSyncedApiKey")
+                defaults.set(iCloudActiveKey, forKey: "settings_apiKey")
+                defaults.set(payload.provider, forKey: "settings_provider")
+                defaults.set(payload.model, forKey: "settings_model")
+                return
+            }
+
+            applyKeys(provider: payload.provider, model: payload.model, keys: payload.keys, source: .iCloudSync)
+            return
+        }
+
+        if settingsBundleHasKey, AIProvider(rawValue: sbProvider) != nil {
+            applyKeys(provider: sbProvider, model: sbModel.isEmpty ? nil : sbModel, keys: [sbProvider: sbApiKey], source: .settingsBundle)
+            return
+        }
+
+        applyNoKeys()
+    }
+
+    func checkForSettingsKeys() {
+        let defaults = UserDefaults.standard
+        let sbApiKey = (defaults.string(forKey: "settings_apiKey") ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let sbProvider = defaults.string(forKey: "settings_provider") ?? "anthropic"
+        let sbModel = (defaults.string(forKey: "settings_model") ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !sbApiKey.isEmpty, sbProvider != "none", AIProvider(rawValue: sbProvider) != nil else {
+            applyNoKeys()
+            return
+        }
+
+        applyKeys(provider: sbProvider, model: sbModel.isEmpty ? nil : sbModel, keys: [sbProvider: sbApiKey], source: .settingsBundle)
+    }
+
+    // MARK: - Key accessors
+
+    func apiKey(for provider: String) -> String? {
+        decryptedKeys[provider]
+    }
+
+    func activeAPIKey() -> String? {
+        guard let provider = activeProvider else { return nil }
+        return decryptedKeys[provider]
+    }
+
+    // MARK: - Private helpers
+
+    private func applyKeys(provider: String, model: String?, keys: [String: String], source: KeySource) {
+        decryptedKeys = keys
+        activeProvider = provider
+        activeModel = model
+        keySource = source
+        isUnlocked = keys.values.contains { !$0.isEmpty }
+        print("[KeySync] Using \(source.rawValue) keys — provider: \(provider)")
+    }
+
+    private func applyNoKeys() {
+        decryptedKeys = [:]
+        activeProvider = nil
+        activeModel = nil
+        keySource = .none
+        isUnlocked = false
+    }
+
+    private func readiCloudPayload(rootURL: URL) -> KeySyncPayload? {
         let fileURL = rootURL.appendingPathComponent(fileName)
         let fm = FileManager.default
 
-        print("[KeySync] Checking for keys at: \(fileURL.path)")
-
-        // Handle iCloud placeholder — file not yet downloaded
-        // iCloud placeholders for ".apikeys.encrypted" → ".apikeys.encrypted.icloud"
         if !fm.fileExists(atPath: fileURL.path) {
             let dir = fileURL.deletingLastPathComponent()
-            // iCloud placeholder naming: prefix dot + original name + .icloud
-            // For already-dotted files: .apikeys.encrypted → ..apikeys.encrypted.icloud
-            // But also check without extra dot in case behavior varies
             let placeholderNames = [
                 ".\(fileName).icloud",
                 "\(fileName).icloud"
             ]
-
-            var foundPlaceholder = false
             for name in placeholderNames {
                 let placeholderURL = dir.appendingPathComponent(name)
                 if fm.fileExists(atPath: placeholderURL.path) {
                     try? fm.startDownloadingUbiquitousItem(at: fileURL)
-                    print("[KeySync] Encrypted file is iCloud placeholder (\(name)), triggered download")
-                    foundPlaceholder = true
+                    print("[KeySync] Encrypted file is iCloud placeholder, triggered download")
                     break
                 }
             }
-
-            if !foundPlaceholder {
-                print("[KeySync] No encrypted key file found at \(fileURL.path)")
-            }
-
-            // No file available yet
-            isUnlocked = false
-            activeProvider = nil
-            activeModel = nil
-            decryptedKeys = [:]
-            return
+            return nil
         }
 
         do {
             let encrypted = try Data(contentsOf: fileURL)
             let decrypted = try KeySyncCrypto.decrypt(encrypted)
-
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
-            let payload = try decoder.decode(KeySyncPayload.self, from: decrypted)
-
-            decryptedKeys = payload.keys
-            activeProvider = payload.provider
-            activeModel = payload.model
-
-            let hasAnyKey = payload.keys.values.contains { !$0.isEmpty }
-            isUnlocked = hasAnyKey
-
-            print("[KeySync] Decrypted keys — provider: \(payload.provider), keys: \(payload.keys.count)")
+            return try decoder.decode(KeySyncPayload.self, from: decrypted)
         } catch {
             print("[KeySync] Decryption failed: \(error.localizedDescription)")
-            isUnlocked = false
-            activeProvider = nil
-            activeModel = nil
-            decryptedKeys = [:]
+            return nil
         }
     }
 
-    /// Get the API key for a specific provider.
-    func apiKey(for provider: String) -> String? {
-        decryptedKeys[provider]
-    }
+    private func writeToiCloud(rootURL: URL, provider: String, model: String, keys: [String: String]) {
+        let payload = KeySyncPayload(
+            provider: provider,
+            model: model,
+            keys: keys,
+            updatedAt: .now
+        )
 
-    /// Get the API key for the currently active provider.
-    func activeAPIKey() -> String? {
-        guard let provider = activeProvider else { return nil }
-        return decryptedKeys[provider]
+        do {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            let plaintext = try encoder.encode(payload)
+            let encrypted = try KeySyncCrypto.encrypt(plaintext)
+            let fileURL = rootURL.appendingPathComponent(fileName)
+            try encrypted.write(to: fileURL, options: .atomic)
+            print("[KeySync] Wrote keys to iCloud — provider: \(provider)")
+        } catch {
+            print("[KeySync] Failed to write to iCloud: \(error.localizedDescription)")
+        }
     }
 }

--- a/ios/SnapGrid/SnapGridTests/KeySyncServiceTests.swift
+++ b/ios/SnapGrid/SnapGridTests/KeySyncServiceTests.swift
@@ -2,8 +2,6 @@ import Testing
 import Foundation
 @testable import SnapGrid
 
-/// Tests for the iOS KeySyncService (PR #124) — the encrypted key file
-/// reading, decryption, and state management logic.
 @Suite("KeySyncService", .tags(.crypto))
 struct KeySyncServiceTests {
 
@@ -60,7 +58,6 @@ struct KeySyncServiceTests {
         let decoded = try JSONDecoder().decode(KeySyncPayload.self, from: data)
 
         #expect(decoded.keys.isEmpty)
-        // hasAnyKey check: empty keys means not unlocked
         let hasAnyKey = decoded.keys.values.contains { !$0.isEmpty }
         #expect(hasAnyKey == false)
     }
@@ -77,7 +74,6 @@ struct KeySyncServiceTests {
         let data = try JSONEncoder().encode(payload)
         let decoded = try JSONDecoder().decode(KeySyncPayload.self, from: data)
 
-        // hasAnyKey should be true because anthropic has a non-empty value
         let hasAnyKey = decoded.keys.values.contains { !$0.isEmpty }
         #expect(hasAnyKey == true)
     }
@@ -112,7 +108,6 @@ struct KeySyncServiceTests {
         let encoded = try JSONEncoder().encode(payload)
         let encrypted = try KeySyncCrypto.encrypt(encoded)
 
-        // Simulate what iOS KeySyncService.checkForKeys does
         let decrypted = try KeySyncCrypto.decrypt(encrypted)
         let decoded = try JSONDecoder().decode(KeySyncPayload.self, from: decrypted)
 
@@ -124,7 +119,7 @@ struct KeySyncServiceTests {
         #expect(hasAnyKey == true)
     }
 
-    // MARK: - iCloud placeholder detection (PR #124)
+    // MARK: - iCloud placeholder detection
 
     @Test("iCloud placeholder names for dotted files")
     func iCloudPlaceholderNames() {
@@ -135,5 +130,124 @@ struct KeySyncServiceTests {
         ]
         #expect(placeholderNames[0] == "..apikeys.encrypted.icloud")
         #expect(placeholderNames[1] == ".apikeys.encrypted.icloud")
+    }
+
+    // MARK: - Settings.bundle key reading
+
+    @Test("Settings.bundle non-empty key unlocks service")
+    @MainActor func settingsBundleUnlocks() async {
+        let defaults = UserDefaults.standard
+        defer {
+            defaults.removeObject(forKey: "settings_apiKey")
+            defaults.removeObject(forKey: "settings_provider")
+            defaults.removeObject(forKey: "settings_model")
+            defaults.removeObject(forKey: "settings_lastSyncedApiKey")
+        }
+
+        defaults.set("sk-ant-test123", forKey: "settings_apiKey")
+        defaults.set("anthropic", forKey: "settings_provider")
+        defaults.set("", forKey: "settings_model")
+
+        let service = KeySyncService.shared
+        service.checkForSettingsKeys()
+
+        #expect(service.isUnlocked == true)
+        #expect(service.keySource == .settingsBundle)
+        #expect(service.activeProvider == "anthropic")
+        #expect(service.activeModel == nil)
+        #expect(service.activeAPIKey() == "sk-ant-test123")
+    }
+
+    @Test("Settings.bundle empty key does not unlock")
+    @MainActor func settingsBundleEmptyKey() async {
+        let defaults = UserDefaults.standard
+        defer {
+            defaults.removeObject(forKey: "settings_apiKey")
+            defaults.removeObject(forKey: "settings_provider")
+        }
+
+        defaults.set("", forKey: "settings_apiKey")
+        defaults.set("openai", forKey: "settings_provider")
+
+        let service = KeySyncService.shared
+        service.checkForSettingsKeys()
+
+        #expect(service.isUnlocked == false)
+        #expect(service.keySource == .none)
+    }
+
+    @Test("Settings.bundle whitespace-only key treated as empty")
+    @MainActor func settingsBundleWhitespaceKey() async {
+        let defaults = UserDefaults.standard
+        defer {
+            defaults.removeObject(forKey: "settings_apiKey")
+            defaults.removeObject(forKey: "settings_provider")
+        }
+
+        defaults.set("   ", forKey: "settings_apiKey")
+        defaults.set("openai", forKey: "settings_provider")
+
+        let service = KeySyncService.shared
+        service.checkForSettingsKeys()
+
+        #expect(service.isUnlocked == false)
+        #expect(service.keySource == .none)
+    }
+
+    @Test("Settings.bundle unknown provider is rejected")
+    @MainActor func settingsBundleUnknownProvider() async {
+        let defaults = UserDefaults.standard
+        defer {
+            defaults.removeObject(forKey: "settings_apiKey")
+            defaults.removeObject(forKey: "settings_provider")
+        }
+
+        defaults.set("sk-test123", forKey: "settings_apiKey")
+        defaults.set("invalid_provider", forKey: "settings_provider")
+
+        let service = KeySyncService.shared
+        service.checkForSettingsKeys()
+
+        #expect(service.isUnlocked == false)
+        #expect(service.keySource == .none)
+    }
+
+    @Test("Settings.bundle with model sets activeModel")
+    @MainActor func settingsBundleWithModel() async {
+        let defaults = UserDefaults.standard
+        defer {
+            defaults.removeObject(forKey: "settings_apiKey")
+            defaults.removeObject(forKey: "settings_provider")
+            defaults.removeObject(forKey: "settings_model")
+            defaults.removeObject(forKey: "settings_lastSyncedApiKey")
+        }
+
+        defaults.set("sk-test123", forKey: "settings_apiKey")
+        defaults.set("openai", forKey: "settings_provider")
+        defaults.set("gpt-4o-mini", forKey: "settings_model")
+
+        let service = KeySyncService.shared
+        service.checkForSettingsKeys()
+
+        #expect(service.isUnlocked == true)
+        #expect(service.activeModel == "gpt-4o-mini")
+    }
+
+    @Test("Settings.bundle provider 'none' does not unlock")
+    @MainActor func settingsBundleNoneProvider() async {
+        let defaults = UserDefaults.standard
+        defer {
+            defaults.removeObject(forKey: "settings_apiKey")
+            defaults.removeObject(forKey: "settings_provider")
+        }
+
+        defaults.set("sk-test123", forKey: "settings_apiKey")
+        defaults.set("none", forKey: "settings_provider")
+
+        let service = KeySyncService.shared
+        service.checkForSettingsKeys()
+
+        #expect(service.isUnlocked == false)
+        #expect(service.keySource == .none)
     }
 }


### PR DESCRIPTION
### Why?

The iOS app requires the Mac app to configure API keys — there's no way to use AI analysis on iOS standalone. Keys also only sync one-way (Mac → iOS), so changes made on iOS can't propagate back.

### How?

Adds a Settings.bundle so users can configure their AI provider directly in iOS System Settings (Settings > SnapGrid), and makes the encrypted iCloud sync file (`.apikeys.encrypted`) bidirectional — whichever platform writes most recently wins via `updatedAt` timestamp comparison. The Mac app now imports incoming keys on launch/foreground via a new `syncFromiCloud()` path, and selecting "None" as provider propagates key removal across both platforms.

<details>
<summary>Implementation Plan</summary>

# Plan: iOS Settings.bundle + Bidirectional Key Sync

## Context

The iOS app requires the Mac app to configure API keys (one-way: Mac writes encrypted file to iCloud, iOS reads it). This blocks standalone iOS usage. We're adding a Settings.bundle so users can set keys in iOS System Settings, AND making sync bidirectional so keys set on either platform propagate to the other. The iCloud encrypted file (`.apikeys.encrypted`) becomes the single source of truth — whichever platform writes most recently wins.

## Sync Design

**iCloud `.apikeys.encrypted` is the shared sync file.** Both platforms read and write it. The `updatedAt` timestamp in `KeySyncPayload` determines which write is newest.

**iOS → Mac flow (new):**
1. User sets key in iOS Settings > SnapGrid
2. iOS detects Settings.bundle changed → encrypts and writes `.apikeys.encrypted` to iCloud
3. Mac reads on foreground → sees newer `updatedAt` → imports keys to KeychainService + updates UserDefaults

**Mac → iOS flow (existing + enhanced):**
1. User saves key on Mac → writes encrypted file to iCloud
2. iOS reads on foreground → sees newer `updatedAt` → updates Settings.bundle UserDefaults to match

**Change detection:**
- iOS tracks `settings_lastSyncedApiKey` in UserDefaults. If Settings.bundle differs → user changed it → write to iCloud.
- Mac tracks `keySyncLastImportedAt` (Date) in UserDefaults. If iCloud `updatedAt` is newer → import.
- Both platforms update their tracking values after every sync operation.

**Without iCloud:** Settings.bundle still works for local-only iOS analysis. No sync happens.

---

## iOS Changes

### 1. Create `Settings.bundle/Root.plist`

**New:** `ios/SnapGrid/SnapGrid/Settings.bundle/Root.plist`

- PSGroupSpecifier: "AI Provider" header with footer explaining standalone usage
- PSMultiValueSpecifier: Provider picker (`settings_provider`, values: openai/anthropic/gemini/openrouter, default: anthropic)
- PSTextFieldSpecifier: API Key (`settings_apiKey`, secure field)
- PSTextFieldSpecifier: Model (`settings_model`, empty = provider default)
- PSGroupSpecifier: Footer explaining that empty model uses default and sync behavior

### 2. Register UserDefaults defaults

**Modify:** `ios/SnapGrid/SnapGrid/App/SnapGridApp.swift`

### 3. Modify KeySyncService (iOS) — add write + bidirectional sync

**Modify:** `ios/SnapGrid/SnapGrid/Services/KeySyncService.swift`

Add `KeySource` enum and `@Published keySource`. Replace one-way sync with bidirectional logic that compares Settings.bundle changes against iCloud state.

### 4. Update ContentView (iOS) — always check keys

**Modify:** `ios/SnapGrid/SnapGrid/App/ContentView.swift`

Remove `isUsingiCloud` guard — always check keys on launch and foreground.

### 5. Add Settings.bundle to Xcode project

**Modify:** `ios/SnapGrid/SnapGrid.xcodeproj/project.pbxproj`

---

## Mac Changes

### 6. Add `syncFromiCloud()` to KeySyncService (Mac)

**Modify:** `SnapGrid/SnapGrid/Services/KeySyncService.swift`

New static method that reads the encrypted file, compares timestamps, and imports if newer. Handles "none" provider by clearing all keys.

### 7. Call `syncFromiCloud()` on Mac launch and foreground

**Modify:** `SnapGrid/SnapGrid/App/SnapGridApp.swift` and `ContentView.swift`

---

## Tests

6 new iOS tests covering Settings.bundle key reading: unlock, empty key, whitespace, unknown provider, model setting, none provider.

</details>

<sub>Generated with Claude Code</sub>