### PR TITLE
Restructure AI analysis prompt so custom guidance works

### DIFF
--- a/SnapGrid/SnapGrid/Services/AIAnalysisService.swift
+++ b/SnapGrid/SnapGrid/Services/AIAnalysisService.swift
@@ -34,37 +34,34 @@ enum AIProvider: String, CaseIterable, Codable, Sendable {
 final class AIAnalysisService: Sendable {
     static let shared = AIAnalysisService()
 
-    private let masterSystemPrompt = """
-    You are an expert AI in analyzing images. Your task is to analyze the content of images and provide appropriate descriptions.
+    private let systemPrompt = """
+    You are an expert image analyst.
 
-    Provide your response in the following JSON format:
+    <output_format>
+    Return a JSON object with this structure:
     {
-      "imageContext": "Detailed description of the entire image, including its purpose and main characteristics",
-      "imageSummary": "Very brief summary (1-2 words) of the main content or purpose",
+      "imageContext": "Detailed description of the image",
+      "imageSummary": "1-2 word summary",
       "patterns": [
-        {
-          "name": "Main object, subject, or element",
-          "confidence": 0.95
-        }
+        {"name": "Element Name", "confidence": 0.95}
       ]
     }
+    </output_format>
 
-    Guidelines:
-      1. The "imageSummary" should be a very brief (1-2 words) description of what the image shows
-      2. The "imageContext" should provide detailed information about the entire image
-      3. List the most prominent objects, subjects, or elements visible in the image
-      4. Use specific, descriptive language appropriate to the content (e.g. technical terms for UI screenshots, descriptive language for photos)
-      5. Each pattern should be 1-2 words maximum, not duplicative of imageSummary
-      6. Include confidence scores between 0.8 and 1.0
-      7. List patterns in order of confidence/importance
-      8. Ensure that the patterns are unique and not duplicates of each other and imageSummary
-      9. Provide exactly 6 patterns, ordered by confidence
-      10. Respond with a strict, valid JSON object — do not include markdown formatting, explanations, or code block symbols
-      11. Use title case for pattern/object names
-      12. Provide up to 6 patterns, ordered by confidence
+    <rules>
+    - imageSummary: 1-2 words only
+    - imageContext: detailed description of the entire image, its purpose and characteristics
+    - Pattern names: 1-2 words, title case, not duplicating imageSummary
+    - Up to 6 unique patterns, ordered by confidence (0.8–1.0)
+    - Respond with valid JSON only — no markdown, code blocks, or explanations
+    </rules>
     """
 
-    static let defaultGuidance = "If it's a UI screenshot, focus on UI patterns and components. If it's a general scene, focus on objects and subjects."
+    static let defaultGuidance = """
+    If it's a UI screenshot, focus on UI patterns and components. \
+    If it's a general scene, focus on objects and subjects. \
+    Use specific, descriptive language appropriate to the content.
+    """
 
     private let userText = "Analyze this image."
 
@@ -306,9 +303,9 @@ final class AIAnalysisService: Sendable {
 
     func buildPrompt(guidance: String? = nil, spaceContext: String? = nil) -> String {
         let effectiveGuidance = (guidance?.isEmpty == false ? guidance : nil) ?? Self.defaultGuidance
-        var result = masterSystemPrompt + "\n\nGuidance:\n" + effectiveGuidance
+        var result = systemPrompt + "\n<analysis_focus>\n" + effectiveGuidance + "\n</analysis_focus>"
         if let spaceContext, !spaceContext.isEmpty {
-            result += "\n" + spaceContext
+            result += "\n\n" + spaceContext
         }
         return result
     }

--- a/SnapGrid/SnapGrid/Services/ImportService.swift
+++ b/SnapGrid/SnapGrid/Services/ImportService.swift
@@ -186,6 +186,7 @@ final class ImportService {
             let resolvedGuidance = SpaceGuidanceResolver.resolve(for: item)
             let guidance = resolvedGuidance.guidance
             let spaceContext = resolvedGuidance.spaceContext
+            print("[Analysis] Guidance for \(item.id): \(guidance ?? "<default>")")
 
             if item.isVideo {
                 let frames = try await VideoFrameExtractor.extractAnalysisFrames(from: storage.mediaURL(filename: item.filename))

--- a/SnapGrid/SnapGridTests/GuidanceFallbackTests.swift
+++ b/SnapGrid/SnapGridTests/GuidanceFallbackTests.swift
@@ -45,21 +45,21 @@ struct GuidanceFallbackTests {
         #expect(prompt1 == prompt2)
     }
 
-    @Test("Prompt always contains master system prompt")
-    func alwaysContainsMasterPrompt() {
+    @Test("Prompt always contains system prompt")
+    func alwaysContainsSystemPrompt() {
         let prompt = service.buildPrompt(guidance: "custom", spaceContext: "context")
-        #expect(prompt.contains("expert AI in analyzing images"))
+        #expect(prompt.contains("expert image analyst"))
         #expect(prompt.contains("imageContext"))
         #expect(prompt.contains("imageSummary"))
     }
 
-    @Test("Prompt structure: master + guidance + context in order")
+    @Test("Prompt structure: system + analysis_focus + context in order")
     func promptStructure() {
         let prompt = service.buildPrompt(guidance: "CUSTOM_GUIDANCE", spaceContext: "SPACE_CONTEXT")
+        let focusIndex = prompt.range(of: "<analysis_focus>")!.lowerBound
         let guidanceIndex = prompt.range(of: "CUSTOM_GUIDANCE")!.lowerBound
         let contextIndex = prompt.range(of: "SPACE_CONTEXT")!.lowerBound
-        let masterIndex = prompt.range(of: "Guidance:")!.lowerBound
-        #expect(masterIndex < guidanceIndex)
+        #expect(focusIndex < guidanceIndex)
         #expect(guidanceIndex < contextIndex)
     }
 }

--- a/ios/SnapGrid/SnapGrid/Services/AIAnalysisService.swift
+++ b/ios/SnapGrid/SnapGrid/Services/AIAnalysisService.swift
@@ -29,37 +29,34 @@ enum AIProvider: String, CaseIterable, Codable, Sendable {
 final class AIAnalysisService: Sendable {
     static let shared = AIAnalysisService()
 
-    private let masterSystemPrompt = """
-    You are an expert AI in analyzing images. Your task is to analyze the content of images and provide appropriate descriptions.
+    private let systemPrompt = """
+    You are an expert image analyst.
 
-    Provide your response in the following JSON format:
+    <output_format>
+    Return a JSON object with this structure:
     {
-      "imageContext": "Detailed description of the entire image, including its purpose and main characteristics",
-      "imageSummary": "Very brief summary (1-2 words) of the main content or purpose",
+      "imageContext": "Detailed description of the image",
+      "imageSummary": "1-2 word summary",
       "patterns": [
-        {
-          "name": "Main object, subject, or element",
-          "confidence": 0.95
-        }
+        {"name": "Element Name", "confidence": 0.95}
       ]
     }
+    </output_format>
 
-    Guidelines:
-      1. The "imageSummary" should be a very brief (1-2 words) description of what the image shows
-      2. The "imageContext" should provide detailed information about the entire image
-      3. List the most prominent objects, subjects, or elements visible in the image
-      4. Use specific, descriptive language appropriate to the content (e.g. technical terms for UI screenshots, descriptive language for photos)
-      5. Each pattern should be 1-2 words maximum, not duplicative of imageSummary
-      6. Include confidence scores between 0.8 and 1.0
-      7. List patterns in order of confidence/importance
-      8. Ensure that the patterns are unique and not duplicates of each other and imageSummary
-      9. Provide exactly 6 patterns, ordered by confidence
-      10. Respond with a strict, valid JSON object — do not include markdown formatting, explanations, or code block symbols
-      11. Use title case for pattern/object names
-      12. Provide up to 6 patterns, ordered by confidence
+    <rules>
+    - imageSummary: 1-2 words only
+    - imageContext: detailed description of the entire image, its purpose and characteristics
+    - Pattern names: 1-2 words, title case, not duplicating imageSummary
+    - Up to 6 unique patterns, ordered by confidence (0.8–1.0)
+    - Respond with valid JSON only — no markdown, code blocks, or explanations
+    </rules>
     """
 
-    static let defaultGuidance = "If it's a UI screenshot, focus on UI patterns and components. If it's a general scene, focus on objects and subjects."
+    static let defaultGuidance = """
+    If it's a UI screenshot, focus on UI patterns and components. \
+    If it's a general scene, focus on objects and subjects. \
+    Use specific, descriptive language appropriate to the content.
+    """
 
     private let userText = "Analyze this image."
 
@@ -293,9 +290,9 @@ final class AIAnalysisService: Sendable {
 
     func buildPrompt(guidance: String? = nil, spaceContext: String? = nil) -> String {
         let effectiveGuidance = (guidance?.isEmpty == false ? guidance : nil) ?? Self.defaultGuidance
-        var result = masterSystemPrompt + "\n\nGuidance:\n" + effectiveGuidance
+        var result = systemPrompt + "\n<analysis_focus>\n" + effectiveGuidance + "\n</analysis_focus>"
         if let spaceContext, !spaceContext.isEmpty {
-            result += "\n" + spaceContext
+            result += "\n\n" + spaceContext
         }
         return result
     }


### PR DESCRIPTION
### Why?

Custom analysis guidance (e.g., "Only focus on colors") had no visible effect on results. The system prompt mixed output format rules with behavioral directives in a single numbered "Guidelines" block, so custom guidance appended at the end was drowned out.

### How?

Rewrote the prompt using XML-tagged sections (`<output_format>`, `<rules>`, `<analysis_focus>`) per Anthropic/OpenAI best practices. The rules section only covers output format constraints; `<analysis_focus>` is the sole place content direction lives, so custom guidance replaces it entirely instead of competing with behavioral directives. Added diagnostic logging for resolved guidance.

<details>
<summary>Implementation Plan</summary>

# Fix: Custom AI Analysis Guidance Not Working

## Context

User reports that setting custom guidance (e.g., "Only focus on colors") has no visible effect on analysis output. The current prompt mixes output format rules with behavioral directives in a single "Guidelines" block, so custom guidance appended at the end gets drowned out. Rewrite the prompt with clear XML-tagged sections so `<analysis_focus>` is the sole place content direction lives.

## Plan

### Step 1: Rewrite prompt in `AIAnalysisService.swift` (Mac)

Replace `masterSystemPrompt` with a new structured prompt using XML tags:
- `<output_format>` — JSON schema (fixed)
- `<rules>` — output constraints only: pattern count, confidence range, title case, valid JSON (fixed)
- No behavioral direction in the fixed sections

Rewrite `buildPrompt` to append `<analysis_focus>` with either custom guidance or the default behavioral guidance. Keep `static let defaultGuidance` for the settings UI prefill.

Add a diagnostic print in `ImportService.swift` to log resolved guidance.

### Step 2: Mirror changes to iOS

Same prompt and `buildPrompt` changes.

### Step 3: Update tests

Update string checks for new prompt format.

### Step 4: Build and verify

Run Mac test suite, then manual test with custom guidance.

</details>

<sub>Generated with Claude Code</sub>