### PR TITLE
Add Xcode build artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ release/*
 # Xcode user-specific files
 xcuserdata/
 *.xcuserstate
+
+# Xcode build artifacts
+SnapGrid/build/
+ios/SnapGrid/build/
+*.xcarchive
+*.ipa


### PR DESCRIPTION
### Why?

Setting up the Mac app notarization workflow produces build artifacts (`*.xcarchive`, DMGs, zips) inside `SnapGrid/build/`. These weren't gitignored and would get picked up by `git status`.

### How?

Adds `SnapGrid/build/`, `ios/SnapGrid/build/`, `*.xcarchive`, and `*.ipa` to `.gitignore`.

<sub>Generated with Claude Code</sub>