### PR TITLE
Harden API key storage and encryption across Mac and iOS

### DIFF
--- a/SnapGrid/SnapGrid/Resources/SnapGrid.entitlements
+++ b/SnapGrid/SnapGrid/Resources/SnapGrid.entitlements
@@ -2,15 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.network.client</key>
-	<true/>
-	<key>com.apple.security.files.user-selected.read-write</key>
-	<true/>
 	<key>com.apple.developer.ubiquity-container-identifiers</key>
 	<array>
 		<string>iCloud.com.SnapGrid</string>
+	</array>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(TeamIdentifierPrefix)com.snapgrid.shared</string>
 	</array>
 </dict>
 </plist>

--- a/SnapGrid/SnapGrid/Services/AIAnalysisService.swift
+++ b/SnapGrid/SnapGrid/Services/AIAnalysisService.swift
@@ -227,8 +227,8 @@ final class AIAnalysisService: Sendable {
             )
         case .gemini:
             return ProviderRequest(
-                url: URL(string: "https://generativelanguage.googleapis.com/v1beta/models/\(model):generateContent?key=\(apiKey)")!,
-                headers: [:],
+                url: URL(string: "https://generativelanguage.googleapis.com/v1beta/models/\(model):generateContent")!,
+                headers: ["x-goog-api-key": apiKey],
                 body: [
                     "contents": [
                         ["parts": [

--- a/SnapGrid/SnapGrid/Services/KeySyncCrypto.swift
+++ b/SnapGrid/SnapGrid/Services/KeySyncCrypto.swift
@@ -1,5 +1,9 @@
 import Foundation
 import CryptoKit
+import Security
+import os
+
+private let logger = Logger(subsystem: "com.snapgrid", category: "KeySyncCrypto")
 
 // MARK: - Encrypted envelope persisted to iCloud
 
@@ -18,31 +22,15 @@ struct KeySyncPayload: Codable {
     let updatedAt: Date
 }
 
-// MARK: - Encryption / decryption using a compiled-in key
+// MARK: - Encryption / decryption
 
 enum KeySyncCrypto {
 
-    // Derived AES-256 symmetric key — split into fragments and combined
-    // via HKDF so no single literal exposes the full secret.
-    nonisolated(unsafe) private static let symmetricKey: SymmetricKey = {
-        let a: [UInt8] = [0x4A, 0x91, 0xD3, 0x17, 0xBB, 0x6E, 0xF0, 0x82]
-        let b: [UInt8] = [0xC5, 0x3A, 0x08, 0x7D, 0xE4, 0x59, 0x1F, 0xA6]
-        let c: [UInt8] = [0x72, 0xDE, 0x45, 0x9B, 0x03, 0xF8, 0x61, 0xCC]
-        let d: [UInt8] = [0x8F, 0x24, 0xB7, 0x53, 0xEA, 0x10, 0x96, 0x4D]
-        let ikm = Data(a + b + c + d)
-        let info = Data("com.snapgrid.keysync.v1".utf8)
-        let derived = HKDF<SHA256>.deriveKey(
-            inputKeyMaterial: SymmetricKey(data: ikm),
-            info: info,
-            outputByteCount: 32
-        )
-        return derived
-    }()
-
     static func encrypt(_ payload: Data) throws -> Data {
-        let sealed = try AES.GCM.seal(payload, using: symmetricKey)
+        let key = try userKey()
+        let sealed = try AES.GCM.seal(payload, using: key)
         let envelope = EncryptedEnvelope(
-            version: 1,
+            version: 2,
             nonce: Data(sealed.nonce).base64EncodedString(),
             ciphertext: sealed.ciphertext.base64EncodedString() + ":" +
                 sealed.tag.base64EncodedString()
@@ -54,7 +42,14 @@ enum KeySyncCrypto {
 
     static func decrypt(_ data: Data) throws -> Data {
         let envelope = try JSONDecoder().decode(EncryptedEnvelope.self, from: data)
-        guard envelope.version == 1 else {
+
+        let key: SymmetricKey
+        switch envelope.version {
+        case 1:
+            key = legacyKey
+        case 2:
+            key = try userKey()
+        default:
             throw KeySyncError.unsupportedVersion
         }
 
@@ -75,17 +70,171 @@ enum KeySyncCrypto {
             ciphertext: ciphertextData,
             tag: tagData
         )
-        return try AES.GCM.open(sealedBox, using: symmetricKey)
+        return try AES.GCM.open(sealedBox, using: key)
+    }
+
+    // MARK: - Per-user key (stored in iCloud Keychain)
+
+    private static func userKey() throws -> SymmetricKey {
+        if let existing = loadKeyFromKeychain() {
+            return deriveKey(from: existing)
+        }
+
+        let newKey = SymmetricKey(size: .bits256)
+        let keyData = newKey.withUnsafeBytes { Data($0) }
+
+        if storeKeyInKeychain(keyData, synchronizable: true) {
+            return deriveKey(from: keyData)
+        }
+
+        if storeKeyInKeychain(keyData, synchronizable: false) {
+            logger.warning("Stored encryption key locally only (iCloud Keychain unavailable)")
+            return deriveKey(from: keyData)
+        }
+
+        throw KeySyncError.keychainUnavailable
+    }
+
+    private static func deriveKey(from ikm: Data) -> SymmetricKey {
+        let info = Data("com.snapgrid.keysync.v2".utf8)
+        return HKDF<SHA256>.deriveKey(
+            inputKeyMaterial: SymmetricKey(data: ikm),
+            info: info,
+            outputByteCount: 32
+        )
+    }
+
+    private static func loadKeyFromKeychain() -> Data? {
+        let syncQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "com.snapgrid.keysync",
+            kSecAttrAccount as String: "encryption-key-v2",
+            kSecAttrSynchronizable as String: true,
+            kSecReturnData as String: true
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(syncQuery as CFDictionary, &result)
+
+        if status == errSecSuccess, let data = result as? Data, data.count == 32 {
+            return data
+        }
+
+        let localQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "com.snapgrid.keysync",
+            kSecAttrAccount as String: "encryption-key-v2",
+            kSecAttrSynchronizable as String: false,
+            kSecReturnData as String: true
+        ]
+
+        var localResult: AnyObject?
+        let localStatus = SecItemCopyMatching(localQuery as CFDictionary, &localResult)
+
+        if localStatus == errSecSuccess, let data = localResult as? Data, data.count == 32 {
+            return data
+        }
+
+        return nil
+    }
+
+    private static func storeKeyInKeychain(_ keyData: Data, synchronizable: Bool) -> Bool {
+        let deleteSync: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "com.snapgrid.keysync",
+            kSecAttrAccount as String: "encryption-key-v2",
+            kSecAttrSynchronizable as String: true
+        ]
+        SecItemDelete(deleteSync as CFDictionary)
+
+        let deleteLocal: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "com.snapgrid.keysync",
+            kSecAttrAccount as String: "encryption-key-v2",
+            kSecAttrSynchronizable as String: false
+        ]
+        SecItemDelete(deleteLocal as CFDictionary)
+
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "com.snapgrid.keysync",
+            kSecAttrAccount as String: "encryption-key-v2",
+            kSecValueData as String: keyData,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+            kSecAttrSynchronizable as String: synchronizable
+        ]
+
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+
+    // MARK: - Legacy key (v1 — hardcoded, kept for migration only)
+
+    nonisolated(unsafe) private static let legacyKey: SymmetricKey = {
+        let a: [UInt8] = [0x4A, 0x91, 0xD3, 0x17, 0xBB, 0x6E, 0xF0, 0x82]
+        let b: [UInt8] = [0xC5, 0x3A, 0x08, 0x7D, 0xE4, 0x59, 0x1F, 0xA6]
+        let c: [UInt8] = [0x72, 0xDE, 0x45, 0x9B, 0x03, 0xF8, 0x61, 0xCC]
+        let d: [UInt8] = [0x8F, 0x24, 0xB7, 0x53, 0xEA, 0x10, 0x96, 0x4D]
+        let ikm = Data(a + b + c + d)
+        let info = Data("com.snapgrid.keysync.v1".utf8)
+        return HKDF<SHA256>.deriveKey(
+            inputKeyMaterial: SymmetricKey(data: ikm),
+            info: info,
+            outputByteCount: 32
+        )
+    }()
+
+    // MARK: - Test support
+
+    static func encrypt(_ payload: Data, using key: SymmetricKey) throws -> Data {
+        let sealed = try AES.GCM.seal(payload, using: key)
+        let envelope = EncryptedEnvelope(
+            version: 2,
+            nonce: Data(sealed.nonce).base64EncodedString(),
+            ciphertext: sealed.ciphertext.base64EncodedString() + ":" +
+                sealed.tag.base64EncodedString()
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        return try encoder.encode(envelope)
+    }
+
+    static func decrypt(_ data: Data, using key: SymmetricKey) throws -> Data {
+        let envelope = try JSONDecoder().decode(EncryptedEnvelope.self, from: data)
+        guard envelope.version == 1 || envelope.version == 2 else {
+            throw KeySyncError.unsupportedVersion
+        }
+
+        guard let nonceData = Data(base64Encoded: envelope.nonce) else {
+            throw KeySyncError.corruptedData
+        }
+
+        let parts = envelope.ciphertext.split(separator: ":")
+        guard parts.count == 2,
+              let ciphertextData = Data(base64Encoded: String(parts[0])),
+              let tagData = Data(base64Encoded: String(parts[1])) else {
+            throw KeySyncError.corruptedData
+        }
+
+        let nonce = try AES.GCM.Nonce(data: nonceData)
+        let sealedBox = try AES.GCM.SealedBox(
+            nonce: nonce,
+            ciphertext: ciphertextData,
+            tag: tagData
+        )
+        return try AES.GCM.open(sealedBox, using: key)
     }
 
     enum KeySyncError: LocalizedError {
         case unsupportedVersion
         case corruptedData
+        case keychainUnavailable
 
         var errorDescription: String? {
             switch self {
             case .unsupportedVersion: return "Unsupported key sync format version"
             case .corruptedData: return "Key sync data is corrupted"
+            case .keychainUnavailable: return "Cannot access Keychain for encryption key storage"
             }
         }
     }

--- a/SnapGrid/SnapGrid/Services/KeySyncService.swift
+++ b/SnapGrid/SnapGrid/Services/KeySyncService.swift
@@ -1,4 +1,7 @@
 import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.snapgrid", category: "KeySync")
 
 enum KeySyncService {
 
@@ -37,9 +40,9 @@ enum KeySyncService {
             let encrypted = try KeySyncCrypto.encrypt(plaintext)
             try encrypted.write(to: url, options: .atomic)
             UserDefaults.standard.set(Date.now.timeIntervalSince1970, forKey: lastImportedAtKey)
-            print("[KeySync] Wrote encrypted keys to iCloud")
+            logger.info("Wrote encrypted keys to iCloud")
         } catch {
-            print("[KeySync] Failed to sync: \(error.localizedDescription)")
+            logger.error("Failed to sync: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -62,7 +65,7 @@ enum KeySyncService {
             let payloadTimestamp = payload.updatedAt.timeIntervalSince1970
 
             guard payloadTimestamp > lastImported else {
-                print("[KeySync] iCloud file not newer than last import, skipping")
+                logger.info("iCloud file not newer than last import, skipping")
                 return
             }
 
@@ -72,7 +75,7 @@ enum KeySyncService {
                 }
                 UserDefaults.standard.set(payloadTimestamp, forKey: lastImportedAtKey)
                 NotificationCenter.default.post(name: .apiKeySaved, object: nil)
-                print("[KeySync] Imported key removal from iCloud")
+                logger.info("Imported key removal from iCloud")
                 return
             }
 
@@ -87,9 +90,9 @@ enum KeySyncService {
             UserDefaults.standard.set(payloadTimestamp, forKey: lastImportedAtKey)
 
             NotificationCenter.default.post(name: .apiKeySaved, object: nil)
-            print("[KeySync] Imported keys from iCloud — provider: \(payload.provider)")
+            logger.info("Imported keys from iCloud — provider: \(payload.provider, privacy: .private)")
         } catch {
-            print("[KeySync] Failed to read from iCloud: \(error.localizedDescription)")
+            logger.error("Failed to read from iCloud: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -99,6 +102,6 @@ enum KeySyncService {
         guard MediaStorageService.shared.isUsingiCloud else { return }
         let url = MediaStorageService.shared.baseURL.appendingPathComponent(fileName)
         try? FileManager.default.removeItem(at: url)
-        print("[KeySync] Removed encrypted keys from iCloud")
+        logger.info("Removed encrypted keys from iCloud")
     }
 }

--- a/SnapGrid/SnapGrid/Services/KeychainService.swift
+++ b/SnapGrid/SnapGrid/Services/KeychainService.swift
@@ -1,64 +1,197 @@
 import Foundation
+import Security
+import os
+
+private let logger = Logger(subsystem: "com.snapgrid", category: "Keychain")
 
 enum KeychainService {
 
-    /// Stores API keys in a JSON file inside Application Support.
-    /// Avoids macOS Keychain password prompts that occur with
-    /// "Sign to Run Locally" code signing.
-    private static let storageURL: URL = {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        let dir = appSupport.appendingPathComponent("SnapGrid", isDirectory: true)
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return dir.appendingPathComponent(".keys.json")
-    }()
+    private static let serviceName = "com.snapgrid.apikeys"
 
     nonisolated(unsafe) private static var cache: [String: String]?
     nonisolated(unsafe) private static let lock = NSLock()
 
-    private static func loadStore() -> [String: String] {
-        lock.lock()
-        defer { lock.unlock() }
+    private static let legacyStorageURL: URL = {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let dir = appSupport.appendingPathComponent("SnapGrid", isDirectory: true)
+        return dir.appendingPathComponent(".keys.json")
+    }()
 
-        if let cache { return cache }
-
-        guard let data = try? Data(contentsOf: storageURL),
-              let dict = try? JSONDecoder().decode([String: String].self, from: data) else {
-            cache = [:]
-            return [:]
-        }
-        cache = dict
-        return dict
-    }
-
-    private static func saveStore(_ store: [String: String]) {
-        lock.lock()
-        cache = store
-        lock.unlock()
-
-        if let data = try? JSONEncoder().encode(store) {
-            try? data.write(to: storageURL, options: .atomic)
-            // Restrict file permissions to owner only
-            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: storageURL.path)
-        }
-    }
+    // MARK: - Public API
 
     static func set(key: String, forService service: String) throws {
-        var store = loadStore()
-        store[service] = key
-        saveStore(store)
+        migrateIfNeeded()
+
+        lock.lock()
+        if cache == nil { cache = [:] }
+        cache?[service] = key
+        lock.unlock()
+
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: service
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: service,
+            kSecValueData as String: Data(key.utf8),
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked
+        ]
+
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        if status != errSecSuccess {
+            logger.error("Keychain write failed for \(service, privacy: .public): \(status)")
+            fallbackSet(key: key, forService: service)
+        }
     }
 
     static func get(service: String) throws -> String? {
-        loadStore()[service]
+        migrateIfNeeded()
+
+        lock.lock()
+        if let cached = cache?[service] {
+            lock.unlock()
+            return cached
+        }
+        lock.unlock()
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: service,
+            kSecReturnData as String: true
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        if status == errSecSuccess, let data = result as? Data, let value = String(data: data, encoding: .utf8) {
+            lock.lock()
+            if cache == nil { cache = [:] }
+            cache?[service] = value
+            lock.unlock()
+            return value
+        }
+
+        if status != errSecItemNotFound {
+            logger.error("Keychain read failed for \(service, privacy: .public): \(status)")
+        }
+
+        return fallbackGet(service: service)
     }
 
     static func delete(service: String) throws {
-        var store = loadStore()
-        store.removeValue(forKey: service)
-        saveStore(store)
+        lock.lock()
+        cache?.removeValue(forKey: service)
+        lock.unlock()
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: service
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            logger.error("Keychain delete failed for \(service, privacy: .public): \(status)")
+        }
+
+        fallbackDelete(service: service)
     }
 
     static func exists(service: String) -> Bool {
-        loadStore()[service] != nil
+        (try? get(service: service)) != nil
+    }
+
+    // MARK: - Migration from legacy .keys.json
+
+    nonisolated(unsafe) private static var migrationDone = false
+
+    private static func migrateIfNeeded() {
+        guard !migrationDone else { return }
+        migrationDone = true
+
+        if UserDefaults.standard.bool(forKey: "keychainMigrationComplete_v1") { return }
+
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: legacyStorageURL.path),
+              let data = try? Data(contentsOf: legacyStorageURL),
+              let dict = try? JSONDecoder().decode([String: String].self, from: data) else {
+            UserDefaults.standard.set(true, forKey: "keychainMigrationComplete_v1")
+            return
+        }
+
+        logger.info("Migrating \(dict.count) keys from .keys.json to Keychain")
+
+        var allSucceeded = true
+        for (service, key) in dict {
+            let addQuery: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: serviceName,
+                kSecAttrAccount as String: service,
+                kSecValueData as String: Data(key.utf8),
+                kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked
+            ]
+            SecItemDelete([
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: serviceName,
+                kSecAttrAccount as String: service
+            ] as CFDictionary)
+            let status = SecItemAdd(addQuery as CFDictionary, nil)
+            if status != errSecSuccess {
+                logger.error("Migration failed for \(service, privacy: .public): \(status)")
+                allSucceeded = false
+            }
+
+            lock.lock()
+            if cache == nil { cache = [:] }
+            cache?[service] = key
+            lock.unlock()
+        }
+
+        if allSucceeded {
+            try? fm.removeItem(at: legacyStorageURL)
+        }
+        UserDefaults.standard.set(true, forKey: "keychainMigrationComplete_v1")
+    }
+
+    // MARK: - File-based fallback for unsigned dev builds
+
+    private static func fallbackGet(service: String) -> String? {
+        guard let data = try? Data(contentsOf: legacyStorageURL),
+              let dict = try? JSONDecoder().decode([String: String].self, from: data) else {
+            return nil
+        }
+        return dict[service]
+    }
+
+    private static func fallbackSet(key: String, forService service: String) {
+        var dict: [String: String] = [:]
+        if let data = try? Data(contentsOf: legacyStorageURL),
+           let existing = try? JSONDecoder().decode([String: String].self, from: data) {
+            dict = existing
+        }
+        dict[service] = key
+
+        let dir = legacyStorageURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        if let data = try? JSONEncoder().encode(dict) {
+            try? data.write(to: legacyStorageURL, options: .atomic)
+            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: legacyStorageURL.path)
+        }
+    }
+
+    private static func fallbackDelete(service: String) {
+        guard let data = try? Data(contentsOf: legacyStorageURL),
+              var dict = try? JSONDecoder().decode([String: String].self, from: data) else { return }
+        dict.removeValue(forKey: service)
+        if let data = try? JSONEncoder().encode(dict) {
+            try? data.write(to: legacyStorageURL, options: .atomic)
+        }
     }
 }

--- a/SnapGrid/SnapGrid/Services/ModelDiscoveryService.swift
+++ b/SnapGrid/SnapGrid/Services/ModelDiscoveryService.swift
@@ -209,8 +209,9 @@ final class ModelDiscoveryService: @unchecked Sendable {
     }
 
     private func fetchGeminiModels(apiKey: String) async throws -> [DiscoveredModel] {
-        let url = URL(string: "https://generativelanguage.googleapis.com/v1beta/models?key=\(apiKey)")!
-        let request = URLRequest(url: url)
+        let url = URL(string: "https://generativelanguage.googleapis.com/v1beta/models")!
+        var request = URLRequest(url: url)
+        request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
 
         let (data, response) = try await URLSession.shared.data(for: request)
         try validateHTTP(response, data: data)

--- a/SnapGrid/SnapGridTests/KeySyncCryptoTests.swift
+++ b/SnapGrid/SnapGridTests/KeySyncCryptoTests.swift
@@ -1,34 +1,34 @@
 import Testing
 import Foundation
+import CryptoKit
 @testable import SnapGrid
 
 @Suite("KeySyncCrypto", .tags(.crypto))
 struct KeySyncCryptoTests {
 
+    private let testKey = SymmetricKey(size: .bits256)
+
     @Test("Encrypt then decrypt returns original data")
     func encryptDecryptRoundtrip() throws {
         let original = Data("hello world".utf8)
-        let encrypted = try KeySyncCrypto.encrypt(original)
-        let decrypted = try KeySyncCrypto.decrypt(encrypted)
+        let encrypted = try KeySyncCrypto.encrypt(original, using: testKey)
+        let decrypted = try KeySyncCrypto.decrypt(encrypted, using: testKey)
         #expect(decrypted == original)
     }
 
     @Test("Empty payload encryption produces valid envelope")
     func emptyPayloadEncrypts() throws {
-        // AES-GCM with empty plaintext produces empty ciphertext,
-        // which the current decrypt can't handle (split on ":" drops empty part).
-        // Verify encryption succeeds and produces valid JSON envelope.
-        let encrypted = try KeySyncCrypto.encrypt(Data())
+        let encrypted = try KeySyncCrypto.encrypt(Data(), using: testKey)
         let envelope = try JSONDecoder().decode(EncryptedEnvelope.self, from: encrypted)
-        #expect(envelope.version == 1)
+        #expect(envelope.version == 2)
         #expect(!envelope.nonce.isEmpty)
     }
 
     @Test("Large payload roundtrip")
     func largePayloadRoundtrip() throws {
         let original = Data(repeating: 0xAB, count: 100_000)
-        let encrypted = try KeySyncCrypto.encrypt(original)
-        let decrypted = try KeySyncCrypto.decrypt(encrypted)
+        let encrypted = try KeySyncCrypto.encrypt(original, using: testKey)
+        let decrypted = try KeySyncCrypto.decrypt(encrypted, using: testKey)
         #expect(decrypted == original)
     }
 
@@ -37,12 +37,12 @@ struct KeySyncCryptoTests {
         let payload = KeySyncPayload(
             provider: "openai",
             model: "gpt-4o",
-            keys: ["openai": "sk-test123", "anthropic": "sk-ant-test"],
+            keys: ["openai": "test-key-openai", "anthropic": "test-key-anthropic"],
             updatedAt: Date(timeIntervalSince1970: 1700000000)
         )
         let encoded = try JSONEncoder().encode(payload)
-        let encrypted = try KeySyncCrypto.encrypt(encoded)
-        let decrypted = try KeySyncCrypto.decrypt(encrypted)
+        let encrypted = try KeySyncCrypto.encrypt(encoded, using: testKey)
+        let decrypted = try KeySyncCrypto.decrypt(encrypted, using: testKey)
         let decoded = try JSONDecoder().decode(KeySyncPayload.self, from: decrypted)
         #expect(decoded.provider == payload.provider)
         #expect(decoded.model == payload.model)
@@ -53,41 +53,39 @@ struct KeySyncCryptoTests {
     func corruptedDataThrows() {
         let garbage = Data("not valid json at all".utf8)
         #expect(throws: (any Error).self) {
-            try KeySyncCrypto.decrypt(garbage)
+            try KeySyncCrypto.decrypt(garbage, using: testKey)
         }
     }
 
     @Test("Decrypt envelope with unsupported version throws")
     func unsupportedVersionThrows() throws {
-        // Build a valid-looking envelope but with version 2
-        let envelope = EncryptedEnvelope(version: 2, nonce: "AAAA", ciphertext: "BBBB:CCCC")
+        let envelope = EncryptedEnvelope(version: 99, nonce: "AAAA", ciphertext: "BBBB:CCCC")
         let data = try JSONEncoder().encode(envelope)
         #expect(throws: KeySyncCrypto.KeySyncError.self) {
-            try KeySyncCrypto.decrypt(data)
+            try KeySyncCrypto.decrypt(data, using: testKey)
         }
     }
 
     @Test("Each encryption produces different ciphertext")
     func encryptionIsNondeterministic() throws {
         let original = Data("same input".utf8)
-        let encrypted1 = try KeySyncCrypto.encrypt(original)
-        let encrypted2 = try KeySyncCrypto.encrypt(original)
-        // AES-GCM uses random nonces, so ciphertext should differ
+        let encrypted1 = try KeySyncCrypto.encrypt(original, using: testKey)
+        let encrypted2 = try KeySyncCrypto.encrypt(original, using: testKey)
         #expect(encrypted1 != encrypted2)
     }
 
     // MARK: - EncryptedEnvelope structure (cross-device contract)
 
-    @Test("Encrypted envelope has version 1")
+    @Test("Encrypted envelope has version 2")
     func envelopeVersion() throws {
-        let encrypted = try KeySyncCrypto.encrypt(Data("test".utf8))
+        let encrypted = try KeySyncCrypto.encrypt(Data("test".utf8), using: testKey)
         let envelope = try JSONDecoder().decode(EncryptedEnvelope.self, from: encrypted)
-        #expect(envelope.version == 1)
+        #expect(envelope.version == 2)
     }
 
     @Test("Encrypted envelope ciphertext contains colon separator")
     func envelopeCiphertextFormat() throws {
-        let encrypted = try KeySyncCrypto.encrypt(Data("test".utf8))
+        let encrypted = try KeySyncCrypto.encrypt(Data("test".utf8), using: testKey)
         let envelope = try JSONDecoder().decode(EncryptedEnvelope.self, from: encrypted)
         #expect(envelope.ciphertext.contains(":"))
         let parts = envelope.ciphertext.split(separator: ":")
@@ -96,8 +94,18 @@ struct KeySyncCryptoTests {
 
     @Test("Encrypted envelope nonce is valid base64")
     func envelopeNonceBase64() throws {
-        let encrypted = try KeySyncCrypto.encrypt(Data("test".utf8))
+        let encrypted = try KeySyncCrypto.encrypt(Data("test".utf8), using: testKey)
         let envelope = try JSONDecoder().decode(EncryptedEnvelope.self, from: encrypted)
         #expect(Data(base64Encoded: envelope.nonce) != nil)
+    }
+
+    @Test("Wrong key fails to decrypt")
+    func wrongKeyFailsDecrypt() throws {
+        let original = Data("secret data".utf8)
+        let encrypted = try KeySyncCrypto.encrypt(original, using: testKey)
+        let wrongKey = SymmetricKey(size: .bits256)
+        #expect(throws: (any Error).self) {
+            try KeySyncCrypto.decrypt(encrypted, using: wrongKey)
+        }
     }
 }

--- a/SnapGrid/project.yml
+++ b/SnapGrid/project.yml
@@ -57,6 +57,8 @@ targets:
         com.apple.security.files.user-selected.read-write: true
         com.apple.developer.ubiquity-container-identifiers:
           - iCloud.com.SnapGrid
+        keychain-access-groups:
+          - $(TeamIdentifierPrefix)com.snapgrid.shared
 
   SnapGridTests:
     type: bundle.unit-test

--- a/ios/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
+++ b/ios/SnapGrid/SnapGrid.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		A100000033 /* MediaDeleteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000033 /* MediaDeleteService.swift */; };
 		A100000036 /* KeySyncCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000036 /* KeySyncCrypto.swift */; };
 		A100000037 /* KeySyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000037 /* KeySyncService.swift */; };
+		KC00000002 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = KC00000001 /* KeychainService.swift */; };
 		A100000038 /* AIAnalysisService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000038 /* AIAnalysisService.swift */; };
 		A100000040 /* ActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000040 /* ActivityView.swift */; };
 		C325B2DE9C4EBB590CE9AA5B /* MediaItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BC6070D4921036591CAB048 /* MediaItemTests.swift */; };
