### PR TITLE
Fix retry badge hidden by floating video layer on hover

### DIFF
--- a/SnapGrid/SnapGrid/Services/VideoPreviewManager.swift
+++ b/SnapGrid/SnapGrid/Services/VideoPreviewManager.swift
@@ -37,12 +37,18 @@ final class VideoPreviewManager {
     /// Pattern names to display on the floating layer during grid hover
     private(set) var gridPatternNames: [String] = []
 
+    /// Whether the previewed item is currently being analyzed
+    private(set) var isAnalyzing: Bool = false
+
+    /// Whether the previewed item has a failed analysis (shows retry badge on floating layer)
+    private(set) var hasAnalysisError: Bool = false
+
     private var loopObserver: NSObjectProtocol?
 
     // MARK: - Grid Hover
 
     /// Start hover preview — creates player, positions floating layer at grid cell
-    func startPreview(itemId: String, url: URL, frame: CGRect, patternNames: [String] = []) {
+    func startPreview(itemId: String, url: URL, frame: CGRect, patternNames: [String] = [], isAnalyzing: Bool = false, hasAnalysisError: Bool = false) {
         if activeItemId == itemId, player != nil {
             gridItemFrame = frame
             if displayState == .grid {
@@ -59,6 +65,8 @@ final class VideoPreviewManager {
         activeItemId = itemId
         gridItemFrame = frame
         gridPatternNames = patternNames
+        self.isAnalyzing = isAnalyzing
+        self.hasAnalysisError = hasAnalysisError
         currentFrame = frame
         cornerRadius = 12
         displayState = .grid
@@ -75,6 +83,12 @@ final class VideoPreviewManager {
         }
     }
 
+    /// Update analysis state for the currently previewed item (called reactively from GridItemView)
+    func updateAnalysisState(isAnalyzing: Bool, hasError: Bool) {
+        self.isAnalyzing = isAnalyzing
+        self.hasAnalysisError = hasError
+    }
+
     /// Stop hover preview
     func stopPreview() {
         displayState = .hidden
@@ -89,6 +103,8 @@ final class VideoPreviewManager {
         player = nil
         activeItemId = nil
         gridPatternNames = []
+        isAnalyzing = false
+        hasAnalysisError = false
     }
 
     private func addLoopObserver(for player: AVPlayer?) {

--- a/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -309,7 +309,9 @@ struct GridItemView: View {
                             itemId: item.id,
                             url: MediaStorageService.shared.mediaURL(filename: item.filename),
                             frame: globalFrame,
-                            patternNames: item.analysisResult?.patterns.prefix(5).map(\.name) ?? []
+                            patternNames: item.analysisResult?.patterns.prefix(5).map(\.name) ?? [],
+                            isAnalyzing: item.isAnalyzing,
+                            hasAnalysisError: !item.isAnalyzing && item.analysisError != nil
                         )
                     }
                 } else if videoPreview.activeItemId == item.id {
@@ -394,6 +396,20 @@ struct GridItemView: View {
                 isHovered = false
                 suppressHoverExit = false
             }
+        }
+        .onChange(of: item.isAnalyzing) {
+            guard videoPreview.activeItemId == item.id else { return }
+            videoPreview.updateAnalysisState(
+                isAnalyzing: item.isAnalyzing,
+                hasError: !item.isAnalyzing && item.analysisError != nil
+            )
+        }
+        .onChange(of: item.analysisError) {
+            guard videoPreview.activeItemId == item.id else { return }
+            videoPreview.updateAnalysisState(
+                isAnalyzing: item.isAnalyzing,
+                hasError: !item.isAnalyzing && item.analysisError != nil
+            )
         }
         .contextMenu {
             let removeFromActiveSpace: (() -> Void)? = {

--- a/SnapGrid/SnapGrid/Views/Shared/FloatingVideoLayer.swift
+++ b/SnapGrid/SnapGrid/Views/Shared/FloatingVideoLayer.swift
@@ -111,6 +111,31 @@ struct FloatingVideoLayer: View {
                             .allowsHitTesting(false)
                         }
                     }
+                    .overlay(alignment: .bottomLeading) {
+                        Group {
+                            if videoPreview.isAnalyzing {
+                                ShimmerText("Analyzing...")
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 3)
+                                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10))
+                                    .environment(\.colorScheme, .dark)
+                            } else if videoPreview.hasAnalysisError {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "arrow.clockwise")
+                                        .font(.caption2)
+                                    Text("Retry")
+                                        .font(.caption.weight(.medium))
+                                }
+                                .foregroundStyle(.white)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 4)
+                                .background(.red.opacity(0.7))
+                                .clipShape(RoundedRectangle(cornerRadius: 6))
+                            }
+                        }
+                        .padding(8)
+                        .allowsHitTesting(false)
+                    }
                     .frame(width: videoPreview.currentFrame.width, height: videoPreview.currentFrame.height)
                     .clipShape(RoundedRectangle(cornerRadius: videoPreview.cornerRadius))
                     .overlay(


### PR DESCRIPTION
### Why?

The failed analysis retry badge disappears when hovering a video thumbnail because the FloatingVideoLayer (NSViewRepresentable with AVPlayerLayer) composites above the grid's SwiftUI overlays, visually hiding the badge. Pressing retry while hovering also didn't show the analyzing shimmer.

### How?

Mirror the retry badge and analyzing shimmer on FloatingVideoLayer itself, with reactive `onChange` handlers on `item.isAnalyzing` and `item.analysisError` so the floating layer badges update in real time — pressing Retry swaps the badge to the shimmer even mid-hover.

<details>
<summary>Implementation Plan</summary>

# Fix: Retry badge hidden by FloatingVideoLayer on video hover

## Context

When hovering a video thumbnail that has a failed analysis, the `FloatingVideoLayer` (AVPlayerLayer via NSViewRepresentable) covers the retry badge at `.bottomLeading` in `GridItemView`. The badge button still works (clicks pass through), but it's invisible to the user.

Root cause: ContentView ZStack renders FloatingVideoLayer above the grid. NSViewRepresentable composites above SwiftUI overlays regardless of z-order within the grid item.

## Changes (3 files)

### 1. VideoPreviewManager.swift — add `isAnalyzing` and `hasAnalysisError` flags

- Add both flags as `private(set)` properties
- Add parameters to `startPreview()`
- Add `updateAnalysisState()` method for reactive updates from GridItemView
- Reset both in `cleanup()`

### 2. GridItemView.swift — pass flags and react to changes

- Pass `isAnalyzing` and `hasAnalysisError` to `startPreview()` call
- Add `onChange(of: item.isAnalyzing)` and `onChange(of: item.analysisError)` handlers that call `updateAnalysisState()` while the video is being previewed

### 3. FloatingVideoLayer.swift — render mirrored badges

- Show shimmer "Analyzing..." pill when `videoPreview.isAnalyzing`
- Show retry badge when `videoPreview.hasAnalysisError` and not analyzing
- Use non-glass style (glass doesn't composite correctly above NSViewRepresentable)

</details>

<sub>Generated with Claude Code</sub>