### PR TITLE
Remove first-run AI analysis confirmation dialog

### DIFF
--- a/SnapGrid/SnapGrid/Services/ImportService.swift
+++ b/SnapGrid/SnapGrid/Services/ImportService.swift
@@ -160,14 +160,6 @@ final class ImportService {
             return
         }
 
-        // First-time consent: confirm user understands images are sent to external AI provider
-        if !UserDefaults.standard.bool(forKey: "aiAnalysisConsentGiven") {
-            let confirmed = await MainActor.run {
-                showAnalysisConsentAlert(provider: provider)
-            }
-            guard confirmed else { return }
-        }
-
         let storedModel = UserDefaults.standard.string(forKey: "\(provider.rawValue)Model") ?? ModelDiscoveryService.autoModelValue
         let model: String
         if storedModel == ModelDiscoveryService.autoModelValue {
@@ -270,25 +262,6 @@ final class ImportService {
 
         if let ext = urlPathExtension, SupportedMedia.allExtensions.contains(ext) { return ext }
         return nil
-    }
-
-    /// Shows a one-time consent alert explaining that images will be sent to an external AI provider.
-    /// Returns `true` if the user consented, `false` if they declined.
-    @MainActor
-    private func showAnalysisConsentAlert(provider: AIProvider) -> Bool {
-        let alert = NSAlert()
-        alert.messageText = "Enable AI Analysis?"
-        alert.informativeText = "Your images will be sent to \(provider.displayName)'s API for analysis using your API key. Image data is transmitted directly to the provider and is subject to their privacy policy.\n\nYou can change or remove your API key in Settings at any time."
-        alert.alertStyle = .informational
-        alert.addButton(withTitle: "Enable")
-        alert.addButton(withTitle: "Not Now")
-
-        let response = alert.runModal()
-        if response == .alertFirstButtonReturn {
-            UserDefaults.standard.set(true, forKey: "aiAnalysisConsentGiven")
-            return true
-        }
-        return false
     }
 
     enum ImportError: LocalizedError {

--- a/ios/SnapGrid/SnapGrid/Services/AnalysisCoordinator.swift
+++ b/ios/SnapGrid/SnapGrid/Services/AnalysisCoordinator.swift
@@ -8,35 +8,6 @@ import UIKit
 final class AnalysisCoordinator {
     private var analysisTask: Task<Void, Never>?
 
-    /// Set to `true` when analysis needs user consent. View layer shows the alert.
-    var needsConsentPrompt = false
-    /// Pending items waiting for consent before analysis can proceed.
-    private var pendingConsentItems: [MediaItem] = []
-    private var pendingConsentAllItems: [MediaItem] = []
-
-    /// Whether the user has granted consent for AI analysis.
-    static var hasConsent: Bool {
-        UserDefaults.standard.bool(forKey: "aiAnalysisConsentGiven")
-    }
-
-    /// Call from view layer after user confirms the consent alert.
-    func grantConsent() {
-        UserDefaults.standard.set(true, forKey: "aiAnalysisConsentGiven")
-        needsConsentPrompt = false
-        let items = pendingConsentItems
-        let allItems = pendingConsentAllItems
-        pendingConsentItems = []
-        pendingConsentAllItems = []
-        analyzeItems(items, allItems: allItems)
-    }
-
-    /// Call from view layer if user declines.
-    func declineConsent() {
-        needsConsentPrompt = false
-        pendingConsentItems = []
-        pendingConsentAllItems = []
-    }
-
     // Dependencies — set once via configure(), used by all analysis methods.
     private var keySyncService: KeySyncService?
     private var fileSystem: FileSystemManager?
@@ -60,14 +31,6 @@ final class AnalysisCoordinator {
     func analyzeItems(_ items: [MediaItem], allItems: [MediaItem]) {
         guard let keySyncService, let fileSystem, let modelContext, let searchService else {
             print("[Analysis] Skipped — coordinator not configured")
-            return
-        }
-
-        // First-time consent check
-        if !Self.hasConsent {
-            pendingConsentItems = items
-            pendingConsentAllItems = allItems
-            needsConsentPrompt = true
             return
         }
 

--- a/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
@@ -214,12 +214,6 @@ struct MainView: View {
             }
             Button("Cancel", role: .cancel) {}
         }
-        .alert("Enable AI Analysis?", isPresented: $analysisCoordinator.needsConsentPrompt) {
-            Button("Enable") { analysisCoordinator.grantConsent() }
-            Button("Not Now", role: .cancel) { analysisCoordinator.declineConsent() }
-        } message: {
-            Text("Your images will be sent to your configured AI provider's API for analysis. Image data is transmitted directly to the provider and is subject to their privacy policy.")
-        }
     }
 
     // MARK: - Tab Content


### PR DESCRIPTION
### Why?

The "Enable AI Analysis?" confirmation dialog on first run is unnecessary friction — the user has already explicitly configured an API key in Settings, which is a clear enough signal of intent. The extra confirmation step just slows things down.

### How?

Removed the one-time consent gate and its supporting machinery from both the iOS `AnalysisCoordinator` and the Mac `ImportService`. Analysis now runs immediately when triggered, as long as an API key is configured.

<sub>Generated with Claude Code</sub>