@@ -150,6 +151,7 @@
 		B100000033 /* MediaDeleteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDeleteService.swift; sourceTree = "<group>"; };
 		B100000036 /* KeySyncCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeySyncCrypto.swift; sourceTree = "<group>"; };
 		B100000037 /* KeySyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeySyncService.swift; sourceTree = "<group>"; };
+		KC00000001 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		B100000038 /* AIAnalysisService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIAnalysisService.swift; sourceTree = "<group>"; };
 		B100000040 /* ActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityView.swift; sourceTree = "<group>"; };
 		B100000041 /* ModelContext+SaveOrLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ModelContext+SaveOrLog.swift"; sourceTree = "<group>"; };
@@ -342,6 +344,7 @@
 				B100000033 /* MediaDeleteService.swift */,
 				B100000036 /* KeySyncCrypto.swift */,
 				B100000037 /* KeySyncService.swift */,
+				KC00000001 /* KeychainService.swift */,
 				B100000038 /* AIAnalysisService.swift */,
 				B100000043 /* AnalysisCoordinator.swift */,
 				B100000044 /* SidecarWriteService.swift */,
@@ -628,6 +631,7 @@
 				A100000033 /* MediaDeleteService.swift in Sources */,
 				A100000036 /* KeySyncCrypto.swift in Sources */,
 				A100000037 /* KeySyncService.swift in Sources */,
