### PR TITLE
Open sidebar when creating a new space via Cmd+N

### DIFF
--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -730,6 +730,7 @@ struct ContentView: View {
         MetadataSidecarService.shared.writeSpaces(from: modelContext)
         syncWatcher.endLocalChange()
         switchToSpace(space.id)
+        withAnimation { columnVisibility = .all }
         pendingEditSpaceId = space.id
     }
 


### PR DESCRIPTION
### Why?

When pressing Cmd+N to create a new space while the sidebar is collapsed, the space gets created but the user can't see or edit its name — the inline rename field lives in the sidebar, which stays hidden.

### How?

Animates the sidebar open (`columnVisibility = .all`) in `createSpace()` right before setting `pendingEditSpaceId`, so the rename TextField is visible and focused.

<details>
<summary>Implementation Plan</summary>

# Plan: Open sidebar when creating a new space

## Context

When the user presses Cmd+N to create a new space while the sidebar is collapsed (`.detailOnly`), the space is created and `pendingEditSpaceId` is set — but the sidebar stays hidden. The user can't see or type the new space name. The sidebar should automatically open so the inline rename TextField is visible.

## Fix

**File:** `SnapGrid/SnapGrid/Views/ContentView/ContentView.swift`

In `createSpace()` (line 737), add one line to reveal the sidebar before setting `pendingEditSpaceId`:

```swift
private func createSpace() {
    syncWatcher.beginLocalChange()
    let space = Space(name: "New Space", order: spaces.count)
    modelContext.insert(space)
    modelContext.saveOrLog()
    MetadataSidecarService.shared.writeSpaces(from: modelContext)
    syncWatcher.endLocalChange()
    switchToSpace(space.id)
    withAnimation { columnVisibility = .all }   // <-- new
    pendingEditSpaceId = space.id
}
```

Using `withAnimation` ensures the sidebar slides open smoothly. `.all` makes the sidebar column visible in the `NavigationSplitView`.

## Verification

1. Run the Mac app
2. Collapse the sidebar (it starts collapsed by default)
3. Press Cmd+N
4. Confirm: sidebar opens and the new space name is editable inline
5. Build check: `cd SnapGrid && xcodegen generate && xcodebuild build -project SnapGrid.xcodeproj -scheme SnapGrid -destination 'platform=macOS' 2>&1 | xcbeautify --quiet`

</details>

<sub>Generated with Claude Code</sub>