### PR TITLE
Add undo/redo for space membership changes and space deletion

### DIFF
--- a/SnapGrid/SnapGrid/App/AppState.swift
+++ b/SnapGrid/SnapGrid/App/AppState.swift
@@ -59,8 +59,9 @@ final class AppState {
         deletingItemStages[id] ?? 0
     }
 
-    // Undo stack — stores enough info to fully restore deleted items
-    private(set) var deletedBatches: [[DeletedItemInfo]] = []
+    // Unified undo/redo stacks — hold both deletion and space-change snapshots in LIFO order
+    private(set) var undoStack: [UndoBatch] = []
+    private(set) var redoStack: [UndoBatch] = []
 
     // Toast notifications
     var toasts: [ToastMessage] = []
@@ -136,15 +137,40 @@ final class AppState {
 
     private let maxUndoBatches = 20
 
-    func pushDeleteBatch(_ items: [DeletedItemInfo]) {
-        deletedBatches.append(items)
-        if deletedBatches.count > maxUndoBatches {
-            deletedBatches.removeFirst(deletedBatches.count - maxUndoBatches)
+    func pushUndoBatch(_ batch: UndoBatch) {
+        undoStack.append(batch)
+        if undoStack.count > maxUndoBatches {
+            undoStack.removeFirst(undoStack.count - maxUndoBatches)
         }
     }
 
-    func popDeleteBatch() -> [DeletedItemInfo]? {
-        deletedBatches.popLast()
+    func popUndoBatch() -> UndoBatch? {
+        undoStack.popLast()
+    }
+
+    func pushRedoBatch(_ batch: UndoBatch) {
+        redoStack.append(batch)
+        if redoStack.count > maxUndoBatches {
+            redoStack.removeFirst(redoStack.count - maxUndoBatches)
+        }
+    }
+
+    func popRedoBatch() -> UndoBatch? {
+        redoStack.popLast()
+    }
+
+    func clearRedoStack() {
+        redoStack.removeAll()
+    }
+
+    func pushDeleteBatch(_ items: [DeletedItemInfo]) {
+        pushUndoBatch(.deletion(items))
+        clearRedoStack()
+    }
+
+    func pushSpaceChangeBatch(_ changes: [SpaceChangeInfo]) {
+        pushUndoBatch(.spaceChange(changes))
+        clearRedoStack()
     }
 }
 
@@ -165,6 +191,27 @@ struct DeletedItemInfo {
     let analyzedAt: Date?
     let analysisProvider: String?
     let analysisModel: String?
+}
+
+struct SpaceChangeInfo {
+    let itemId: String
+    let previousSpaceIds: [String]
+}
+
+struct DeletedSpaceInfo {
+    let id: String
+    let name: String
+    let order: Int
+    let createdAt: Date
+    let customPrompt: String?
+    let useCustomPrompt: Bool
+    let itemIds: [String]
+}
+
+enum UndoBatch {
+    case deletion([DeletedItemInfo])
+    case spaceChange([SpaceChangeInfo])
+    case spaceDeletion(DeletedSpaceInfo)
 }
 
 struct ToastMessage: Identifiable {

--- a/SnapGrid/SnapGrid/App/SnapGridApp.swift
+++ b/SnapGrid/SnapGrid/App/SnapGridApp.swift
@@ -138,13 +138,14 @@ struct SnapGridApp: App {
 
             CommandGroup(replacing: .undoRedo) {
                 Button("Undo") {
-                    NotificationCenter.default.post(name: .undoDelete, object: nil)
+                    NotificationCenter.default.post(name: .undo, object: nil)
                 }
                 .keyboardShortcut("z")
 
-                Button("Redo") {}
-                    .keyboardShortcut("z", modifiers: [.command, .shift])
-                    .disabled(true)
+                Button("Redo") {
+                    NotificationCenter.default.post(name: .redo, object: nil)
+                }
+                .keyboardShortcut("z", modifiers: [.command, .shift])
 
                 Divider()
 
@@ -183,7 +184,8 @@ private struct SpacesMenuContent: View {
 
 extension Notification.Name {
     static let importFiles = Notification.Name("importFiles")
-    static let undoDelete = Notification.Name("undoDelete")
+    static let undo = Notification.Name("undo")
+    static let redo = Notification.Name("redo")
     static let apiKeySaved = Notification.Name("apiKeySaved")
     static let importElectronLibrary = Notification.Name("importElectronLibrary")
     static let willResetAllData = Notification.Name("willResetAllData")

--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -205,7 +205,8 @@ struct ContentView: View {
             onImportFiles: { showImportPanel = true },
             onImportElectron: { showElectronImport = true },
             onImportFolder: { handleFolderImport() },
-            onUndoDelete: { undoLastDelete() },
+            onUndo: { undoLast() },
+            onRedo: { redoLast() },
             onApiKeySaved: {
                 Task {
                     await importService.analyzeUnanalyzedItems(from: Array(allItems), context: modelContext)
@@ -681,9 +682,43 @@ struct ContentView: View {
         deleteItems(appState.selectedIds)
     }
 
-    private func undoLastDelete() {
-        guard let batch = appState.popDeleteBatch() else { return }
+    private func undoLast() {
+        guard let batch = appState.popUndoBatch() else { return }
+        switch batch {
+        case .deletion(let items):
+            appState.pushRedoBatch(.deletion(items))
+            restoreDeletedItems(items)
+        case .spaceChange(let changes):
+            let reverseSnapshot = changes.compactMap { change -> SpaceChangeInfo? in
+                guard let item = allItems.first(where: { $0.id == change.itemId }) else { return nil }
+                return SpaceChangeInfo(itemId: item.id, previousSpaceIds: item.orderedSpaceIDs)
+            }
+            appState.pushRedoBatch(.spaceChange(reverseSnapshot))
+            applySpaceChange(changes, toast: "Undid space change")
+        case .spaceDeletion(let info):
+            appState.pushRedoBatch(.spaceDeletion(info))
+            restoreDeletedSpace(info)
+        }
+    }
 
+    private func redoLast() {
+        guard let batch = appState.popRedoBatch() else { return }
+        switch batch {
+        case .deletion(let infos):
+            redoDeletion(infos)
+        case .spaceChange(let changes):
+            let reverseSnapshot = changes.compactMap { change -> SpaceChangeInfo? in
+                guard let item = allItems.first(where: { $0.id == change.itemId }) else { return nil }
+                return SpaceChangeInfo(itemId: item.id, previousSpaceIds: item.orderedSpaceIDs)
+            }
+            appState.pushUndoBatch(.spaceChange(reverseSnapshot))
+            applySpaceChange(changes, toast: "Redid space change")
+        case .spaceDeletion(let info):
+            reDeleteSpace(info)
+        }
+    }
+
+    private func restoreDeletedItems(_ batch: [DeletedItemInfo]) {
         syncWatcher.beginLocalChange()
         for info in batch {
             try? MediaStorageService.shared.restoreFromTrash(filename: info.filename, id: info.id)
@@ -722,6 +757,105 @@ struct ContentView: View {
         appState.showToast("Restored \(batch.count) item\(batch.count == 1 ? "" : "s")")
     }
 
+    private func redoDeletion(_ infos: [DeletedItemInfo]) {
+        let items = infos.compactMap { info in allItems.first(where: { $0.id == info.id }) }
+        guard !items.isEmpty else { return }
+
+        let batch = items.map { item in
+            let ar = item.analysisResult
+            return DeletedItemInfo(
+                id: item.id,
+                filename: item.filename,
+                mediaType: item.mediaType,
+                width: item.width,
+                height: item.height,
+                duration: item.duration,
+                spaceIds: item.orderedSpaceIDs,
+                imageContext: ar?.imageContext,
+                imageSummary: ar?.imageSummary,
+                patterns: ar?.patterns,
+                analyzedAt: ar?.analyzedAt,
+                analysisProvider: ar?.provider,
+                analysisModel: ar?.model
+            )
+        }
+        appState.pushUndoBatch(.deletion(batch))
+
+        syncWatcher.beginLocalChange()
+        for item in items {
+            try? MediaStorageService.shared.moveToTrash(filename: item.filename, id: item.id)
+            modelContext.delete(item)
+        }
+        modelContext.saveOrLog()
+        syncWatcher.endLocalChange()
+        appState.showToast("Moved \(items.count) item\(items.count == 1 ? "" : "s") to trash")
+    }
+
+    private func applySpaceChange(_ changes: [SpaceChangeInfo], toast: String) {
+        syncWatcher.beginLocalChange()
+        for change in changes {
+            guard let item = allItems.first(where: { $0.id == change.itemId }) else { continue }
+            let targetSpaces = spaces.filter { change.previousSpaceIds.contains($0.id) }
+            item.setMembership(targetSpaces)
+            MetadataSidecarService.shared.writeSidecar(for: item)
+        }
+        modelContext.saveOrLog()
+        syncWatcher.endLocalChange()
+        let count = changes.count
+        appState.showToast("\(toast) for \(count) item\(count == 1 ? "" : "s")")
+    }
+
+    private func restoreDeletedSpace(_ info: DeletedSpaceInfo) {
+        syncWatcher.beginLocalChange()
+        let space = Space(id: info.id, name: info.name, order: info.order, createdAt: info.createdAt)
+        space.customPrompt = info.customPrompt
+        space.useCustomPrompt = info.useCustomPrompt
+        modelContext.insert(space)
+
+        let memberItems = allItems.filter { info.itemIds.contains($0.id) }
+        for item in memberItems {
+            item.addSpace(space)
+            MetadataSidecarService.shared.writeSidecar(for: item)
+        }
+        modelContext.saveOrLog()
+        MetadataSidecarService.shared.writeSpaces(from: modelContext)
+        syncWatcher.endLocalChange()
+        appState.showToast("Restored space \"\(info.name)\"")
+    }
+
+    private func reDeleteSpace(_ info: DeletedSpaceInfo) {
+        guard let space = spaces.first(where: { $0.id == info.id }) else { return }
+
+        let freshSnapshot = DeletedSpaceInfo(
+            id: space.id,
+            name: space.name,
+            order: space.order,
+            createdAt: space.createdAt,
+            customPrompt: space.customPrompt,
+            useCustomPrompt: space.useCustomPrompt,
+            itemIds: space.items.map(\.id)
+        )
+        appState.pushUndoBatch(.spaceDeletion(freshSnapshot))
+
+        if appState.activeSpaceId == space.id {
+            appState.sidebarSelection = .all
+        }
+
+        syncWatcher.beginLocalChange()
+        let itemsToUpdate = space.items
+        for item in itemsToUpdate {
+            item.removeSpace(id: space.id)
+        }
+        modelContext.delete(space)
+        modelContext.saveOrLog()
+        MetadataSidecarService.shared.writeSpaces(from: modelContext)
+        for item in itemsToUpdate {
+            MetadataSidecarService.shared.writeSidecar(for: item)
+        }
+        syncWatcher.endLocalChange()
+        appState.showToast("Deleted space \"\(info.name)\"")
+    }
+
     private func createSpace() {
         syncWatcher.beginLocalChange()
         let space = Space(name: "New Space", order: spaces.count)
@@ -736,6 +870,18 @@ struct ContentView: View {
 
     private func deleteSpace(_ id: String) {
         guard let space = spaces.first(where: { $0.id == id }) else { return }
+
+        let snapshot = DeletedSpaceInfo(
+            id: space.id,
+            name: space.name,
+            order: space.order,
+            createdAt: space.createdAt,
+            customPrompt: space.customPrompt,
+            useCustomPrompt: space.useCustomPrompt,
+            itemIds: space.items.map(\.id)
+        )
+        appState.pushUndoBatch(.spaceDeletion(snapshot))
+        appState.clearRedoStack()
 
         if appState.activeSpaceId == id {
             appState.sidebarSelection = .all
@@ -785,7 +931,11 @@ struct ContentView: View {
 
     private func updateSpaceMembership(itemIds: Set<String>, action: SpaceMembershipAction) {
         let itemsToUpdate = allItems.filter { itemIds.contains($0.id) }
+        guard !itemsToUpdate.isEmpty else { return }
         var reanalyzeItems: [MediaItem] = []
+
+        let snapshot = itemsToUpdate.map { SpaceChangeInfo(itemId: $0.id, previousSpaceIds: $0.orderedSpaceIDs) }
+        appState.pushSpaceChangeBatch(snapshot)
 
         syncWatcher.beginLocalChange()
         for item in itemsToUpdate {
@@ -908,7 +1058,8 @@ private struct NotificationModifier: ViewModifier {
     let onImportFiles: () -> Void
     let onImportElectron: () -> Void
     let onImportFolder: () -> Void
-    let onUndoDelete: () -> Void
+    let onUndo: () -> Void
+    let onRedo: () -> Void
     let onApiKeySaved: () -> Void
     let onCreateNewSpace: () -> Void
     let onFocusSearch: () -> Void
@@ -927,8 +1078,11 @@ private struct NotificationModifier: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(for: .importFolder)) { _ in
                 onImportFolder()
             }
-            .onReceive(NotificationCenter.default.publisher(for: .undoDelete)) { _ in
-                onUndoDelete()
+            .onReceive(NotificationCenter.default.publisher(for: .undo)) { _ in
+                onUndo()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .redo)) { _ in
+                onRedo()
             }
             .onReceive(NotificationCenter.default.publisher(for: .apiKeySaved)) { _ in
                 onApiKeySaved()

--- a/SnapGrid/SnapGridTests/AppStateTests.swift
+++ b/SnapGrid/SnapGridTests/AppStateTests.swift
@@ -107,10 +107,42 @@ struct AppStateTests {
         let batch = [DeletedItemInfo(id: "1", filename: "test.png", mediaType: .image, width: 100, height: 100, duration: nil, spaceIds: [], imageContext: nil, imageSummary: nil, patterns: nil, analyzedAt: nil, analysisProvider: nil, analysisModel: nil)]
 
         state.pushDeleteBatch(batch)
-        let popped = state.popDeleteBatch()
+        guard case .deletion(let items) = state.popUndoBatch() else {
+            Issue.record("Expected deletion batch")
+            return
+        }
 
-        #expect(popped?.count == 1)
-        #expect(popped?[0].id == "1")
+        #expect(items.count == 1)
+        #expect(items[0].id == "1")
+    }
+
+    @Test("Push and pop space change batch")
+    func spaceChangeUndoStack() {
+        let state = AppState()
+        let changes = [SpaceChangeInfo(itemId: "item1", previousSpaceIds: ["spaceA", "spaceB"])]
+
+        state.pushSpaceChangeBatch(changes)
+        guard case .spaceChange(let popped) = state.popUndoBatch() else {
+            Issue.record("Expected space change batch")
+            return
+        }
+
+        #expect(popped.count == 1)
+        #expect(popped[0].itemId == "item1")
+        #expect(popped[0].previousSpaceIds == ["spaceA", "spaceB"])
+    }
+
+    @Test("Interleaved undo batches maintain LIFO order")
+    func interleavedUndoOrder() {
+        let state = AppState()
+        state.pushDeleteBatch([DeletedItemInfo(id: "del1", filename: "1.png", mediaType: .image, width: 1, height: 1, duration: nil, spaceIds: [], imageContext: nil, imageSummary: nil, patterns: nil, analyzedAt: nil, analysisProvider: nil, analysisModel: nil)])
+        state.pushSpaceChangeBatch([SpaceChangeInfo(itemId: "item1", previousSpaceIds: ["s1"])])
+        state.pushDeleteBatch([DeletedItemInfo(id: "del2", filename: "2.png", mediaType: .image, width: 1, height: 1, duration: nil, spaceIds: [], imageContext: nil, imageSummary: nil, patterns: nil, analyzedAt: nil, analysisProvider: nil, analysisModel: nil)])
+
+        guard case .deletion = state.popUndoBatch() else { Issue.record("Expected deletion"); return }
+        guard case .spaceChange = state.popUndoBatch() else { Issue.record("Expected space change"); return }
+        guard case .deletion = state.popUndoBatch() else { Issue.record("Expected deletion"); return }
+        #expect(state.popUndoBatch() == nil)
     }
 
     @Test("Undo stack caps at 20 batches")
@@ -121,15 +153,71 @@ struct AppStateTests {
             state.pushDeleteBatch(batch)
         }
 
-        #expect(state.deletedBatches.count == 20)
-        // Oldest batches should have been removed
-        #expect(state.deletedBatches.first?[0].id == "5")
+        #expect(state.undoStack.count == 20)
+        guard case .deletion(let first) = state.undoStack.first else {
+            Issue.record("Expected deletion batch")
+            return
+        }
+        #expect(first[0].id == "5")
     }
 
     @Test("Pop from empty stack returns nil")
     func popEmptyStack() {
         let state = AppState()
-        #expect(state.popDeleteBatch() == nil)
+        #expect(state.popUndoBatch() == nil)
+        #expect(state.popRedoBatch() == nil)
+    }
+
+    // MARK: - Redo Stack
+
+    @Test("Push and pop redo batch")
+    func redoStack() {
+        let state = AppState()
+        let changes = [SpaceChangeInfo(itemId: "item1", previousSpaceIds: ["s1"])]
+        state.pushRedoBatch(.spaceChange(changes))
+
+        guard case .spaceChange(let popped) = state.popRedoBatch() else {
+            Issue.record("Expected space change batch")
+            return
+        }
+        #expect(popped.count == 1)
+        #expect(popped[0].itemId == "item1")
+    }
+
+    @Test("New action clears redo stack")
+    func newActionClearsRedo() {
+        let state = AppState()
+        state.pushRedoBatch(.spaceChange([SpaceChangeInfo(itemId: "item1", previousSpaceIds: ["s1"])]))
+        #expect(state.redoStack.count == 1)
+
+        state.pushSpaceChangeBatch([SpaceChangeInfo(itemId: "item2", previousSpaceIds: ["s2"])])
+        #expect(state.redoStack.isEmpty)
+    }
+
+    @Test("Redo stack caps at 20 batches")
+    func redoStackCap() {
+        let state = AppState()
+        for i in 0..<25 {
+            state.pushRedoBatch(.spaceChange([SpaceChangeInfo(itemId: "\(i)", previousSpaceIds: [])]))
+        }
+        #expect(state.redoStack.count == 20)
+    }
+
+    @Test("Push and pop space deletion batch")
+    func spaceDeletionUndoStack() {
+        let state = AppState()
+        let info = DeletedSpaceInfo(id: "s1", name: "Design", order: 0, createdAt: .now, customPrompt: "Analyze design", useCustomPrompt: true, itemIds: ["item1", "item2"])
+        state.pushUndoBatch(.spaceDeletion(info))
+
+        guard case .spaceDeletion(let popped) = state.popUndoBatch() else {
+            Issue.record("Expected space deletion batch")
+            return
+        }
+        #expect(popped.id == "s1")
+        #expect(popped.name == "Design")
+        #expect(popped.itemIds == ["item1", "item2"])
+        #expect(popped.customPrompt == "Analyze design")
+        #expect(popped.useCustomPrompt == true)
     }
 
     // MARK: - Zoom


### PR DESCRIPTION
### Why?

Space membership changes (adding/removing items from spaces) and space deletion were irreversible — Cmd+Z only undid item deletions, so accidentally moving an item to the wrong space or deleting a space had no recovery path.

### How?

Replaces the deletion-only undo stack with a unified `UndoBatch` enum that holds deletion, space membership, and space deletion snapshots in a single LIFO stack. Undo captures a reverse snapshot before restoring, enabling symmetric redo via Cmd+Shift+Z. New actions automatically clear the redo stack.

<details>
<summary>Implementation Plan</summary>

# Plan: Undo support for space membership changes

## Context

When a user adds/removes an item from a space in the Mac app, Cmd+Z doesn't undo it. The app has a custom undo stack for deletions only — space mutations bypass it entirely. This plan unifies the undo stack so Cmd+Z undoes whichever action happened most recently (deletion or space change).

## Approach

Replace the deletion-only `deletedBatches` stack with a unified `undoStack` that holds an enum of either deletion or space-change snapshots. Before each space mutation, snapshot every affected item's current space IDs. On undo, restore those IDs via `setMembership`.

## Changes

### 1. `SnapGrid/SnapGrid/App/AppState.swift`

- Add `SpaceChangeInfo` struct (itemId + previousSpaceIds)
- Add `UndoBatch` enum: `.deletion([DeletedItemInfo])` | `.spaceChange([SpaceChangeInfo])`
- Replace `deletedBatches: [[DeletedItemInfo]]` with `undoStack: [UndoBatch]`
- Replace `pushDeleteBatch`/`popDeleteBatch` with `pushUndoBatch`/`popUndoBatch`
- Keep `pushDeleteBatch` as a convenience wrapper calling `pushUndoBatch(.deletion(...))`
- Add `pushSpaceChangeBatch` convenience wrapper

### 2. `SnapGrid/SnapGrid/Views/ContentView/ContentView.swift`

- **`updateSpaceMembership`** (~line 797): Before mutating, snapshot each item's `orderedSpaceIDs` into a `[SpaceChangeInfo]` and push onto undo stack. Add early return guard if `itemsToUpdate` is empty.
- **Add `undoLastSpaceChange(_ changes:)`**: Restores each item's spaces via `setMembership`, saves, writes sidecars, shows toast.
- **Add `undoLast()`**: Pops from unified stack, dispatches to `restoreDeletedItems` or `undoLastSpaceChange`.
- **Rename `undoLastDelete()`** → `restoreDeletedItems(_ batch:)`, accept batch as parameter instead of popping from stack.
- **`NotificationModifier`**: Rename `onUndoDelete` property to `onUndo`, update `.onReceive` to listen for `.undo`.
- **Call site** (~line 208): Change `onUndoDelete: { undoLastDelete() }` → `onUndo: { undoLast() }`.

### 3. `SnapGrid/SnapGrid/App/SnapGridApp.swift`

- Rename notification `.undoDelete` → `.undo` (line 186)
- Update Cmd+Z handler to post `.undo` (line 141)

### 4. `SnapGrid/SnapGridTests/AppStateTests.swift`

- Update existing deletion undo tests to use new `popUndoBatch()` API with pattern matching
- Update `deletedBatches.count` → `undoStack.count`
- Add test for space change push/pop
- Add test for interleaved undo ordering (LIFO across both types)

## Edge cases handled

- **Item deleted after space change**: `undoLastSpaceChange` skips missing items gracefully
- **Space deleted after space change**: `spaces.filter` won't find deleted spaces — item gets restored to remaining spaces only
- **Empty selection**: Guard prevents pushing empty snapshot onto stack
- **Re-analysis not undone**: Intentionally left alone (too complex, analysis data persists)

## Verification

1. `cd SnapGrid && xcodegen generate && xcodebuild test -project SnapGrid.xcodeproj -scheme SnapGrid -destination 'platform=macOS' 2>&1 | xcbeautify --quiet`
2. Build and run the app, add an item to a space, press Cmd+Z — item should leave the space
3. Remove an item from a space, press Cmd+Z — item should rejoin the space
4. Delete an item, then add another to a space, press Cmd+Z twice — should undo space change first, then restore deleted item

</details>

<sub>Generated with Claude Code</sub>