+				KC00000002 /* KeychainService.swift in Sources */,
 				A100000038 /* AIAnalysisService.swift in Sources */,
 				A100000040 /* ActivityView.swift in Sources */,
 				A100000041 /* ModelContext+SaveOrLog.swift in Sources */,

--- a/ios/SnapGrid/SnapGrid/Resources/SnapGrid.entitlements
+++ b/ios/SnapGrid/SnapGrid/Resources/SnapGrid.entitlements
@@ -10,5 +10,9 @@
 	<array>
 		<string>group.com.snapgrid</string>
 	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(TeamIdentifierPrefix)com.snapgrid.shared</string>
+	</array>
 </dict>
 </plist>

--- a/ios/SnapGrid/SnapGrid/Services/AIAnalysisService.swift
+++ b/ios/SnapGrid/SnapGrid/Services/AIAnalysisService.swift
@@ -215,8 +215,8 @@ final class AIAnalysisService: Sendable {
             )
         case .gemini:
             return ProviderRequest(
-                url: URL(string: "https://generativelanguage.googleapis.com/v1beta/models/\(model):generateContent?key=\(apiKey)")!,
-                headers: [:],
+                url: URL(string: "https://generativelanguage.googleapis.com/v1beta/models/\(model):generateContent")!,
+                headers: ["x-goog-api-key": apiKey],
                 body: [
                     "contents": [
                         ["parts": [

--- a/ios/SnapGrid/SnapGrid/Services/KeySyncCrypto.swift
+++ b/ios/SnapGrid/SnapGrid/Services/KeySyncCrypto.swift
@@ -1,5 +1,9 @@
 import Foundation
 import CryptoKit
+import Security
+import os
+
+private let logger = Logger(subsystem: "com.snapgrid.ios", category: "KeySyncCrypto")
 
 // MARK: - Encrypted envelope persisted to iCloud
 
@@ -18,31 +22,15 @@ struct KeySyncPayload: Codable {
     let updatedAt: Date
 }
 
-// MARK: - Encryption / decryption using a compiled-in key
+// MARK: - Encryption / decryption
 
 enum KeySyncCrypto {
 
-    // Derived AES-256 symmetric key — split into fragments and combined
-    // via HKDF so no single literal exposes the full secret.
-    private static let symmetricKey: SymmetricKey = {
-        let a: [UInt8] = [0x4A, 0x91, 0xD3, 0x17, 0xBB, 0x6E, 0xF0, 0x82]
-        let b: [UInt8] = [0xC5, 0x3A, 0x08, 0x7D, 0xE4, 0x59, 0x1F, 0xA6]
-        let c: [UInt8] = [0x72, 0xDE, 0x45, 0x9B, 0x03, 0xF8, 0x61, 0xCC]
-        let d: [UInt8] = [0x8F, 0x24, 0xB7, 0x53, 0xEA, 0x10, 0x96, 0x4D]
-        let ikm = Data(a + b + c + d)
-        let info = Data("com.snapgrid.keysync.v1".utf8)
-        let derived = HKDF<SHA256>.deriveKey(
-            inputKeyMaterial: SymmetricKey(data: ikm),
-            info: info,
-            outputByteCount: 32
-        )
-        return derived
-    }()
-
     static func encrypt(_ payload: Data) throws -> Data {
-        let sealed = try AES.GCM.seal(payload, using: symmetricKey)
+        let key = try userKey()
+        let sealed = try AES.GCM.seal(payload, using: key)
         let envelope = EncryptedEnvelope(
-            version: 1,
+            version: 2,
             nonce: Data(sealed.nonce).base64EncodedString(),
             ciphertext: sealed.ciphertext.base64EncodedString() + ":" +
                 sealed.tag.base64EncodedString()
@@ -54,7 +42,14 @@ enum KeySyncCrypto {
 
     static func decrypt(_ data: Data) throws -> Data {
         let envelope = try JSONDecoder().decode(EncryptedEnvelope.self, from: data)
-        guard envelope.version == 1 else {
+
+        let key: SymmetricKey
+        switch envelope.version {
+        case 1:
+            key = legacyKey
+        case 2:
+            key = try userKey()
+        default:
             throw KeySyncError.unsupportedVersion
         }
 
@@ -75,17 +70,175 @@ enum KeySyncCrypto {
             ciphertext: ciphertextData,
             tag: tagData
         )
-        return try AES.GCM.open(sealedBox, using: symmetricKey)
+        return try AES.GCM.open(sealedBox, using: key)
+    }
+
+    // MARK: - Per-user key (stored in iCloud Keychain)
+
+    private static func userKey() throws -> SymmetricKey {
+        if let existing = loadKeyFromKeychain() {
+            return deriveKey(from: existing)
+        }
+
+        let newKey = SymmetricKey(size: .bits256)
+        let keyData = newKey.withUnsafeBytes { Data($0) }
+
+        if storeKeyInKeychain(keyData, synchronizable: true) {
+            return deriveKey(from: keyData)
+        }
+
+        if storeKeyInKeychain(keyData, synchronizable: false) {
+            logger.warning("Stored encryption key locally only (iCloud Keychain unavailable)")
+            return deriveKey(from: keyData)
+        }
+
+        throw KeySyncError.keychainUnavailable
+    }
+
+    private static func deriveKey(from ikm: Data) -> SymmetricKey {
+        let info = Data("com.snapgrid.keysync.v2".utf8)
+        return HKDF<SHA256>.deriveKey(
+            inputKeyMaterial: SymmetricKey(data: ikm),
+            info: info,
+            outputByteCount: 32
+        )
+    }
+
+    private static func loadKeyFromKeychain() -> Data? {
+        let syncQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "com.snapgrid.keysync",
+            kSecAttrAccount as String: "encryption-key-v2",
+            kSecAttrSynchronizable as String: true,
+            kSecReturnData as String: true
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(syncQuery as CFDictionary, &result)
+
+        if status == errSecSuccess, let data = result as? Data, data.count == 32 {
+            return data
+        }
+
+        let localQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "com.snapgrid.keysync",
+            kSecAttrAccount as String: "encryption-key-v2",
+            kSecAttrSynchronizable as String: false,
+            kSecReturnData as String: true
+        ]
+
+        var localResult: AnyObject?
+        let localStatus = SecItemCopyMatching(localQuery as CFDictionary, &localResult)
+
+        if localStatus == errSecSuccess, let data = localResult as? Data, data.count == 32 {
+            return data
+        }
+
+        return nil
+    }
+
+    private static func storeKeyInKeychain(_ keyData: Data, synchronizable: Bool) -> Bool {
+        let deleteSync: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "com.snapgrid.keysync",
+            kSecAttrAccount as String: "encryption-key-v2",
+            kSecAttrSynchronizable as String: true
+        ]
+        SecItemDelete(deleteSync as CFDictionary)
+
+        let deleteLocal: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "com.snapgrid.keysync",
+            kSecAttrAccount as String: "encryption-key-v2",
+            kSecAttrSynchronizable as String: false
+        ]
+        SecItemDelete(deleteLocal as CFDictionary)
+
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "com.snapgrid.keysync",
+            kSecAttrAccount as String: "encryption-key-v2",
+            kSecValueData as String: keyData,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+            kSecAttrSynchronizable as String: synchronizable
+        ]
+
+        if !synchronizable {
+            query[kSecAttrAccessGroup as String] = "group.com.snapgrid"
+        }
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+
+    // MARK: - Legacy key (v1 — hardcoded, kept for migration only)
+
+    private static let legacyKey: SymmetricKey = {
+        let a: [UInt8] = [0x4A, 0x91, 0xD3, 0x17, 0xBB, 0x6E, 0xF0, 0x82]
+        let b: [UInt8] = [0xC5, 0x3A, 0x08, 0x7D, 0xE4, 0x59, 0x1F, 0xA6]
+        let c: [UInt8] = [0x72, 0xDE, 0x45, 0x9B, 0x03, 0xF8, 0x61, 0xCC]
+        let d: [UInt8] = [0x8F, 0x24, 0xB7, 0x53, 0xEA, 0x10, 0x96, 0x4D]
+        let ikm = Data(a + b + c + d)
+        let info = Data("com.snapgrid.keysync.v1".utf8)
+        return HKDF<SHA256>.deriveKey(
+            inputKeyMaterial: SymmetricKey(data: ikm),
+            info: info,
+            outputByteCount: 32
+        )
+    }()
+
+    // MARK: - Test support
+
+    static func encrypt(_ payload: Data, using key: SymmetricKey) throws -> Data {
+        let sealed = try AES.GCM.seal(payload, using: key)
+        let envelope = EncryptedEnvelope(
+            version: 2,
+            nonce: Data(sealed.nonce).base64EncodedString(),
+            ciphertext: sealed.ciphertext.base64EncodedString() + ":" +
+                sealed.tag.base64EncodedString()
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        return try encoder.encode(envelope)
+    }
+
+    static func decrypt(_ data: Data, using key: SymmetricKey) throws -> Data {
+        let envelope = try JSONDecoder().decode(EncryptedEnvelope.self, from: data)
+        guard envelope.version == 1 || envelope.version == 2 else {
+            throw KeySyncError.unsupportedVersion
+        }
+
+        guard let nonceData = Data(base64Encoded: envelope.nonce) else {
+            throw KeySyncError.corruptedData
+        }
+
+        let parts = envelope.ciphertext.split(separator: ":")
+        guard parts.count == 2,
+              let ciphertextData = Data(base64Encoded: String(parts[0])),
+              let tagData = Data(base64Encoded: String(parts[1])) else {
+            throw KeySyncError.corruptedData
+        }
+
+        let nonce = try AES.GCM.Nonce(data: nonceData)
+        let sealedBox = try AES.GCM.SealedBox(
+            nonce: nonce,
+            ciphertext: ciphertextData,
+            tag: tagData
+        )
+        return try AES.GCM.open(sealedBox, using: key)
     }
 
     enum KeySyncError: LocalizedError {
         case unsupportedVersion
         case corruptedData
+        case keychainUnavailable
 
         var errorDescription: String? {
             switch self {
             case .unsupportedVersion: return "Unsupported key sync format version"
             case .corruptedData: return "Key sync data is corrupted"
+            case .keychainUnavailable: return "Cannot access Keychain for encryption key storage"
             }
         }
     }

--- a/ios/SnapGrid/SnapGrid/Services/KeySyncService.swift
+++ b/ios/SnapGrid/SnapGrid/Services/KeySyncService.swift
@@ -1,4 +1,8 @@
 import Foundation
+import CryptoKit
+import os
+
+private let logger = Logger(subsystem: "com.snapgrid.ios", category: "KeySync")
 
 enum KeySource: String {
     case settingsBundle
@@ -25,19 +29,21 @@ final class KeySyncService: ObservableObject {
 
     func checkForKeys(rootURL: URL) {
         let defaults = UserDefaults.standard
-        let sbApiKey = (defaults.string(forKey: "settings_apiKey") ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let sbApiKey = readAndClearSettingsBundleKey(defaults: defaults)
         let sbProvider = defaults.string(forKey: "settings_provider") ?? "anthropic"
         let sbModel = (defaults.string(forKey: "settings_model") ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        let lastSyncedKey = defaults.string(forKey: "settings_lastSyncedApiKey") ?? ""
+        let lastSyncedHash = defaults.string(forKey: "settings_lastSyncedKeyHash") ?? ""
 
         let providerIsNone = sbProvider == "none"
         let settingsBundleHasKey = !sbApiKey.isEmpty && !providerIsNone
-        let settingsBundleChanged = settingsBundleHasKey && sbApiKey != lastSyncedKey
-        let settingsBundleCleared = providerIsNone && lastSyncedKey != ""
+        let currentHash = settingsBundleHasKey ? hashKey(sbApiKey) : ""
+        let settingsBundleChanged = settingsBundleHasKey && currentHash != lastSyncedHash
+        let settingsBundleCleared = providerIsNone && lastSyncedHash != ""
 
         if settingsBundleCleared {
-            defaults.set("", forKey: "settings_lastSyncedApiKey")
-            defaults.set("", forKey: "settings_apiKey")
+            defaults.set("", forKey: "settings_lastSyncedKeyHash")
+            clearKeychainKeys()
             if FileSystemManager.shared?.isUsingiCloud == true {
                 writeToiCloud(rootURL: rootURL, provider: "none", model: "", keys: [:])
             }
@@ -47,13 +53,14 @@ final class KeySyncService: ObservableObject {
 
         if settingsBundleChanged {
             guard AIProvider(rawValue: sbProvider) != nil else {
-                print("[KeySync] Settings.bundle has unknown provider: \(sbProvider)")
+                logger.warning("Settings.bundle has unknown provider: \(sbProvider, privacy: .public)")
                 applyNoKeys()
                 return
             }
 
+            saveKeyToKeychain(sbApiKey, provider: sbProvider)
             applyKeys(provider: sbProvider, model: sbModel.isEmpty ? nil : sbModel, keys: [sbProvider: sbApiKey], source: .settingsBundle)
-            defaults.set(sbApiKey, forKey: "settings_lastSyncedApiKey")
+            defaults.set(currentHash, forKey: "settings_lastSyncedKeyHash")
 
             if FileSystemManager.shared?.isUsingiCloud == true {
                 writeToiCloud(rootURL: rootURL, provider: sbProvider, model: sbModel, keys: [sbProvider: sbApiKey])
@@ -65,19 +72,22 @@ final class KeySyncService: ObservableObject {
             let iCloudActiveKey = payload.keys[payload.provider] ?? ""
 
             if payload.provider == "none" || iCloudActiveKey.isEmpty {
-                if lastSyncedKey != "" {
-                    defaults.set("", forKey: "settings_lastSyncedApiKey")
-                    defaults.set("", forKey: "settings_apiKey")
+                if lastSyncedHash != "" {
+                    defaults.set("", forKey: "settings_lastSyncedKeyHash")
                     defaults.set("none", forKey: "settings_provider")
+                    clearKeychainKeys()
                 }
                 applyNoKeys()
                 return
             }
 
-            if iCloudActiveKey != lastSyncedKey {
+            let iCloudHash = hashKey(iCloudActiveKey)
+            if iCloudHash != lastSyncedHash {
+                for (provider, key) in payload.keys {
+                    saveKeyToKeychain(key, provider: provider)
+                }
                 applyKeys(provider: payload.provider, model: payload.model, keys: payload.keys, source: .iCloudSync)
-                defaults.set(iCloudActiveKey, forKey: "settings_lastSyncedApiKey")
-                defaults.set(iCloudActiveKey, forKey: "settings_apiKey")
+                defaults.set(iCloudHash, forKey: "settings_lastSyncedKeyHash")
                 defaults.set(payload.provider, forKey: "settings_provider")
                 defaults.set(payload.model, forKey: "settings_model")
                 return
@@ -88,7 +98,15 @@ final class KeySyncService: ObservableObject {
         }
 
         if settingsBundleHasKey, AIProvider(rawValue: sbProvider) != nil {
-            applyKeys(provider: sbProvider, model: sbModel.isEmpty ? nil : sbModel, keys: [sbProvider: sbApiKey], source: .settingsBundle)
+            let keychainKey = try? KeychainService.get(service: sbProvider)
+            let effectiveKey = keychainKey ?? sbApiKey
+            if !effectiveKey.isEmpty {
+                applyKeys(provider: sbProvider, model: sbModel.isEmpty ? nil : sbModel, keys: [sbProvider: effectiveKey], source: .settingsBundle)
+                return
+            }
+        }
+
+        if let provider = loadKeysFromKeychain() {
             return
         }
 
@@ -97,15 +115,17 @@ final class KeySyncService: ObservableObject {
 
     func checkForSettingsKeys() {
         let defaults = UserDefaults.standard
-        let sbApiKey = (defaults.string(forKey: "settings_apiKey") ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let sbApiKey = readAndClearSettingsBundleKey(defaults: defaults)
         let sbProvider = defaults.string(forKey: "settings_provider") ?? "anthropic"
         let sbModel = (defaults.string(forKey: "settings_model") ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard !sbApiKey.isEmpty, sbProvider != "none", AIProvider(rawValue: sbProvider) != nil else {
+            if loadKeysFromKeychain() != nil { return }
             applyNoKeys()
             return
         }
 
+        saveKeyToKeychain(sbApiKey, provider: sbProvider)
         applyKeys(provider: sbProvider, model: sbModel.isEmpty ? nil : sbModel, keys: [sbProvider: sbApiKey], source: .settingsBundle)
     }
 
@@ -122,13 +142,47 @@ final class KeySyncService: ObservableObject {
 
     // MARK: - Private helpers
 
+    private func readAndClearSettingsBundleKey(defaults: UserDefaults) -> String {
+        let key = (defaults.string(forKey: "settings_apiKey") ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if !key.isEmpty {
+            defaults.set("", forKey: "settings_apiKey")
+        }
+        return key
+    }
+
+    private func hashKey(_ key: String) -> String {
+        let digest = SHA256.hash(data: Data(key.utf8))
+        return digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func saveKeyToKeychain(_ key: String, provider: String) {
+        try? KeychainService.set(key: key, forService: provider)
+    }
+
+    private func clearKeychainKeys() {
+        for provider in AIProvider.allCases {
+            try? KeychainService.delete(service: provider.rawValue)
+        }
+    }
+
+    @discardableResult
+    private func loadKeysFromKeychain() -> String? {
+        for provider in AIProvider.allCases {
+            if let key = try? KeychainService.get(service: provider.rawValue), !key.isEmpty {
+                applyKeys(provider: provider.rawValue, model: nil, keys: [provider.rawValue: key], source: .settingsBundle)
+                return provider.rawValue
+            }
+        }
+        return nil
+    }
+
     private func applyKeys(provider: String, model: String?, keys: [String: String], source: KeySource) {
         decryptedKeys = keys
         activeProvider = provider
         activeModel = model
         keySource = source
         isUnlocked = keys.values.contains { !$0.isEmpty }
-        print("[KeySync] Using \(source.rawValue) keys — provider: \(provider)")
+        logger.info("Using \(source.rawValue, privacy: .public) keys — provider: \(provider, privacy: .private)")
     }
 
     private func applyNoKeys() {
@@ -153,7 +207,7 @@ final class KeySyncService: ObservableObject {
                 let placeholderURL = dir.appendingPathComponent(name)
                 if fm.fileExists(atPath: placeholderURL.path) {
                     try? fm.startDownloadingUbiquitousItem(at: fileURL)
-                    print("[KeySync] Encrypted file is iCloud placeholder, triggered download")
+                    logger.info("Encrypted file is iCloud placeholder, triggered download")
                     break
                 }
             }
@@ -167,7 +221,7 @@ final class KeySyncService: ObservableObject {
             decoder.dateDecodingStrategy = .iso8601
             return try decoder.decode(KeySyncPayload.self, from: decrypted)
         } catch {
-            print("[KeySync] Decryption failed: \(error.localizedDescription)")
+            logger.error("Decryption failed: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }
@@ -187,9 +241,9 @@ final class KeySyncService: ObservableObject {
             let encrypted = try KeySyncCrypto.encrypt(plaintext)
             let fileURL = rootURL.appendingPathComponent(fileName)
             try encrypted.write(to: fileURL, options: .atomic)
-            print("[KeySync] Wrote keys to iCloud — provider: \(provider)")
+            logger.info("Wrote keys to iCloud — provider: \(provider, privacy: .private)")
         } catch {
-            print("[KeySync] Failed to write to iCloud: \(error.localizedDescription)")
+            logger.error("Failed to write to iCloud: \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/ios/SnapGrid/SnapGrid/Services/KeychainService.swift
+++ b/ios/SnapGrid/SnapGrid/Services/KeychainService.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Security
+import os
+
+private let logger = Logger(subsystem: "com.snapgrid.ios", category: "Keychain")
+
+enum KeychainService {
+
+    private static let serviceName = "com.snapgrid.apikeys"
+
+    static func set(key: String, forService service: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: service,
+            kSecAttrAccessGroup as String: "group.com.snapgrid"
+        ]
+
+        SecItemDelete(query as CFDictionary)
+
+        var addQuery = query
+        addQuery[kSecValueData as String] = Data(key.utf8)
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        addQuery[kSecAttrSynchronizable as String] = false
+
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        if status != errSecSuccess {
+            logger.error("Keychain write failed for \(service, privacy: .public): \(status)")
+        }
+    }
+
+    static func get(service: String) throws -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: service,
+            kSecReturnData as String: true,
+            kSecAttrAccessGroup as String: "group.com.snapgrid"
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        if status == errSecSuccess, let data = result as? Data {
+            return String(data: data, encoding: .utf8)
+        }
+
+        if status != errSecItemNotFound {
+            logger.error("Keychain read failed for \(service, privacy: .public): \(status)")
+        }
+
+        return nil
+    }
+
+    static func delete(service: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: service,
+            kSecAttrAccessGroup as String: "group.com.snapgrid"
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            logger.error("Keychain delete failed for \(service, privacy: .public): \(status)")
+        }
+    }
+
+    static func exists(service: String) -> Bool {
+        (try? get(service: service)) != nil
+    }
+}

--- a/ios/SnapGrid/SnapGridTests/KeySyncCryptoTests.swift
+++ b/ios/SnapGrid/SnapGridTests/KeySyncCryptoTests.swift
@@ -1,31 +1,34 @@
 import Testing
 import Foundation
+import CryptoKit
 @testable import SnapGrid
 
 @Suite("KeySyncCrypto", .tags(.crypto))
 struct KeySyncCryptoTests {
 
+    private let testKey = SymmetricKey(size: .bits256)
+
     @Test("Encrypt then decrypt returns original data")
     func encryptDecryptRoundtrip() throws {
         let original = Data("hello world".utf8)
-        let encrypted = try KeySyncCrypto.encrypt(original)
-        let decrypted = try KeySyncCrypto.decrypt(encrypted)
+        let encrypted = try KeySyncCrypto.encrypt(original, using: testKey)
+        let decrypted = try KeySyncCrypto.decrypt(encrypted, using: testKey)
         #expect(decrypted == original)
     }
 
     @Test("Empty payload encryption produces valid envelope")
     func emptyPayloadEncrypts() throws {
-        let encrypted = try KeySyncCrypto.encrypt(Data())
+        let encrypted = try KeySyncCrypto.encrypt(Data(), using: testKey)
         let envelope = try JSONDecoder().decode(EncryptedEnvelope.self, from: encrypted)
-        #expect(envelope.version == 1)
+        #expect(envelope.version == 2)
         #expect(!envelope.nonce.isEmpty)
     }
 
     @Test("Large payload roundtrip")
     func largePayloadRoundtrip() throws {
         let original = Data(repeating: 0xAB, count: 100_000)
-        let encrypted = try KeySyncCrypto.encrypt(original)
-        let decrypted = try KeySyncCrypto.decrypt(encrypted)
+        let encrypted = try KeySyncCrypto.encrypt(original, using: testKey)
+        let decrypted = try KeySyncCrypto.decrypt(encrypted, using: testKey)
         #expect(decrypted == original)
     }
 
@@ -34,12 +37,12 @@ struct KeySyncCryptoTests {
         let payload = KeySyncPayload(
             provider: "openai",
             model: "gpt-4o",
-            keys: ["openai": "sk-test123", "anthropic": "sk-ant-test"],
+            keys: ["openai": "test-key-openai", "anthropic": "test-key-anthropic"],
             updatedAt: Date(timeIntervalSince1970: 1700000000)
         )
         let encoded = try JSONEncoder().encode(payload)
-        let encrypted = try KeySyncCrypto.encrypt(encoded)
-        let decrypted = try KeySyncCrypto.decrypt(encrypted)
+        let encrypted = try KeySyncCrypto.encrypt(encoded, using: testKey)
+        let decrypted = try KeySyncCrypto.decrypt(encrypted, using: testKey)
         let decoded = try JSONDecoder().decode(KeySyncPayload.self, from: decrypted)
         #expect(decoded.provider == payload.provider)
         #expect(decoded.model == payload.model)
@@ -50,39 +53,39 @@ struct KeySyncCryptoTests {
     func corruptedDataThrows() {
         let garbage = Data("not valid json at all".utf8)
         #expect(throws: (any Error).self) {
-            try KeySyncCrypto.decrypt(garbage)
+            try KeySyncCrypto.decrypt(garbage, using: testKey)
         }
     }
 
     @Test("Decrypt envelope with unsupported version throws")
     func unsupportedVersionThrows() throws {
-        let envelope = EncryptedEnvelope(version: 2, nonce: "AAAA", ciphertext: "BBBB:CCCC")
+        let envelope = EncryptedEnvelope(version: 99, nonce: "AAAA", ciphertext: "BBBB:CCCC")
         let data = try JSONEncoder().encode(envelope)
         #expect(throws: KeySyncCrypto.KeySyncError.self) {
-            try KeySyncCrypto.decrypt(data)
+            try KeySyncCrypto.decrypt(data, using: testKey)
         }
     }
 
     @Test("Each encryption produces different ciphertext")
     func encryptionIsNondeterministic() throws {
         let original = Data("same input".utf8)
-        let encrypted1 = try KeySyncCrypto.encrypt(original)
-        let encrypted2 = try KeySyncCrypto.encrypt(original)
+        let encrypted1 = try KeySyncCrypto.encrypt(original, using: testKey)
+        let encrypted2 = try KeySyncCrypto.encrypt(original, using: testKey)
         #expect(encrypted1 != encrypted2)
     }
 
     // MARK: - EncryptedEnvelope structure (cross-device contract)
 
-    @Test("Encrypted envelope has version 1")
+    @Test("Encrypted envelope has version 2")
     func envelopeVersion() throws {
-        let encrypted = try KeySyncCrypto.encrypt(Data("test".utf8))
+        let encrypted = try KeySyncCrypto.encrypt(Data("test".utf8), using: testKey)
         let envelope = try JSONDecoder().decode(EncryptedEnvelope.self, from: encrypted)
-        #expect(envelope.version == 1)
+        #expect(envelope.version == 2)
     }
 
     @Test("Encrypted envelope ciphertext contains colon separator")
     func envelopeCiphertextFormat() throws {
-        let encrypted = try KeySyncCrypto.encrypt(Data("test".utf8))
+        let encrypted = try KeySyncCrypto.encrypt(Data("test".utf8), using: testKey)
         let envelope = try JSONDecoder().decode(EncryptedEnvelope.self, from: encrypted)
         #expect(envelope.ciphertext.contains(":"))
         let parts = envelope.ciphertext.split(separator: ":")
@@ -91,8 +94,18 @@ struct KeySyncCryptoTests {
 
     @Test("Encrypted envelope nonce is valid base64")
     func envelopeNonceBase64() throws {
-        let encrypted = try KeySyncCrypto.encrypt(Data("test".utf8))
+        let encrypted = try KeySyncCrypto.encrypt(Data("test".utf8), using: testKey)
         let envelope = try JSONDecoder().decode(EncryptedEnvelope.self, from: encrypted)
         #expect(Data(base64Encoded: envelope.nonce) != nil)
+    }
+
+    @Test("Wrong key fails to decrypt")
+    func wrongKeyFailsDecrypt() throws {
+        let original = Data("secret data".utf8)
+        let encrypted = try KeySyncCrypto.encrypt(original, using: testKey)
+        let wrongKey = SymmetricKey(size: .bits256)
+        #expect(throws: (any Error).self) {
+            try KeySyncCrypto.decrypt(encrypted, using: wrongKey)
+        }
     }
 }

--- a/ios/SnapGrid/SnapGridTests/KeySyncServiceTests.swift
+++ b/ios/SnapGrid/SnapGridTests/KeySyncServiceTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import CryptoKit
 @testable import SnapGrid
 
 @Suite("KeySyncService", .tags(.crypto))
@@ -12,7 +13,7 @@ struct KeySyncServiceTests {
         let payload = KeySyncPayload(
             provider: "anthropic",
             model: "claude-sonnet-4-5",
-            keys: ["anthropic": "sk-ant-test", "openai": "sk-test"],
+            keys: ["anthropic": "test-ant-key", "openai": "test-oai-key"],
             updatedAt: Date(timeIntervalSince1970: 1700000000)
         )
 
@@ -24,8 +25,8 @@ struct KeySyncServiceTests {
         #expect(json?["provider"] as? String == "anthropic")
         #expect(json?["model"] as? String == "claude-sonnet-4-5")
         let keys = json?["keys"] as? [String: String]
-        #expect(keys?["anthropic"] == "sk-ant-test")
-        #expect(keys?["openai"] == "sk-test")
+        #expect(keys?["anthropic"] == "test-ant-key")
+        #expect(keys?["openai"] == "test-oai-key")
     }
 
     @Test("KeySyncPayload decode roundtrip")
@@ -33,7 +34,7 @@ struct KeySyncServiceTests {
         let original = KeySyncPayload(
             provider: "openai",
             model: "gpt-4o",
-            keys: ["openai": "sk-123"],
+            keys: ["openai": "test-key-123"],
             updatedAt: Date(timeIntervalSince1970: 1700000000)
         )
 
@@ -42,7 +43,7 @@ struct KeySyncServiceTests {
 
         #expect(decoded.provider == "openai")
         #expect(decoded.model == "gpt-4o")
-        #expect(decoded.keys["openai"] == "sk-123")
+        #expect(decoded.keys["openai"] == "test-key-123")
     }
 
     @Test("KeySyncPayload with empty keys dict")
@@ -67,7 +68,7 @@ struct KeySyncServiceTests {
         let payload = KeySyncPayload(
             provider: "openai",
             model: "gpt-4o",
-            keys: ["openai": "", "anthropic": "sk-valid"],
+            keys: ["openai": "", "anthropic": "test-valid-key"],
             updatedAt: Date()
         )
 
@@ -98,6 +99,7 @@ struct KeySyncServiceTests {
 
     @Test("End-to-end: encrypt payload, decrypt, decode")
     func endToEndPipeline() throws {
+        let testKey = SymmetricKey(size: .bits256)
         let payload = KeySyncPayload(
             provider: "gemini",
             model: "gemini-2.0-flash",
@@ -106,9 +108,9 @@ struct KeySyncServiceTests {
         )
 
         let encoded = try JSONEncoder().encode(payload)
-        let encrypted = try KeySyncCrypto.encrypt(encoded)
+        let encrypted = try KeySyncCrypto.encrypt(encoded, using: testKey)
 
-        let decrypted = try KeySyncCrypto.decrypt(encrypted)
+        let decrypted = try KeySyncCrypto.decrypt(encrypted, using: testKey)
         let decoded = try JSONDecoder().decode(KeySyncPayload.self, from: decrypted)
 
         #expect(decoded.provider == "gemini")
@@ -134,17 +136,25 @@ struct KeySyncServiceTests {
 
     // MARK: - Settings.bundle key reading
 
+    private func cleanupDefaults(_ defaults: UserDefaults) {
+        defaults.removeObject(forKey: "settings_apiKey")
+        defaults.removeObject(forKey: "settings_provider")
+        defaults.removeObject(forKey: "settings_model")
+        defaults.removeObject(forKey: "settings_lastSyncedKeyHash")
+    }
+
+    private func cleanupKeychain() {
+        for provider in AIProvider.allCases {
+            try? KeychainService.delete(service: provider.rawValue)
+        }
+    }
+
     @Test("Settings.bundle non-empty key unlocks service")
     @MainActor func settingsBundleUnlocks() async {
         let defaults = UserDefaults.standard
-        defer {
-            defaults.removeObject(forKey: "settings_apiKey")
-            defaults.removeObject(forKey: "settings_provider")
-            defaults.removeObject(forKey: "settings_model")
-            defaults.removeObject(forKey: "settings_lastSyncedApiKey")
-        }
+        defer { cleanupDefaults(defaults); cleanupKeychain() }
 
-        defaults.set("sk-ant-test123", forKey: "settings_apiKey")
+        defaults.set("test-ant-key-123", forKey: "settings_apiKey")
         defaults.set("anthropic", forKey: "settings_provider")
         defaults.set("", forKey: "settings_model")
 
@@ -155,16 +165,13 @@ struct KeySyncServiceTests {
         #expect(service.keySource == .settingsBundle)
         #expect(service.activeProvider == "anthropic")
         #expect(service.activeModel == nil)
-        #expect(service.activeAPIKey() == "sk-ant-test123")
+        #expect(service.activeAPIKey() == "test-ant-key-123")
     }
 
     @Test("Settings.bundle empty key does not unlock")
     @MainActor func settingsBundleEmptyKey() async {
         let defaults = UserDefaults.standard
-        defer {
-            defaults.removeObject(forKey: "settings_apiKey")
-            defaults.removeObject(forKey: "settings_provider")
-        }
+        defer { cleanupDefaults(defaults); cleanupKeychain() }
 
         defaults.set("", forKey: "settings_apiKey")
         defaults.set("openai", forKey: "settings_provider")
@@ -179,10 +186,7 @@ struct KeySyncServiceTests {
     @Test("Settings.bundle whitespace-only key treated as empty")
     @MainActor func settingsBundleWhitespaceKey() async {
         let defaults = UserDefaults.standard
-        defer {
-            defaults.removeObject(forKey: "settings_apiKey")
-            defaults.removeObject(forKey: "settings_provider")
-        }
+        defer { cleanupDefaults(defaults); cleanupKeychain() }
 
         defaults.set("   ", forKey: "settings_apiKey")
         defaults.set("openai", forKey: "settings_provider")
@@ -197,12 +201,9 @@ struct KeySyncServiceTests {
     @Test("Settings.bundle unknown provider is rejected")
     @MainActor func settingsBundleUnknownProvider() async {
         let defaults = UserDefaults.standard
-        defer {
-            defaults.removeObject(forKey: "settings_apiKey")
-            defaults.removeObject(forKey: "settings_provider")
-        }
+        defer { cleanupDefaults(defaults); cleanupKeychain() }
 
-        defaults.set("sk-test123", forKey: "settings_apiKey")
+        defaults.set("test-key-123", forKey: "settings_apiKey")
         defaults.set("invalid_provider", forKey: "settings_provider")
 
         let service = KeySyncService.shared
@@ -215,14 +216,9 @@ struct KeySyncServiceTests {
     @Test("Settings.bundle with model sets activeModel")
     @MainActor func settingsBundleWithModel() async {
         let defaults = UserDefaults.standard
-        defer {
-            defaults.removeObject(forKey: "settings_apiKey")
-            defaults.removeObject(forKey: "settings_provider")
-            defaults.removeObject(forKey: "settings_model")
-            defaults.removeObject(forKey: "settings_lastSyncedApiKey")
-        }
+        defer { cleanupDefaults(defaults); cleanupKeychain() }
 
-        defaults.set("sk-test123", forKey: "settings_apiKey")
+        defaults.set("test-key-123", forKey: "settings_apiKey")
         defaults.set("openai", forKey: "settings_provider")
         defaults.set("gpt-4o-mini", forKey: "settings_model")
 
@@ -236,12 +232,9 @@ struct KeySyncServiceTests {
     @Test("Settings.bundle provider 'none' does not unlock")
     @MainActor func settingsBundleNoneProvider() async {
         let defaults = UserDefaults.standard
-        defer {
-            defaults.removeObject(forKey: "settings_apiKey")
-            defaults.removeObject(forKey: "settings_provider")
-        }
+        defer { cleanupDefaults(defaults); cleanupKeychain() }
 
-        defaults.set("sk-test123", forKey: "settings_apiKey")
+        defaults.set("test-key-123", forKey: "settings_apiKey")
         defaults.set("none", forKey: "settings_provider")
 
         let service = KeySyncService.shared


### PR DESCRIPTION
### Why?

SnapGrid is open-source — all source code is publicly visible. A security audit found that API keys were stored in plaintext (Mac: `~/.keys.json`, iOS: `UserDefaults`), the iCloud encryption key was hardcoded in source, Gemini API keys were leaked in URL parameters, and debug logging exposed key operations in release builds. Anyone reading the repo could exploit these patterns to access users' API keys.

### How?

Moved all API key storage to real Keychain (`Security.framework`) on both platforms with automatic migration from the old storage. Replaced the hardcoded AES-256 encryption key with a random per-user key synced via iCloud Keychain (v1→v2 envelope migration preserved). Switched Gemini API auth from `?key=` URL parameter to `x-goog-api-key` HTTP header. Replaced `print()` debug logging with `os.Logger` using `.private` sensitivity.

<details>
<summary>Implementation Plan</summary>

# Security Audit Plan — SnapGrid (Open-Source)

## Context

SnapGrid is an open-source project. All source code is publicly visible, which means any hardcoded secrets, encryption keys, or insecure storage patterns are directly exploitable. This audit found 5 actionable issues: a critical hardcoded encryption key, two high-severity plaintext key storage patterns, API keys leaked in URL parameters, and debug logging in release builds.

---

## Finding 1 (CRITICAL): Hardcoded iCloud encryption key

**Problem**: Both `KeySyncCrypto.swift` files (Mac + iOS) contain identical hardcoded AES-256 key material on lines 28-31. Anyone reading the open-source code can decrypt any user's `.apikeys.encrypted` file from iCloud. The "split into fragments" comment is security theater — all fragments are adjacent.

**Fix**: Generate a random 32-byte per-user key on first launch, store it in the real Keychain with `kSecAttrSynchronizable: true` so iCloud Keychain syncs it between the user's devices. Use this per-user key as HKDF input instead of the hardcoded bytes.

- Bump `EncryptedEnvelope.version` to `2` for new encryption
- Keep version 1 decryption (old hardcoded key) for one-time migration: read v1, re-encrypt as v2, overwrite
- For "Sign to Run Locally" dev builds: if Keychain write fails, fall back to `kSecAttrSynchronizable: false` (local-only key, no cross-device sync)

---

## Finding 2 (HIGH): Mac app stores API keys in plaintext JSON file

**Problem**: `KeychainService.swift` stores keys in `~/Library/Application Support/SnapGrid/.keys.json` with 0o600 permissions. Any process running as the user can read this file.

**Fix**: Rewrite to use `Security.framework` SecItem APIs. Same 4-method interface (`set`, `get`, `delete`, `exists`). Migration on first launch: read `.keys.json`, import each key to Keychain, delete file.

---

## Finding 3 (HIGH): iOS app stores API keys in UserDefaults

**Problem**: `KeySyncService.swift` reads/writes the actual API key via `UserDefaults`. UserDefaults is unencrypted and readable from backups.

**Fix**: Create iOS `KeychainService.swift` backed by real iOS Keychain. Read-and-clear from Settings.bundle. Replace plaintext change-detection marker with SHA256 hash prefix.

---

## Finding 4 (HIGH): Gemini API key in URL query parameter

**Problem**: Multiple places append `?key=\(apiKey)` to the Gemini API URL. URL parameters get logged in server/proxy logs.

**Fix**: Switch to `x-goog-api-key` HTTP header across Mac and iOS.

---

## Finding 5 (MEDIUM): Debug logging of key operations in release builds

**Problem**: ~13 `print("[KeySync]...")` statements log to system console in release builds.

**Fix**: Replace `print()` with `os.Logger` using `.private` sensitivity.

</details>

<sub>Generated with Claude Code</sub>