### PR TITLE
Show AI analysis errors in alert and stop batch on first failure

### DIFF
--- a/SnapGrid/SnapGrid/Services/AIAnalysisService.swift
+++ b/SnapGrid/SnapGrid/Services/AIAnalysisService.swift
@@ -428,7 +428,14 @@ final class AIAnalysisService: Sendable {
             case .noAPIKey: return "No API key configured"
             case .imageConversionFailed: return "Failed to convert image for analysis"
             case .invalidResponse: return "Invalid response from AI provider"
-            case .apiError(let code, let msg): return "API error (\(code)): \(msg)"
+            case .apiError(let code, _):
+                switch code {
+                case 401, 403: return "Your API key is invalid or unauthorized. Check your key in Settings."
+                case 402: return "Insufficient credits. Check your account balance with your AI provider."
+                case 429: return "Rate limit exceeded. Wait a moment and try again."
+                case 500...599: return "The AI provider is experiencing issues (HTTP \(code)). Try again later."
+                default: return "API request failed with HTTP \(code). Check your provider settings."
+                }
             case .parseFailed: return "Failed to parse AI response"
             }
         }

--- a/SnapGrid/SnapGrid/Services/ImportService.swift
+++ b/SnapGrid/SnapGrid/Services/ImportService.swift
@@ -11,6 +11,8 @@ final class ImportService {
     private let analysisService = AIAnalysisService.shared
     let sidecarService: MetadataSidecarService
 
+    var analysisAlertError: String?
+
     init(storage: MediaStorageService = .shared, sidecarService: MetadataSidecarService = .shared) {
         self.storage = storage
         self.sidecarService = sidecarService
@@ -146,18 +148,19 @@ final class ImportService {
         }
     }
 
-    func analyzeItem(_ item: MediaItem, context: ModelContext) async {
+    @discardableResult
+    func analyzeItem(_ item: MediaItem, context: ModelContext) async -> Bool {
         // Prevent duplicate analysis (e.g. SyncWatcher detecting our own sidecar write)
         guard !item.isAnalyzing else {
             print("[Analysis] Skipping \(item.id) — already analyzing")
-            return
+            return true
         }
 
         // Check for API key
         let provider = AIProvider(rawValue: UserDefaults.standard.string(forKey: "aiProvider") ?? "openai") ?? .openai
         guard KeychainService.exists(service: provider.keychainService) else {
             print("[Analysis] No API key for \(provider.rawValue), skipping")
-            return
+            return true
         }
 
         let storedModel = UserDefaults.standard.string(forKey: "\(provider.rawValue)Model") ?? ModelDiscoveryService.autoModelValue
@@ -170,6 +173,7 @@ final class ImportService {
         print("[Analysis] Starting analysis with \(provider.rawValue)/\(model) for \(item.id)")
 
         item.isAnalyzing = true
+        analysisAlertError = nil
         context.saveOrLog()
 
         do {
@@ -197,11 +201,14 @@ final class ImportService {
             context.saveOrLog()
             sidecarService.writeSidecar(for: item)
             NotificationCenter.default.post(name: .analysisCompleted, object: nil, userInfo: ["itemId": item.id])
+            return true
         } catch {
             print("[Analysis] Failed for \(item.id): \(error)")
             item.isAnalyzing = false
             item.analysisError = error.localizedDescription
+            analysisAlertError = error.localizedDescription
             context.saveOrLog()
+            return false
         }
     }
 
@@ -211,7 +218,8 @@ final class ImportService {
 
         print("[Analysis] Batch analyzing \(unanalyzed.count) unanalyzed items")
         for item in unanalyzed {
-            await analyzeItem(item, context: context)
+            let success = await analyzeItem(item, context: context)
+            if !success { break }
             try? await Task.sleep(for: .milliseconds(300))
         }
     }

--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -230,6 +230,14 @@ struct ContentView: View {
             ElectronImportView(isPresented: $showElectronImport)
                 .presentationBackground(Color.snapCard)
         }
+        .alert("Analysis Failed", isPresented: Binding(
+            get: { importService.analysisAlertError != nil },
+            set: { if !$0 { importService.analysisAlertError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(importService.analysisAlertError ?? "")
+        }
         .onChange(of: showElectronImport) { _, isPresented in
             if !isPresented {
                 syncWatcher.beginLocalChange()
@@ -304,7 +312,8 @@ struct ContentView: View {
                     guard let items = try? modelContext.fetch(descriptor) else { return }
                     let newItems = items.filter { ids.contains($0.id) }
                     for item in newItems {
-                        await importService.analyzeItem(item, context: modelContext)
+                        let success = await importService.analyzeItem(item, context: modelContext)
+                        if !success { break }
                     }
                 }
             }
@@ -801,9 +810,10 @@ struct ContentView: View {
             item.analysisResult = nil
         }
         modelContext.saveOrLog()
-        for item in items {
-            Task {
-                await importService.analyzeItem(item, context: modelContext)
+        Task {
+            for item in items {
+                let success = await importService.analyzeItem(item, context: modelContext)
+                if !success { break }
             }
         }
     }

--- a/ios/SnapGrid/SnapGrid/Services/AIAnalysisService.swift
+++ b/ios/SnapGrid/SnapGrid/Services/AIAnalysisService.swift
@@ -390,7 +390,14 @@ final class AIAnalysisService: Sendable {
             case .noAPIKey: return "No API key configured"
             case .imageConversionFailed: return "Failed to convert image for analysis"
             case .invalidResponse: return "Invalid response from AI provider"
-            case .apiError(let code, let msg): return "API error (\(code)): \(msg)"
+            case .apiError(let code, _):
+                switch code {
+                case 401, 403: return "Your API key is invalid or unauthorized. Check your key in Settings."
+                case 402: return "Insufficient credits. Check your account balance with your AI provider."
+                case 429: return "Rate limit exceeded. Wait a moment and try again."
+                case 500...599: return "The AI provider is experiencing issues (HTTP \(code)). Try again later."
+                default: return "API request failed with HTTP \(code). Check your provider settings."
+                }
             case .parseFailed: return "Failed to parse AI response"
             }
         }

--- a/ios/SnapGrid/SnapGrid/Services/AnalysisCoordinator.swift
+++ b/ios/SnapGrid/SnapGrid/Services/AnalysisCoordinator.swift
@@ -7,6 +7,7 @@ import UIKit
 @MainActor
 final class AnalysisCoordinator {
     private var analysisTask: Task<Void, Never>?
+    var analysisAlertError: String?
 
     // Dependencies — set once via configure(), used by all analysis methods.
     private var keySyncService: KeySyncService?
@@ -62,6 +63,7 @@ final class AnalysisCoordinator {
 
         print("[Analysis] Starting analysis of \(items.count) item(s)")
 
+        analysisAlertError = nil
         analysisTask?.cancel()
         analysisTask = Task {
             for item in items {
@@ -104,7 +106,9 @@ final class AnalysisCoordinator {
                 } catch {
                     item.isAnalyzing = false
                     item.analysisError = error.localizedDescription
+                    self.analysisAlertError = error.localizedDescription
                     print("[Analysis] Failed for \(item.id): \(error.localizedDescription)")
+                    break
                 }
             }
         }

--- a/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
@@ -214,6 +214,14 @@ struct MainView: View {
             }
             Button("Cancel", role: .cancel) {}
         }
+        .alert("Analysis Failed", isPresented: Binding(
+            get: { analysisCoordinator.analysisAlertError != nil },
+            set: { if !$0 { analysisCoordinator.analysisAlertError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(analysisCoordinator.analysisAlertError ?? "")
+        }
     }
 
     // MARK: - Tab Content


### PR DESCRIPTION
### Why?

When AI analysis fails (wrong API key, exceeded credits, rate limit), the error is silently stored but the user only sees a generic "Analysis failed" label. Users need to see the actual error to diagnose and fix the issue. Additionally, batch analysis keeps running after the first failure, wasting API calls that will also fail.

### How?

Added an `analysisAlertError` property to `ImportService` (Mac) and `AnalysisCoordinator` (iOS) that drives a native `.alert()` with a human-readable message based on the HTTP status code. All batch analysis loops now break on first failure, so remaining items stay unanalyzed until the user explicitly retries.

<details>
<summary>Implementation Plan</summary>

# Plan: Surface AI analysis error messages via alert + stop batch on failure

## Context

When AI analysis fails (wrong API key, exceeded credits, rate limit), the error is captured and stored on `MediaItem.analysisError` but the user only sees a generic "Analysis failed" label. Additionally, batch analysis keeps running after the first failure, wasting API calls that will also fail. The user needs to see the actual server error in an alert, and batch analysis should stop on first failure.

## Approach

1. Add an `analysisAlertError: String?` property to `ImportService` (Mac) and `AnalysisCoordinator` (iOS)
2. Set it on failure, clear it when starting a new analysis attempt
3. Break batch loops on first failure
4. Wire a `.alert()` modifier in `ContentView` (Mac) and `MainView` (iOS) bound to this property
5. Keep existing inline "Analysis failed" labels — they mark which items failed

## Files to modify

### Mac app

**`SnapGrid/SnapGrid/Services/ImportService.swift`**
- Add `var analysisAlertError: String?` property
- Change `analyzeItem` → `@discardableResult func analyzeItem(...) async -> Bool`
  - Clear `analysisAlertError` at start
  - Return `false` and set `analysisAlertError` in catch block
  - Return `true` on success
- In `analyzeUnanalyzedItems`: break loop when `analyzeItem` returns `false`

**`SnapGrid/SnapGrid/Views/ContentView/ContentView.swift`**
- Add `.alert("Analysis Failed", ...)` modifier bound to `importService.analysisAlertError`
- Fix SyncWatcher callback loop (line ~300-308) to break on first failure
- Fix `retryAnalysis` (line ~796) to run sequentially in one Task and break on failure

### iOS app

**`ios/SnapGrid/SnapGrid/Services/AnalysisCoordinator.swift`**
- Add `var analysisAlertError: String?` property
- Clear it at start of `analyzeItems` loop
- Set it in catch block and `break` to stop the batch

**`ios/SnapGrid/SnapGrid/Views/Main/MainView.swift`**
- Add `.alert("Analysis Failed", ...)` modifier bound to `analysisCoordinator.analysisAlertError`

## Verification

1. Mac: Set an intentionally wrong API key, import an image → alert should show the server error (e.g., "API error (401): ...")
2. Mac: Import multiple images with wrong key → only the first should attempt analysis, rest remain unanalyzed (no error flag set)
3. Mac: Fix key, press retry → analysis succeeds, alert doesn't appear
4. iOS: Same flow via AnalysisCoordinator
5. Build both apps to verify no compile errors

</details>

<sub>Generated with Claude Code</sub>