### PR TITLE
Fix SnapGrid 1 import for sandboxed builds

### DIFF
--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -15,7 +15,7 @@ struct ContentView: View {
     @State private var syncWatcher = SyncWatcher()
     @State private var isDragTargeted = false
     @State private var pendingEditSpaceId: String?
-    @State private var showElectronImport = false
+    @State private var electronImportURL: URL?
     @State private var showImportPanel = false
     @State private var debounceTask: Task<Void, Never>?
     @State private var indexRebuildTask: Task<Void, Never>?
@@ -25,7 +25,6 @@ struct ContentView: View {
     @State private var isSearchFieldPresented = false
     @State private var shareAnchorView: NSView?
     @State private var columnVisibility: NavigationSplitViewVisibility = .detailOnly
-    @State private var electronLibraryDetected = false
 
     #if DEBUG
     @AppStorage("debugSimulateEmptyState") private var debugSimulateEmptyState = false
@@ -203,7 +202,7 @@ struct ContentView: View {
         )
         .modifier(NotificationModifier(
             onImportFiles: { showImportPanel = true },
-            onImportElectron: { showElectronImport = true },
+            onImportElectron: { handleElectronImport() },
             onImportFolder: { handleFolderImport() },
             onUndo: { undoLast() },
             onRedo: { redoLast() },
@@ -229,9 +228,17 @@ struct ContentView: View {
             },
             onPasteImages: { handlePaste() }
         ))
-        .sheet(isPresented: $showElectronImport) {
-            ElectronImportView(isPresented: $showElectronImport)
+        .sheet(isPresented: Binding(
+            get: { electronImportURL != nil },
+            set: { if !$0 { electronImportURL = nil } }
+        )) {
+            if let url = electronImportURL {
+                ElectronImportView(isPresented: Binding(
+                    get: { electronImportURL != nil },
+                    set: { if !$0 { electronImportURL = nil } }
+                ), initialLibraryURL: url)
                 .presentationBackground(Color.snapCard)
+            }
         }
         .alert("Analysis Failed", isPresented: Binding(
             get: { importService.analysisAlertError != nil },
@@ -241,8 +248,8 @@ struct ContentView: View {
         } message: {
             Text(importService.analysisAlertError ?? "")
         }
-        .onChange(of: showElectronImport) { _, isPresented in
-            if !isPresented {
+        .onChange(of: electronImportURL) { old, new in
+            if old != nil && new == nil {
                 syncWatcher.beginLocalChange()
                 syncWatcher.endLocalChange()
             }
@@ -290,8 +297,6 @@ struct ContentView: View {
             DataCleanupService.cleanOrphanedRecords(context: modelContext)
             DataCleanupService.cleanOrphanedSidecars()
             await DataCleanupService.migrateVideoDimensions(context: modelContext)
-
-            electronLibraryDetected = ElectronImportService().detectElectronLibrary() != nil
 
             // Sync items that arrived via iCloud while app was closed
             await syncWatcher.initialSync(context: modelContext)
@@ -389,7 +394,7 @@ struct ContentView: View {
     private var detailContent: some View {
         let items = activeFilteredItems
         if allItems.isEmpty || debugSimulateEmptyState {
-            EmptyStateView(electronLibraryDetected: electronLibraryDetected, isDragTargeted: isDragTargeted)
+            EmptyStateView(isDragTargeted: isDragTargeted)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if items.isEmpty && isSearchActive {
             VStack(spacing: 12) {
@@ -448,6 +453,24 @@ struct ContentView: View {
                 syncWatcher.endLocalChange()
             }
         }
+    }
+
+    private func handleElectronImport() {
+        let service = ElectronImportService()
+        if let detected = service.detectElectronLibrary() {
+            electronImportURL = detected
+            return
+        }
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.message = "Select your SnapGrid 1 library folder"
+        panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Documents")
+        guard panel.runModal() == .OK, let url = panel.url,
+              service.validateLibraryFolder(url) else { return }
+        electronImportURL = url
     }
 
     private func handleFolderImport() {

--- a/SnapGrid/SnapGrid/Views/Grid/EmptyStateView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/EmptyStateView.swift
@@ -7,7 +7,6 @@ struct EmptyStateView: View {
     }
 
     var mode: Mode = .appLevel
-    var electronLibraryDetected: Bool = false
     var isDragTargeted: Bool = false
 
     // Random-looking heights for skeleton placeholders
@@ -54,23 +53,17 @@ struct EmptyStateView: View {
                             .font(.title3.weight(.semibold))
                             .foregroundStyle(.primary)
 
-                        Text(mode == .appLevel ? "Drop files here, or use File \u{2192} Import (\u{2318}O)" : "Drop images here or move items from All")
+                        Text(mode == .appLevel ? "Drop files here or import a folder to get started.\nIf you have a SnapGrid 1.0 library, select it to migrate." : "Drop images here or move items from All")
                             .font(.body)
                             .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
                     }
 
                     if mode == .appLevel {
-                        if electronLibraryDetected {
-                            Button("Import from SnapGrid") {
-                                NotificationCenter.default.post(name: .importElectronLibrary, object: nil)
-                            }
-                            .controlSize(.large)
-                        } else {
-                            Button("Import") {
-                                NotificationCenter.default.post(name: .importFolder, object: nil)
-                            }
-                            .controlSize(.large)
+                        Button("Import") {
+                            NotificationCenter.default.post(name: .importElectronLibrary, object: nil)
                         }
+                        .controlSize(.large)
                     }
 
                     if mode == .appLevel,
@@ -90,6 +83,7 @@ struct EmptyStateView: View {
                         }
                     }
                 }
+                .frame(maxWidth: 360)
                 .padding(40)
                 .background(
                     RoundedRectangle(cornerRadius: 16)

--- a/SnapGrid/SnapGrid/Views/Shared/ElectronImportView.swift
+++ b/SnapGrid/SnapGrid/Views/Shared/ElectronImportView.swift
@@ -6,20 +6,19 @@ struct ElectronImportView: View {
     @Binding var isPresented: Bool
 
     @State private var importService = ElectronImportService()
+    var initialLibraryURL: URL
     @State private var libraryURL: URL?
     @State private var itemCount = 0
 
     private enum Phase {
-        case detecting, ready, importing, done
+        case ready, importing, done
     }
 
-    @State private var phase: Phase = .detecting
+    @State private var phase: Phase = .ready
 
     var body: some View {
         VStack(spacing: 0) {
             switch phase {
-            case .detecting:
-                detectingView
             case .ready:
                 readyView
             case .importing:
@@ -30,42 +29,13 @@ struct ElectronImportView: View {
         }
         .frame(width: 400)
         .fixedSize(horizontal: false, vertical: true)
-        .task {
-            if let detected = importService.detectElectronLibrary() {
-                libraryURL = detected
-                itemCount = importService.countItems(in: detected)
-                phase = .ready
-            } else {
-                phase = .detecting
-            }
+        .onAppear {
+            libraryURL = initialLibraryURL
+            itemCount = importService.countItems(in: initialLibraryURL)
         }
     }
 
     // MARK: - Phases
-
-    private var detectingView: some View {
-        VStack(spacing: 20) {
-            Image(systemName: "questionmark.folder")
-                .font(.system(size: 36, weight: .light))
-                .foregroundStyle(.secondary)
-
-            VStack(spacing: 6) {
-                Text("SnapGrid 1 Library Not Found")
-                    .font(.headline)
-                Text("No library found at ~/Documents/SnapGrid/")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            HStack(spacing: 12) {
-                Button("Cancel") { isPresented = false }
-                    .keyboardShortcut(.cancelAction)
-                Button("Choose Folder...") { pickFolder() }
-                    .keyboardShortcut(.defaultAction)
-            }
-        }
-        .padding(32)
-    }
 
     private var readyView: some View {
         VStack(spacing: 20) {
@@ -178,6 +148,8 @@ struct ElectronImportView: View {
         panel.canChooseFiles = false
         panel.allowsMultipleSelection = false
         panel.message = "Select your SnapGrid 1 library folder"
+        panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Documents")
 
         let response = panel.runModal()
         if response == .OK, let url = panel.url {


### PR DESCRIPTION
### Why?

The Mac app is sandboxed with `user-selected.read-write` file access only. `FileManager.fileExists()` silently returns `false` for `~/Documents/SnapGrid` in production builds (sandbox relaxed in Xcode debug), causing a false "SnapGrid 1 Library Not Found" message even when the library exists on the machine.

### How?

Moved detection + folder picker logic to ContentView so NSOpenPanel opens directly when auto-detection fails — the import sheet only appears once a valid folder is selected. Empty state always shows the Import button with SnapGrid 1.0 migration guidance, removing the unreliable sandbox-based detection gate.

<details>
<summary>Implementation Plan</summary>

# Fix SnapGrid 1 library detection under sandbox

## Context

The Mac app is **sandboxed** (`com.apple.security.app-sandbox: true`) with only `user-selected.read-write` file access. `ElectronImportService.detectElectronLibrary()` uses `FileManager.fileExists()` on `~/Documents/SnapGrid/`, but sandboxed apps can't access `~/Documents/` without prior user selection via NSOpenPanel. This works in Xcode debug builds (sandbox relaxed) but **fails in production** — showing "SnapGrid 1 Library Not Found" even when the library exists.

## Changes

### 1. Fix misleading "Not Found" messaging
**File:** `SnapGrid/SnapGrid/Views/Shared/ElectronImportView.swift`

In `detectingView` (lines 52-57), change:
- `"SnapGrid 1 Library Not Found"` → `"Import"`
- `"No library found at ~/Documents/SnapGrid/"` → `"If you used SnapGrid before, select your library folder from ~/Documents/SnapGrid."`

The dialog already has a "Choose Folder..." button. The messaging should guide, not alarm.

### 2. Pre-populate NSOpenPanel directory
**File:** `SnapGrid/SnapGrid/Views/Shared/ElectronImportView.swift`

In `pickFolder()` (after line 180), add:
```swift
panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
    .appendingPathComponent("Documents")
```
So the user starts one click from `SnapGrid/` instead of navigating from scratch.

### 3. Always show "Import" button in empty state
**File:** `SnapGrid/SnapGrid/Views/Grid/EmptyStateView.swift` (lines 62-73)

Remove the `if/else electronLibraryDetected` branch. Always show an "Import" button posting `.importElectronLibrary`. The old `else` branch posted `.importFolder` (a completely different generic folder import flow that doesn't understand SnapGrid 1 metadata/spaces). The label stays "Import" — the dialog itself explains the SnapGrid 1 option.

### 4. Clean up dead state
Since `electronLibraryDetected` is no longer consumed:

| File | Line | Remove |
|------|------|--------|
| `ContentView.swift` | 28 | `@State private var electronLibraryDetected = false` |
| `ContentView.swift` | 293 | `electronLibraryDetected = ElectronImportService().detectElectronLibrary() != nil` |
| `ContentView.swift` | 391 | `electronLibraryDetected: electronLibraryDetected` arg from `EmptyStateView(...)` |
| `EmptyStateView.swift` | 10 | `var electronLibraryDetected: Bool = false` property |

## What stays unchanged
- `detectElectronLibrary()` still runs in `ElectronImportView.task` — works when sandbox has access (debug, or after prior NSOpenPanel)
- Menu item "Import from SnapGrid 1..." always visible
- `pickFolder()` validation logic still validates selected folder
- No new entitlements added

</details>

<sub>Generated with Claude Code</sub>