### PR TITLE
Hide left sidebar by default in Mac app

### DIFF
--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -24,6 +24,7 @@ struct ContentView: View {
     @State private var isSearchActive = false
     @State private var isSearchFieldPresented = false
     @State private var shareAnchorView: NSView?
+    @State private var columnVisibility: NavigationSplitViewVisibility = .detailOnly
 
     #if DEBUG
     @AppStorage("debugSimulateEmptyState") private var debugSimulateEmptyState = false
@@ -78,7 +79,7 @@ struct ContentView: View {
 
     var body: some View {
         @Bindable var appState = appState
-        NavigationSplitView {
+        NavigationSplitView(columnVisibility: $columnVisibility) {
             SpaceSidebarView(
                 spaces: spaces,
                 selection: $appState.sidebarSelection,


### PR DESCRIPTION
### Why?

The spaces sidebar takes up screen real estate on launch when the primary action is browsing the media grid. Hiding it by default gives the content area full width from the start, while keeping the sidebar a single click away.

### How?

Uses SwiftUI's built-in `NavigationSplitView(columnVisibility:)` with `.detailOnly` as the initial state. The sidebar resets to hidden on each launch but remains toggleable via the standard macOS toolbar button.

<details>
<summary>Implementation Plan</summary>

# Plan: Hide left sidebar by default in Mac app

## Context
The Mac app's `NavigationSplitView` always shows the sidebar on launch. The user wants it hidden by default, while still allowing users to toggle it open via the standard macOS sidebar button.

## Approach
SwiftUI's `NavigationSplitView` accepts an optional `columnVisibility` binding of type `NavigationSplitViewVisibility`. By initializing it to `.detailOnly`, the sidebar starts collapsed but remains toggleable via the built-in toolbar button.

### Changes

**`SnapGrid/SnapGrid/Views/ContentView/ContentView.swift`** (~line 81)
- Add a `@State` property: `@State private var columnVisibility: NavigationSplitViewVisibility = .detailOnly`
- Pass it to the existing `NavigationSplitView`: `NavigationSplitView(columnVisibility: $columnVisibility)`

That's it — one property, one parameter addition. No changes to AppState since this is pure view-level presentation state that resets each launch (which is the desired behavior: hidden by default every time).

## Verification
1. `cd SnapGrid && xcodegen generate && xcodebuild build -project SnapGrid.xcodeproj -scheme SnapGrid -destination 'platform=macOS' 2>&1 | xcbeautify --quiet`
2. Launch the app — sidebar should be hidden
3. Click the sidebar toggle button in the toolbar — sidebar should appear
4. Quit and relaunch — sidebar should be hidden again

</details>

<sub>Generated with Claude Code</sub>