### PR TITLE
Fix crash when deleting last item in grid

### DIFF
--- a/SnapGrid/SnapGrid/Views/Grid/MasonryGridView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/MasonryGridView.swift
@@ -105,29 +105,31 @@ struct MasonryGridView: View {
                         ForEach(0..<columns, id: \.self) { column in
                             LazyVStack(spacing: spacing) {
                                 ForEach(distribution[column]) { item in
-                                    GridItemView(
-                                        item: item,
-                                        width: columnWidth,
-                                        spaces: spaces,
-                                        activeSpaceId: activeSpaceId,
-                                        onSelect: { frame in onSelect(item.id, frame) },
-                                        onToggleSelect: { onToggleSelect(item.id) },
-                                        onShiftSelect: { onShiftSelect(item.id) },
-                                        onDelete: onDelete,
-                                        onChangeSpaceMembership: onChangeSpaceMembership,
-                                        onRetryAnalysis: onRetryAnalysis,
-                                        onShare: onShare
-                                    )
-                                    .background(
-                                        GeometryReader { geo in
-                                            Color.clear.preference(
-                                                key: ItemFramePreferenceKey.self,
-                                                value: rubberBandStart != nil
-                                                    ? [item.id: geo.frame(in: .named(coordinateSpaceName))]
-                                                    : [:]
-                                            )
-                                        }
-                                    )
+                                    if !item.isDeleted {
+                                        GridItemView(
+                                            item: item,
+                                            width: columnWidth,
+                                            spaces: spaces,
+                                            activeSpaceId: activeSpaceId,
+                                            onSelect: { frame in onSelect(item.id, frame) },
+                                            onToggleSelect: { onToggleSelect(item.id) },
+                                            onShiftSelect: { onShiftSelect(item.id) },
+                                            onDelete: onDelete,
+                                            onChangeSpaceMembership: onChangeSpaceMembership,
+                                            onRetryAnalysis: onRetryAnalysis,
+                                            onShare: onShare
+                                        )
+                                        .background(
+                                            GeometryReader { geo in
+                                                Color.clear.preference(
+                                                    key: ItemFramePreferenceKey.self,
+                                                    value: rubberBandStart != nil
+                                                        ? [item.id: geo.frame(in: .named(coordinateSpaceName))]
+                                                        : [:]
+                                                )
+                                            }
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -166,7 +168,7 @@ struct MasonryGridView: View {
         var columnHeights = Array(repeating: CGFloat(0), count: totalColumns)
         var columnItems = Array(repeating: [MediaItem](), count: totalColumns)
 
-        for item in items {
+        for item in items where !item.isDeleted {
             let shortest = columnHeights.enumerated().min(by: { $0.element < $1.element })?.offset ?? 0
             columnItems[shortest].append(item)
             let estimatedHeight = 1.0 / item.aspectRatio


### PR DESCRIPTION
### Why?

The app crashes (`EXC_BREAKPOINT` in SwiftData) when deleting the only item in the grid. SwiftUI's `ForEach` re-evaluates its content closure with a reference to the now-deleted `MediaItem`, and `GridItemView`'s init eagerly accesses properties whose backing store has been destroyed.

### How?

Guard against deleted SwiftData models using `PersistentModel.isDeleted` checks — in the ForEach content closure (preventing `GridItemView` init from running on deleted models) and in `computeDistribution` (preventing `aspectRatio` access during layout). Safe because `isDeleted` is metadata that doesn't touch the backing store, and stays `false` during the CardCrush animation phases.

<details>
<summary>Implementation Plan</summary>

# Fix: SwiftData crash when deleting last grid item

## Context

Deleting the only item in the grid crashes the app (`EXC_BREAKPOINT` in SwiftData). The crash happens because SwiftUI's `ForEach` re-evaluates its content closure with a reference to the now-deleted `MediaItem` — the `GridItemView` init eagerly accesses properties (`isVideo`, `orderedSpaceIDs`, `aspectRatio`) whose backing store has been destroyed.

No `isDeleted` guards exist anywhere in the codebase today.

## Fix (2 edits in 1 file)

**File:** `SnapGrid/SnapGrid/Views/Grid/MasonryGridView.swift`

### 1. Guard in ForEach content closure (line 107)

Wrap `GridItemView(...)` + its `.background` modifier in `if !item.isDeleted`. This prevents the init from running on deleted models. Safe because `PersistentModel.isDeleted` is metadata — doesn't touch the backing store.

Does NOT break CardCrush animation: `isDeleted` stays false during stages 0→1→2 (animation runs before `commitDeletion` calls `modelContext.delete`).

### 2. Filter in `computeDistribution` (line 169)

Change `for item in items` → `for item in items where !item.isDeleted`. Prevents `item.aspectRatio` access on deleted models during layout computation.

## Verification

1. Build: `cd SnapGrid && xcodegen generate && xcodebuild build`
2. Manual test: launch app → drag in one image → delete it → should not crash
3. Manual test: add multiple items → select all → delete → should not crash, CardCrush animation intact

</details>

<sub>Generated with Claude Code</sub>