### PR TITLE
Remove privacy policy and support links from Mac settings

### DIFF
--- a/SnapGrid/SnapGrid/Views/Settings/GeneralSettingsTab.swift
+++ b/SnapGrid/SnapGrid/Views/Settings/GeneralSettingsTab.swift
@@ -65,9 +65,6 @@ struct GeneralSettingsTab: View {
         }
     }
 
-    private let privacyPolicyURL = URL(string: "https://snapgrid.app/privacy")!
-    private let supportURL = URL(string: "https://snapgrid.app/support")!
-
     var body: some View {
         Form {
             Section("Appearance") {
@@ -126,14 +123,6 @@ struct GeneralSettingsTab: View {
                 modelPicker
             }
 
-            Section("About") {
-                Link(destination: privacyPolicyURL) {
-                    Label("Privacy Policy", systemImage: "hand.raised")
-                }
-                Link(destination: supportURL) {
-                    Label("Support", systemImage: "questionmark.circle")
-                }
-            }
         }
         .formStyle(.grouped)
         .onAppear {


### PR DESCRIPTION
### Why?

The privacy policy and support links in Settings pointed to snapgrid.app pages that don't exist. Removing them cleans up the settings UI.

### How?

Deleted the "About" section from `GeneralSettingsTab` along with its two URL constants.

<sub>Generated with Claude Code</sub>