### PR TITLE
Context-aware empty state import button

### DIFF
--- a/SnapGrid/SnapGrid/App/SnapGridApp.swift
+++ b/SnapGrid/SnapGrid/App/SnapGridApp.swift
@@ -192,6 +192,7 @@ extension Notification.Name {
     static let focusSearch = Notification.Name("focusSearch")
     static let selectAll = Notification.Name("selectAll")
     static let pasteImages = Notification.Name("pasteImages")
+    static let importFolder = Notification.Name("importFolder")
     static let deleteSelected = Notification.Name("deleteSelected")
     static let analysisCompleted = Notification.Name("analysisCompleted")
     static let zoomIn = Notification.Name("zoomIn")

--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -25,6 +25,7 @@ struct ContentView: View {
     @State private var isSearchFieldPresented = false
     @State private var shareAnchorView: NSView?
     @State private var columnVisibility: NavigationSplitViewVisibility = .detailOnly
+    @State private var electronLibraryDetected = false
 
     #if DEBUG
     @AppStorage("debugSimulateEmptyState") private var debugSimulateEmptyState = false
@@ -203,6 +204,7 @@ struct ContentView: View {
         .modifier(NotificationModifier(
             onImportFiles: { showImportPanel = true },
             onImportElectron: { showElectronImport = true },
+            onImportFolder: { handleFolderImport() },
             onUndoDelete: { undoLastDelete() },
             onApiKeySaved: {
                 Task {
@@ -279,6 +281,8 @@ struct ContentView: View {
             DataCleanupService.cleanOrphanedRecords(context: modelContext)
             DataCleanupService.cleanOrphanedSidecars()
             await DataCleanupService.migrateVideoDimensions(context: modelContext)
+
+            electronLibraryDetected = ElectronImportService().detectElectronLibrary() != nil
 
             // Sync items that arrived via iCloud while app was closed
             await syncWatcher.initialSync(context: modelContext)
@@ -375,7 +379,7 @@ struct ContentView: View {
     private var detailContent: some View {
         let items = activeFilteredItems
         if allItems.isEmpty || debugSimulateEmptyState {
-            EmptyStateView(isDragTargeted: isDragTargeted)
+            EmptyStateView(electronLibraryDetected: electronLibraryDetected, isDragTargeted: isDragTargeted)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if items.isEmpty && isSearchActive {
             VStack(spacing: 12) {
@@ -433,6 +437,39 @@ struct ContentView: View {
                 await importService.importFiles(urls, into: modelContext, spaceId: appState.activeSpaceId)
                 syncWatcher.endLocalChange()
             }
+        }
+    }
+
+    private func handleFolderImport() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.message = "Choose a folder to import media from"
+        panel.prompt = "Import"
+
+        let response = panel.runModal()
+        guard response == .OK, let folderURL = panel.url else { return }
+
+        guard let enumerator = FileManager.default.enumerator(
+            at: folderURL,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else { return }
+
+        var mediaURLs: [URL] = []
+        for case let fileURL as URL in enumerator {
+            if SupportedMedia.isSupported(fileURL.pathExtension) {
+                mediaURLs.append(fileURL)
+            }
+        }
+
+        guard !mediaURLs.isEmpty else { return }
+
+        syncWatcher.beginLocalChange()
+        Task {
+            await importService.importFiles(mediaURLs, into: modelContext, spaceId: appState.activeSpaceId)
+            syncWatcher.endLocalChange()
         }
     }
 
@@ -871,6 +908,7 @@ private struct ShareAnchorView: NSViewRepresentable {
 private struct NotificationModifier: ViewModifier {
     let onImportFiles: () -> Void
     let onImportElectron: () -> Void
+    let onImportFolder: () -> Void
     let onUndoDelete: () -> Void
     let onApiKeySaved: () -> Void
     let onCreateNewSpace: () -> Void
@@ -886,6 +924,9 @@ private struct NotificationModifier: ViewModifier {
             }
             .onReceive(NotificationCenter.default.publisher(for: .importElectronLibrary)) { _ in
                 onImportElectron()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .importFolder)) { _ in
+                onImportFolder()
             }
             .onReceive(NotificationCenter.default.publisher(for: .undoDelete)) { _ in
                 onUndoDelete()

--- a/SnapGrid/SnapGrid/Views/Grid/EmptyStateView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/EmptyStateView.swift
@@ -7,6 +7,7 @@ struct EmptyStateView: View {
     }
 
     var mode: Mode = .appLevel
+    var electronLibraryDetected: Bool = false
     var isDragTargeted: Bool = false
 
     // Random-looking heights for skeleton placeholders
@@ -59,12 +60,17 @@ struct EmptyStateView: View {
                     }
 
                     if mode == .appLevel {
-                        Button {
-                            NotificationCenter.default.post(name: .importElectronLibrary, object: nil)
-                        } label: {
-                            Label("Import from SnapGrid 1", systemImage: "square.and.arrow.down.on.square")
+                        if electronLibraryDetected {
+                            Button("Import from SnapGrid") {
+                                NotificationCenter.default.post(name: .importElectronLibrary, object: nil)
+                            }
+                            .controlSize(.large)
+                        } else {
+                            Button("Import") {
+                                NotificationCenter.default.post(name: .importFolder, object: nil)
+                            }
+                            .controlSize(.large)
                         }
-                        .controlSize(.large)
                     }
 
                     if mode == .appLevel,


### PR DESCRIPTION
### Why?

The empty state always showed "Import from SnapGrid 1" — irrelevant and confusing for users who never used the Electron app. New users should see a generic import option instead.

### How?

On launch, detect whether a SnapGrid 1 library exists on disk. If found, show "Import from SnapGrid" (existing electron import flow). Otherwise, show a generic "Import" button that opens an `NSOpenPanel` folder picker and imports all supported media via `ImportService`.

<details>
<summary>Implementation Plan</summary>

# Plan: Smart Empty State Import Button

## Context
The Mac app's empty state always shows "Import from SnapGrid 1" — even for users who never used the Electron app. This change makes the button contextual: detect whether a SnapGrid 1 library exists, and show either "Import from SnapGrid" (with the existing electron import flow) or a generic "Import" button that opens a folder picker.

## Changes

### 1. EmptyStateView.swift
**Path:** `SnapGrid/SnapGrid/Views/Grid/EmptyStateView.swift`

- Add parameter: `var electronLibraryDetected: Bool = false`
- Replace the hardcoded "Import from SnapGrid 1" button (lines 60-67) with conditional logic:
  - `electronLibraryDetected == true` → "Import from SnapGrid" button, posts `.importElectronLibrary`
  - `electronLibraryDetected == false` → "Import" button, posts `.importFolder`
- Both keep `.controlSize(.large)`, both only show when `mode == .appLevel`

### 2. SnapGridApp.swift
**Path:** `SnapGrid/SnapGrid/App/SnapGridApp.swift`

- Add notification name: `static let importFolder = Notification.Name("importFolder")` (line ~194)

### 3. ContentView.swift
**Path:** `SnapGrid/SnapGrid/Views/ContentView/ContentView.swift`

**a) State** (near line 26, with other `@State` vars):
- Add `@State private var electronLibraryDetected = false`

**b) Detection** (in existing `.task` block at line 267, after cleanup/migration code around line 280):
```swift
electronLibraryDetected = ElectronImportService().detectElectronLibrary() != nil
```

**c) Pass to EmptyStateView** (line 377):
```swift
EmptyStateView(electronLibraryDetected: electronLibraryDetected, isDragTargeted: isDragTargeted)
```
Line 390 (space-level) unchanged — button only renders in `.appLevel` mode.

**d) Folder import handler** — new private function:
- Opens `NSOpenPanel` (directories only, single selection)
- Message: "Choose a folder to import media from", prompt: "Import"
- Enumerates folder recursively with `FileManager.enumerator`, `skipsHiddenFiles`
- Filters with `SupportedMedia.isSupported(ext)`
- Calls `importService.importFiles(mediaURLs, into: modelContext, spaceId: appState.activeSpaceId)`
- Wraps in `syncWatcher.beginLocalChange()` / `endLocalChange()` — matches `handleFileImport` pattern (line 428-436)

**e) NotificationModifier** (line 870):
- Add `let onImportFolder: () -> Void` property
- Add `.onReceive` for `.importFolder` notification
- Wire in `.modifier(NotificationModifier(...))` call (line 202) with `onImportFolder: { handleFolderImport() }`

## Files modified
1. `SnapGrid/SnapGrid/Views/Grid/EmptyStateView.swift`
2. `SnapGrid/SnapGrid/App/SnapGridApp.swift`
3. `SnapGrid/SnapGrid/Views/ContentView/ContentView.swift`

## Verification
1. `cd SnapGrid && xcodegen generate && xcodebuild build -project SnapGrid.xcodeproj -scheme SnapGrid -destination 'platform=macOS' 2>&1 | xcbeautify --quiet`
2. Run the app — if ~/Documents/SnapGrid/ exists with images/ and metadata/ subdirs, empty state should say "Import from SnapGrid". Otherwise it should say "Import".
3. Click "Import" (no SnapGrid 1 case) — should open a folder picker, import all media from selected folder.

</details>

<sub>Generated with Claude Code</sub>