### PR TITLE
Simplify delete animation to single-stage scale+fade

### DIFF
--- a/SnapGrid/SnapGrid/App/AppState.swift
+++ b/SnapGrid/SnapGrid/App/AppState.swift
@@ -52,8 +52,7 @@ final class AppState {
     var isSettingsOpen: Bool = false
     var isDraggingFromApp: Bool = false
 
-    /// Per-item delete animation stage: 1 = height crush, 2 = width crush + fade.
-    /// Items not in this dictionary are at stage 0 (normal).
+    /// Items currently animating deletion (value 1). Absent entries are normal (stage 0).
     var deletingItemStages: [String: Int] = [:]
 
     func deleteStage(for id: String) -> Int {

--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -629,28 +629,16 @@ struct ContentView: View {
         appState.clearSelection()
 
         let reduceMotion = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+        let anim = reduceMotion ? DeleteAnim.reducedMotionFade : DeleteAnim.shrinkFade
 
-        if reduceMotion {
-            withAnimation(CardCrush.reducedMotionFade) {
-                for id in ids { appState.deletingItemStages[id] = 2 }
-            }
-            Task { @MainActor in
-                try? await Task.sleep(for: CardCrush.reducedMotionDelay)
-                commitDeletion(ids)
-            }
-        } else {
-            withAnimation(CardCrush.heightCrush) {
-                for id in ids { appState.deletingItemStages[id] = 1 }
-            }
-            Task { @MainActor in
-                try? await Task.sleep(for: CardCrush.widthDelay)
-                withAnimation(CardCrush.widthCrush) {
-                    for id in ids { appState.deletingItemStages[id] = 2 }
-                }
+        withAnimation(anim) {
+            for id in ids { appState.deletingItemStages[id] = 1 }
+        }
 
-                try? await Task.sleep(for: CardCrush.completeDelay)
-                commitDeletion(ids)
-            }
+        let delay = reduceMotion ? DeleteAnim.reducedMotionDelay : DeleteAnim.commitDelay
+        Task { @MainActor in
+            try? await Task.sleep(for: delay)
+            commitDeletion(ids)
         }
     }
 

--- a/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -83,6 +83,10 @@ struct GridItemView: View {
         appState.deleteStage(for: item.id)
     }
 
+    private var isDeleting: Bool {
+        deleteStage > 0
+    }
+
     /// Whether this item is part of a multi-selection context menu
     private var isBulk: Bool {
         isSelected && selectedCount > 1
@@ -263,19 +267,13 @@ struct GridItemView: View {
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: 12))
-        // Delete animation — wallet card crush (mask approach)
-        .mask {
-            let maskH = deleteStage >= 1 ? height * CardCrush.crushedScaleY : height
-            let maskW = deleteStage >= 2 ? width * CardCrush.crushedScaleX : width
-            RoundedRectangle(cornerRadius: 12)
-                .frame(width: maskW, height: maskH)
-        }
+        .scaleEffect(isDeleting ? DeleteAnim.targetScale : 1.0)
         .overlay(
             RoundedRectangle(cornerRadius: 12)
-                .strokeBorder(isSelected && deleteStage == 0 ? Color.accentColor : Color.clear, lineWidth: 2)
+                .strokeBorder(isSelected && !isDeleting ? Color.accentColor : Color.clear, lineWidth: 2)
         )
         .shadow(
-            color: .black.opacity(deleteStage > 0 ? 0 : (effectiveHover ? 0.1 : 0.05)),
+            color: .black.opacity(isDeleting ? 0 : (effectiveHover ? 0.1 : 0.05)),
             radius: effectiveHover ? 6 : 2,
             x: 0,
             y: effectiveHover ? 4 : 1
@@ -284,9 +282,9 @@ struct GridItemView: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityDescription)
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
-        .accessibilityHidden(deleteStage > 0)
+        .accessibilityHidden(isDeleting)
         .onHover { hovering in
-            guard deleteStage == 0 else {
+            guard !isDeleting else {
                 isHovered = false
                 return
             }
@@ -368,7 +366,7 @@ struct GridItemView: View {
                 bulkCount: isBulk ? selectedCount : nil
             )
         }
-        .opacity(deleteStage >= 2 ? 0 : gridItemOpacity)
+        .opacity(isDeleting ? 0 : gridItemOpacity)
         .onGeometryChange(for: CGRect.self) { proxy in
             proxy.frame(in: .global)
         } action: { newValue in

--- a/SnapGrid/SnapGrid/Views/Shared/AnimationTokens.swift
+++ b/SnapGrid/SnapGrid/Views/Shared/AnimationTokens.swift
@@ -35,14 +35,11 @@ enum SnapSpring {
     }
 }
 
-/// Card-crush delete animation presets (matches iOS wallet-style crush).
-enum CardCrush {
-    static let heightCrush = Animation.spring(response: 0.2, dampingFraction: 0.85)
-    static let widthCrush  = Animation.spring(response: 0.15, dampingFraction: 0.92)
-    static let widthDelay: Duration = .milliseconds(160)
-    static let completeDelay: Duration = .milliseconds(300)
-    static let crushedScaleY: CGFloat = 0.05
-    static let crushedScaleX: CGFloat = 0.0
+/// Single-stage delete animation: scale down + fade out, then animated reflow.
+enum DeleteAnim {
+    static let shrinkFade = Animation.spring(response: 0.2, dampingFraction: 0.85)
+    static let targetScale: CGFloat = 0.8
+    static let commitDelay: Duration = .milliseconds(250)
 
     static let reducedMotionFade = Animation.easeInOut(duration: 0.15)
     static let reducedMotionDelay: Duration = .milliseconds(200)

--- a/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Detail/FullScreenImageOverlay.swift
@@ -37,46 +37,10 @@ enum MetadataReveal {
     static let slideDistance:    CGFloat  = 8
 }
 
-/* ─────────────────────────────────────────────────────────
- * ANIMATION STORYBOARD — Delete (Wallet Card Crush)
- *
- *    0ms   height clips inward (top + bottom) → 5%, width stays 100%
- *  280ms   width shrinks → 0%, opacity fades → 0
- *  500ms   animation complete, item removed, next image loads
- * ───────────────────────────────────────────────────────── */
-
 private enum DeleteAnimation {
-    static let heightCrush = Animation.spring(response: 0.32, dampingFraction: 0.82)
-    static let widthCrush  = Animation.spring(response: 0.25, dampingFraction: 0.9)
-    static let widthDelay: Duration = .milliseconds(280)
-    static let completeDelay: Duration = .milliseconds(500)
-    static let crushedScaleY: CGFloat = 0.05   // near-zero height slit
-    static let crushedScaleX: CGFloat = 0.0     // fully collapsed
-}
-
-/// Conditionally applies the delete-animation mask only when active.
-/// Skipping `.mask {}` entirely when `deleteStage == 0` avoids an
-/// unnecessary offscreen compositing pass on every frame.
-private struct DeleteMaskModifier: ViewModifier {
-    let deleteStage: Int
-    let finalFrame: CGRect
-    let zoomScale: CGFloat
-    let cornerRadius: CGFloat
-
-    func body(content: Content) -> some View {
-        if deleteStage >= 1 {
-            content.mask {
-                let maskH = finalFrame.height * DeleteAnimation.crushedScaleY
-                let maskW = deleteStage >= 2
-                    ? finalFrame.width * DeleteAnimation.crushedScaleX
-                    : finalFrame.width * zoomScale
-                RoundedRectangle(cornerRadius: cornerRadius)
-                    .frame(width: maskW, height: maskH)
-            }
-        } else {
-            content
-        }
-    }
+    static let shrinkFade = Animation.spring(response: 0.2, dampingFraction: 0.85)
+    static let targetScale: CGFloat = 0.8
+    static let commitDelay: Duration = .milliseconds(250)
 }
 
 // MARK: - Stage Reveal Modifier
@@ -165,9 +129,7 @@ struct FullScreenImageOverlay: View {
     private enum GestureMode { case none, dismiss, scroll, swipe, zoomPan }
     @State private var gestureMode: GestureMode = .none
 
-    // Delete animation — wallet-style card crush
-    // Stage 0: normal, 1: height clips inward, 2: width shrinks + fade, 3: complete
-    @State private var deleteStage: Int = 0
+    @State private var isDeleting = false
 
     // Share sheet
     @State private var shareItem: URL?
@@ -437,7 +399,7 @@ struct FullScreenImageOverlay: View {
             prepareShareItem()
         }
         .onChange(of: deleteRequestID) { oldValue, newValue in
-            guard newValue != oldValue, deleteStage == 0, !isClosing else { return }
+            guard newValue != oldValue, !isDeleting, !isClosing else { return }
             handleDelete()
         }
     }
@@ -499,14 +461,10 @@ struct FullScreenImageOverlay: View {
                         }
                     }
                     .clipShape(RoundedRectangle(cornerRadius: zoomedCornerRadius))
-                    .modifier(DeleteMaskModifier(
-                        deleteStage: deleteStage,
-                        finalFrame: finalFrame,
-                        zoomScale: zoomScale,
-                        cornerRadius: zoomedCornerRadius
-                    ))
+                    .scaleEffect(isDeleting ? DeleteAnimation.targetScale : 1.0)
+                    .opacity(isDeleting ? 0 : 1)
+                    .animation(DeleteAnimation.shrinkFade, value: isDeleting)
                     .offset(effectiveZoomPanOffset)
-                    .opacity(deleteStage >= 2 ? 0 : 1)
                 }
                 .frame(width: screen.width, height: finalFrame.height)
 
@@ -522,7 +480,7 @@ struct FullScreenImageOverlay: View {
                 )
                 .padding(.top, 32)
                 .padding(.bottom, 50)
-                .opacity(deleteStage >= 1 ? 0 : (isZoomed ? 0 : metadataOpacity * metadataDismissOpacity))
+                .opacity(isDeleting ? 0 : (isZoomed ? 0 : metadataOpacity * metadataDismissOpacity))
                 .offset(y: dismissVisualProgress * 24)
             }
             .frame(maxWidth: .infinity)
@@ -927,7 +885,6 @@ struct FullScreenImageOverlay: View {
     // MARK: - Delete
 
     private func handleDelete() {
-        // Reset zoom before delete animation so mask dimensions are correct
         if isZoomed {
             withAnimation(SnapSpring.resolvedFast) {
                 zoomScale = minZoomScale
@@ -942,25 +899,14 @@ struct FullScreenImageOverlay: View {
         let deletedItem = items[deletedIndex]
         let isLastItem = deletedIndex == items.count - 1
 
-        // Stage 1 — height crushes inward
-        withAnimation(DeleteAnimation.heightCrush) {
-            deleteStage = 1
+        withAnimation(DeleteAnimation.shrinkFade) {
+            isDeleting = true
         }
 
         Task { @MainActor in
-            // Stage 2 — width collapses + fade out
-            try? await Task.sleep(for: DeleteAnimation.widthDelay)
-            withAnimation(DeleteAnimation.widthCrush) {
-                deleteStage = 2
-            }
+            try? await Task.sleep(for: DeleteAnimation.commitDelay)
 
-            // Stage 3 — crush complete, commit deletion + slide in replacement
-            try? await Task.sleep(for: DeleteAnimation.completeDelay)
-
-            // Notify parent to handle file move + SwiftData deletion
             onDelete?(deletedItem)
-
-            // Update local items array
             items.remove(at: deletedIndex)
 
             if items.isEmpty {
@@ -968,31 +914,26 @@ struct FullScreenImageOverlay: View {
                 return
             }
 
-            // Adjust index
             if deletedIndex >= items.count {
                 currentIndex = items.count - 1
             }
 
             onCurrentItemChanged?(items[currentIndex].id)
 
-            // Prepare new image before resetting delete state
             player?.pause()
             player = nil
             image = adjacentImages[items[currentIndex].id]
             contentOffset = 0
 
-            // Position replacement off-screen: from right normally, from left if last
             let slideFrom = isLastItem ? -screenSize.width : screenSize.width
             swipeOffset = slideFrom
-            deleteStage = 0
+            isDeleting = false
             metadataStage = 0
 
-            // Animate the slide-in
             withAnimation(SnapSpring.resolvedStandard) {
                 swipeOffset = 0
             }
 
-            // Stagger metadata reveal after slide settles
             try? await Task.sleep(for: .milliseconds(200))
             startMetadataReveal()
 

--- a/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
@@ -500,7 +500,9 @@ struct MainView: View {
             )
         }
         modelContext.delete(item)
-        modelContext.saveOrLog()
+        withAnimation(SnapSpring.resolvedStandard) {
+            modelContext.saveOrLog()
+        }
     }
 
     // MARK: - Item Sharing


### PR DESCRIPTION
### Why?

The delete animation on both Mac and iOS was janky. The two-stage mask-crush approach didn't affect `LazyVStack` layout — the card visually crushed to nothing but left a full-height gap that snapped closed abruptly when the item was actually removed.

### How?

Replace the mask-based crush with compositor-friendly `scaleEffect` + `opacity` fade (single stage), then let the existing `withAnimation` on model save handle smooth gap-close reflow. Also added animated grid deletion on iOS, which previously had no animation at all.

<details>
<summary>Implementation Plan</summary>

# Plan: Simplify Delete Animation

## Context

The current delete animation uses a two-stage "card crush" mask approach that causes jank. The `.mask` modifier visually crushes the card but doesn't affect `LazyVStack` layout — so a full-height gap remains until `commitDeletion` removes the item, causing an abrupt layout jump. The two-stage timing via `Task.sleep` adds brittleness.

**Goal:** Replace with a single-stage `scaleEffect` + `opacity` fade, followed by animated layout reflow. Simpler code, smoother result.

## Changes

### 1. AnimationTokens.swift
**Replace `CardCrush` enum (lines 38-49) with `DeleteAnim`:**
```swift
enum DeleteAnim {
    static let shrinkFade = Animation.spring(response: 0.2, dampingFraction: 0.85)
    static let targetScale: CGFloat = 0.8
    static let commitDelay: Duration = .milliseconds(250)
    static let reducedMotionFade = Animation.easeInOut(duration: 0.15)
    static let reducedMotionDelay: Duration = .milliseconds(200)
}
```

### 2. GridItemView.swift
- Add `private var isDeleting: Bool { appState.deleteStage(for: item.id) > 0 }`
- **Remove** the `.mask { ... }` block (lines 267-272)
- **Add** `.scaleEffect(isDeleting ? DeleteAnim.targetScale : 1.0)` after `.clipShape`
- **Replace** `.opacity(deleteStage >= 2 ? 0 : gridItemOpacity)` → `.opacity(isDeleting ? 0 : gridItemOpacity)`
- Place `.animation(DeleteAnim.shrinkFade, value: isDeleting)` after both scale + opacity
- Update `deleteStage > 0` / `deleteStage == 0` references → `isDeleting` / `!isDeleting`

### 3. ContentView.swift — `deleteItems()`
Replace two-stage orchestration (lines 631-654) with single stage:
```swift
let anim = reduceMotion ? DeleteAnim.reducedMotionFade : DeleteAnim.shrinkFade
withAnimation(anim) {
    for id in ids { appState.deletingItemStages[id] = 1 }
}
let delay = reduceMotion ? DeleteAnim.reducedMotionDelay : DeleteAnim.commitDelay
Task { @MainActor in
    try? await Task.sleep(for: delay)
    commitDeletion(ids)
}
```
`commitDeletion` is unchanged — already wraps `modelContext.saveOrLog()` in `withAnimation(SnapSpring.standard)` for smooth reflow.

### 4. AppState.swift
Update doc comment on `deletingItemStages` (line 55). Data structure unchanged.

## Verification
1. `cd SnapGrid && xcodegen generate && xcodebuild build -project SnapGrid.xcodeproj -scheme SnapGrid -destination 'platform=macOS' 2>&1 | xcbeautify --quiet`
2. Run the app, import a few images, delete single + bulk items — confirm smooth scale+fade then gap closes
3. Test undo after delete — items restore correctly
4. Test with System Settings → Accessibility → Display → Reduce Motion enabled

</details>

<sub>Generated with Claude Code</sub>