### PR TITLE
Fix Cmd+O file import by adding security-scoped URL access

### DIFF
--- a/SnapGrid/SnapGrid/Services/ImportService.swift
+++ b/SnapGrid/SnapGrid/Services/ImportService.swift
@@ -74,6 +74,9 @@ final class ImportService {
     }
 
     func importSingleFile(_ url: URL, into context: ModelContext, spaceId: String?, sourceURL: String? = nil) async throws {
+        let accessed = url.startAccessingSecurityScopedResource()
+        defer { if accessed { url.stopAccessingSecurityScopedResource() } }
+
         let ext = url.pathExtension.lowercased()
         let isVideo = videoTypes.contains(ext)
         let isImage = imageTypes.contains(ext)


### PR DESCRIPTION
### Why?

Files selected via Cmd+O (`.fileImporter`) silently fail to import. The file picker opens and the user can select files, but nothing gets added to the library. Drag-and-drop works fine for the same files.

### How?

Added `startAccessingSecurityScopedResource()` / `stopAccessingSecurityScopedResource()` in `importSingleFile()`. SwiftUI's `.fileImporter` returns security-scoped URLs that require explicit access grants before reading — without this, `NSImage(contentsOf:)` returns nil and `FileManager.copyItem` throws. The call is a no-op on regular URLs, so drag-and-drop, paste, and URL imports are unaffected.

<details>
<summary>Implementation Plan</summary>

# Fix Cmd+O file import (security-scoped URL access)

## Context

When using Cmd+O to import files, the file picker opens but selected files never get added. Drag-and-drop works fine. The root cause: SwiftUI's `.fileImporter` returns **security-scoped URLs** that require `startAccessingSecurityScopedResource()` before the file can be read. `ImportService.importSingleFile()` never calls this, so all file reads (`NSImage(contentsOf:)`, `FileManager.copyItem()`) fail silently.

Drag-and-drop works because `NSItemProvider` automatically grants read access during the drag session — no security scope needed.

## Fix

Add security-scoped resource access in `ImportService.importSingleFile()`.

### File: `SnapGrid/SnapGrid/Services/ImportService.swift` (line 76)

Add two lines at the start of `importSingleFile()`:

```swift
func importSingleFile(_ url: URL, into context: ModelContext, spaceId: String?, sourceURL: String? = nil) async throws {
    let accessed = url.startAccessingSecurityScopedResource()
    defer { if accessed { url.stopAccessingSecurityScopedResource() } }

    let ext = url.pathExtension.lowercased()
    // ... rest unchanged
```

This is safe for all callers:
- **`.fileImporter` URLs**: `accessed` = true, grants read access, cleaned up in defer
- **Drag/paste/temp URLs**: `accessed` = false (not security-scoped), defer is a no-op, files remain accessible as before

</details>

<sub>Generated with Claude Code</sub>