### PR TITLE
Fix broken staggered pill opacity animation in Mac detail view

### DIFF
--- a/SnapGrid/SnapGrid/Views/Detail/DetailItemView.swift
+++ b/SnapGrid/SnapGrid/Views/Detail/DetailItemView.swift
@@ -813,7 +813,7 @@ struct DetailMetadataSection: View {
                 .stageReveal(stage: stage, threshold: 1)
             } else if let result = item.analysisResult {
                 if !result.patterns.isEmpty {
-                    let pillsContent = FlowLayout(spacing: 8) {
+                    FlowLayout(spacing: 8) {
                         ForEach(Array(result.patterns.enumerated()), id: \.element.name) { index, pattern in
                             Button {
                                 onSearchPattern?(pattern.name)
@@ -833,16 +833,6 @@ struct DetailMetadataSection: View {
                     }
                     .padding(.leading, -8)
                     .padding(.bottom, 16)
-
-                    #if compiler(>=6.3)
-                    if #available(macOS 26, *) {
-                        GlassEffectContainer(spacing: 8) { pillsContent }
-                    } else {
-                        pillsContent
-                    }
-                    #else
-                    pillsContent
-                    #endif
                 }
 
                 if hasDescription(result) {


### PR DESCRIPTION
### Why?

The staggered fade-in animation for pattern pills in the Mac detail view stopped working. Pills appear all at once instead of fading in individually with a stagger delay. Regression introduced in PR #199 when `GlassEffectContainer` was added to wrap the pills on macOS 26+.

### How?

Remove the `GlassEffectContainer` wrapper — it batches child views into a single composited glass layer, preventing SwiftUI from animating individual pill opacity/offset transitions. Each `PatternPill` already applies its own `.glassEffect()`, making the container redundant. This mirrors the same fix already applied on iOS (commit d3b5e6c).

<details>
<summary>Implementation Plan</summary>

# Fix pill opacity animation on Mac

## Context

The staggered fade-in animation for pattern pills in the detail metadata view broke on macOS. Each pill should fade in individually with a 50ms stagger delay, but they currently appear all at once (or not at all on macOS 26+).

**Root cause:** PR #199 (`674291e` — "Add light mode support and appearance settings") wrapped the pills in `GlassEffectContainer` on macOS 26+. This container batches child views into a shared glass layer, preventing SwiftUI from animating individual pill opacity/offset transitions independently.

**Precedent:** The iOS app had the exact same bug and already fixed it in commit `d3b5e6c` by removing `GlassEffectContainer` from pills. Each `PatternPill` already applies `.glassEffect()` individually (PatternPill.swift:25), so the container wrapper is redundant.

## Change

**File:** `SnapGrid/SnapGrid/Views/Detail/DetailItemView.swift` (lines 837–845)

Remove the `GlassEffectContainer` wrapper and inline `pillsContent` back to a direct `FlowLayout`.

## Verification

1. Build Mac app — must compile clean
2. Launch the app, open a detail view for an item with analysis results — pills should fade in one by one with stagger

</details>

<sub>Generated with Claude Code</sub>