### PR TITLE
Auto-import folders without confirmation modals

### DIFF
--- a/SnapGrid/SnapGrid/App/SnapGridApp.swift
+++ b/SnapGrid/SnapGrid/App/SnapGridApp.swift
@@ -70,7 +70,7 @@ struct SnapGridApp: App {
                 }
                 .keyboardShortcut("o")
 
-                Button("Import from SnapGrid 1...") {
+                Button("Import Folder...") {
                     NotificationCenter.default.post(name: .importElectronLibrary, object: nil)
                 }
                 .keyboardShortcut("i", modifiers: [.command, .shift])

--- a/SnapGrid/SnapGrid/Services/ImportService.swift
+++ b/SnapGrid/SnapGrid/Services/ImportService.swift
@@ -24,11 +24,17 @@ final class ImportService {
     func importFiles(_ urls: [URL], into context: ModelContext, spaceId: String? = nil) async {
         for url in urls {
             do {
-                try await importSingleFile(url, into: context, spaceId: spaceId)
+                try await importSingleFile(url, into: context, spaceId: spaceId, analyze: false)
             } catch {
                 print("[ImportService] Failed to import \(url.lastPathComponent): \(error)")
             }
+            await Task.yield()
         }
+
+        let unanalyzed = (try? context.fetch(FetchDescriptor<MediaItem>()))?.filter {
+            $0.analysisResult == nil && $0.analysisError == nil && !$0.isAnalyzing
+        } ?? []
+        await analyzeUnanalyzedItems(from: unanalyzed, context: context)
     }
 
     /// Import a raw NSImage (e.g. from pasteboard or browser drag) — converts to PNG and runs the full pipeline.
@@ -73,7 +79,7 @@ final class ImportService {
         }
     }
 
-    func importSingleFile(_ url: URL, into context: ModelContext, spaceId: String?, sourceURL: String? = nil) async throws {
+    func importSingleFile(_ url: URL, into context: ModelContext, spaceId: String?, sourceURL: String? = nil, analyze: Bool = true) async throws {
         let accessed = url.startAccessingSecurityScopedResource()
         defer { if accessed { url.stopAccessingSecurityScopedResource() } }
 
@@ -145,9 +151,10 @@ final class ImportService {
         try context.save()
         sidecarService.writeSidecar(for: item)
 
-        // Queue AI analysis in background
-        Task { @MainActor [weak self] in
-            await self?.analyzeItem(item, context: context)
+        if analyze {
+            Task { @MainActor [weak self] in
+                await self?.analyzeItem(item, context: context)
+            }
         }
     }
 

--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -465,12 +465,16 @@ struct ContentView: View {
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
         panel.allowsMultipleSelection = false
-        panel.message = "Select your SnapGrid 1 library folder"
+        panel.message = "Select your SnapGrid 1 library folder or a folder with images"
         panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Documents")
-        guard panel.runModal() == .OK, let url = panel.url,
-              service.validateLibraryFolder(url) else { return }
-        electronImportURL = url
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        if service.validateLibraryFolder(url) {
+            electronImportURL = url
+        } else {
+            importFolderContents(url)
+        }
     }
 
     private func handleFolderImport() {
@@ -481,9 +485,11 @@ struct ContentView: View {
         panel.message = "Choose a folder to import media from"
         panel.prompt = "Import"
 
-        let response = panel.runModal()
-        guard response == .OK, let folderURL = panel.url else { return }
+        guard panel.runModal() == .OK, let folderURL = panel.url else { return }
+        importFolderContents(folderURL)
+    }
 
+    private func importFolderContents(_ folderURL: URL) {
         guard let enumerator = FileManager.default.enumerator(
             at: folderURL,
             includingPropertiesForKeys: [.isRegularFileKey],

--- a/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
+++ b/SnapGrid/SnapGrid/Views/ContentView/ContentView.swift
@@ -465,7 +465,7 @@ struct ContentView: View {
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
         panel.allowsMultipleSelection = false
-        panel.message = "Select your SnapGrid 1 library folder or a folder with images"
+        panel.message = "Select a folder with your media"
         panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Documents")
         guard panel.runModal() == .OK, let url = panel.url else { return }

--- a/SnapGrid/SnapGrid/Views/Grid/EmptyStateView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/EmptyStateView.swift
@@ -53,7 +53,7 @@ struct EmptyStateView: View {
                             .font(.title3.weight(.semibold))
                             .foregroundStyle(.primary)
 
-                        Text(mode == .appLevel ? "Drop files here or import a folder to get started." : "Drop images here or move items from All")
+                        Text(mode == .appLevel ? "Drop files here or import a folder to get started.\nIf you have a SnapGrid 1.0 library, select it to migrate." : "Drop images here or move items from All")
                             .font(.body)
                             .foregroundStyle(.secondary)
                             .multilineTextAlignment(.center)

--- a/SnapGrid/SnapGrid/Views/Grid/EmptyStateView.swift
+++ b/SnapGrid/SnapGrid/Views/Grid/EmptyStateView.swift
@@ -53,7 +53,7 @@ struct EmptyStateView: View {
                             .font(.title3.weight(.semibold))
                             .foregroundStyle(.primary)
 
-                        Text(mode == .appLevel ? "Drop files here or import a folder to get started.\nIf you have a SnapGrid 1.0 library, select it to migrate." : "Drop images here or move items from All")
+                        Text(mode == .appLevel ? "Drop files here or import a folder to get started." : "Drop images here or move items from All")
                             .font(.body)
                             .foregroundStyle(.secondary)
                             .multilineTextAlignment(.center)

--- a/SnapGrid/SnapGrid/Views/Shared/ElectronImportView.swift
+++ b/SnapGrid/SnapGrid/Views/Shared/ElectronImportView.swift
@@ -8,31 +8,7 @@ struct ElectronImportView: View {
     @State private var importService = ElectronImportService()
     var initialLibraryURL: URL
 
-    private enum Phase {
-        case importing, done
-    }
-
-    @State private var phase: Phase = .importing
-
     var body: some View {
-        VStack(spacing: 0) {
-            switch phase {
-            case .importing:
-                importingView
-            case .done:
-                doneView
-            }
-        }
-        .frame(width: 400)
-        .fixedSize(horizontal: false, vertical: true)
-        .onAppear {
-            startImport()
-        }
-    }
-
-    // MARK: - Phases
-
-    private var importingView: some View {
         VStack(spacing: 20) {
             VStack(spacing: 8) {
                 Text("Importing...")
@@ -59,52 +35,13 @@ struct ElectronImportView: View {
             }
         }
         .padding(32)
-    }
-
-    private var doneView: some View {
-        VStack(spacing: 20) {
-            let result = importService.importResult
-
-            Image(systemName: "checkmark.circle")
-                .font(.system(size: 36, weight: .light))
-                .foregroundStyle(.green)
-
-            VStack(spacing: 6) {
-                Text("Import Complete")
-                    .font(.headline)
-
-                if let result {
-                    VStack(spacing: 2) {
-                        Text("\(result.itemsImported) items imported")
-                        if result.spacesImported > 0 {
-                            Text("\(result.spacesImported) spaces created")
-                        }
-                        if result.duplicatesSkipped > 0 {
-                            Text("\(result.duplicatesSkipped) duplicates skipped")
-                        }
-                        if result.errors > 0 {
-                            Text("\(result.errors) errors")
-                                .foregroundStyle(.red)
-                        }
-                    }
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                }
+        .frame(width: 400)
+        .fixedSize(horizontal: false, vertical: true)
+        .onAppear {
+            Task {
+                await importService.importLibrary(from: initialLibraryURL, into: modelContext)
+                isPresented = false
             }
-
-            Button("Done") { isPresented = false }
-                .keyboardShortcut(.defaultAction)
-        }
-        .padding(32)
-    }
-
-    // MARK: - Actions
-
-    private func startImport() {
-        phase = .importing
-        Task {
-            await importService.importLibrary(from: initialLibraryURL, into: modelContext)
-            phase = .done
         }
     }
 }

--- a/SnapGrid/SnapGrid/Views/Shared/ElectronImportView.swift
+++ b/SnapGrid/SnapGrid/Views/Shared/ElectronImportView.swift
@@ -7,20 +7,16 @@ struct ElectronImportView: View {
 
     @State private var importService = ElectronImportService()
     var initialLibraryURL: URL
-    @State private var libraryURL: URL?
-    @State private var itemCount = 0
 
     private enum Phase {
-        case ready, importing, done
+        case importing, done
     }
 
-    @State private var phase: Phase = .ready
+    @State private var phase: Phase = .importing
 
     var body: some View {
         VStack(spacing: 0) {
             switch phase {
-            case .ready:
-                readyView
             case .importing:
                 importingView
             case .done:
@@ -30,49 +26,11 @@ struct ElectronImportView: View {
         .frame(width: 400)
         .fixedSize(horizontal: false, vertical: true)
         .onAppear {
-            libraryURL = initialLibraryURL
-            itemCount = importService.countItems(in: initialLibraryURL)
+            startImport()
         }
     }
 
     // MARK: - Phases
-
-    private var readyView: some View {
-        VStack(spacing: 20) {
-            Image(systemName: "square.and.arrow.down.on.square")
-                .font(.system(size: 36, weight: .light))
-                .foregroundStyle(Color.snapAccent)
-
-            VStack(spacing: 6) {
-                Text("Import from SnapGrid 1")
-                    .font(.headline)
-                Text("Found \(itemCount) items at:")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                Text(libraryURL?.path.replacingOccurrences(of: FileManager.default.homeDirectoryForCurrentUser.path, with: "~") ?? "")
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-            }
-
-            Text("Your screenshots, spaces, and analysis results will be copied over. Nothing in your original library will be changed.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 320)
-
-            HStack(spacing: 12) {
-                Button("Cancel") { isPresented = false }
-                    .keyboardShortcut(.cancelAction)
-                Button("Choose Folder...") { pickFolder() }
-                Button("Import") { startImport() }
-                    .keyboardShortcut(.defaultAction)
-                    .disabled(itemCount == 0)
-            }
-        }
-        .padding(32)
-    }
 
     private var importingView: some View {
         VStack(spacing: 20) {
@@ -142,30 +100,10 @@ struct ElectronImportView: View {
 
     // MARK: - Actions
 
-    private func pickFolder() {
-        let panel = NSOpenPanel()
-        panel.canChooseDirectories = true
-        panel.canChooseFiles = false
-        panel.allowsMultipleSelection = false
-        panel.message = "Select your SnapGrid 1 library folder"
-        panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Documents")
-
-        let response = panel.runModal()
-        if response == .OK, let url = panel.url {
-            if importService.validateLibraryFolder(url) {
-                libraryURL = url
-                itemCount = importService.countItems(in: url)
-                phase = .ready
-            }
-        }
-    }
-
     private func startImport() {
-        guard let url = libraryURL else { return }
         phase = .importing
         Task {
-            await importService.importLibrary(from: url, into: modelContext)
+            await importService.importLibrary(from: initialLibraryURL, into: modelContext)
             phase = .done
         }
     }


### PR DESCRIPTION
### Why?

The SnapGrid 1 import flow required clicking through a confirmation modal before and after importing — unnecessary friction since the user already decided to import by selecting the folder. Additionally, selecting a folder with just images (not a SnapGrid 1 library) silently failed instead of importing the files.

### How?

Stripped the confirmation and completion phases from `ElectronImportView` so it auto-starts on appear and auto-dismisses on completion. When the selected folder isn't a valid SnapGrid 1 library, it falls back to importing all supported media files. Bulk folder imports now defer AI analysis and yield between files to keep the UI responsive.

<details>
<summary>Implementation Plan</summary>

# Plan: Auto-import folders without confirmation modal

## Context

When a user triggers "Import from SnapGrid 1..." (Cmd+Shift+I), the app currently shows a confirmation modal before importing. This is unnecessary friction — the user already decided to import by selecting the folder. Additionally, if the user picks a folder that isn't a valid SnapGrid 1 library (just has images, no `metadata/` subdir), the import silently fails instead of importing the images.

## Changes

### 1. Auto-start import in ElectronImportView (skip confirmation phase)

**File:** `SnapGrid/SnapGrid/Views/Shared/ElectronImportView.swift`

- Remove the `.ready` case from the `Phase` enum — only keep `.importing` and `.done`
- Remove `readyView` (lines 40-75) and `pickFolder()` method (lines 145-161)
- Remove the `itemCount` state variable (no longer displayed)
- Simplify `libraryURL` state — use `initialLibraryURL` directly
- Change `onAppear` to call `startImport()` immediately instead of just counting items
- Start `phase` at `.importing`

### 2. Fall back to folder import for non-SnapGrid-1 folders

**File:** `SnapGrid/SnapGrid/Views/ContentView/ContentView.swift`

- Extract file enumeration + import logic from `handleFolderImport()` into a new `importFolderContents(_ folderURL: URL)` method
- Modify `handleElectronImport()`: when NSOpenPanel returns a folder that fails `validateLibraryFolder()`, call `importFolderContents()` instead of returning silently
- Update the NSOpenPanel message to reflect dual-purpose: "Select your SnapGrid 1 library folder or a folder with images"
- `handleFolderImport()` calls `importFolderContents()` after its own panel

### 3. No changes needed

- `ElectronImportService.swift` — detection/validation logic stays the same
- `SnapGridApp.swift` — menu item label "Import from SnapGrid 1..." stays (it's still the primary purpose)

## Verification

1. Build: `cd SnapGrid && xcodegen generate && xcodebuild build -project SnapGrid.xcodeproj -scheme SnapGrid -destination 'platform=macOS' 2>&1 | xcbeautify --quiet`
2. Run existing tests: `cd SnapGrid && xcodebuild test -project SnapGrid.xcodeproj -scheme SnapGrid -destination 'platform=macOS' 2>&1 | xcbeautify --quiet`
3. Manual: Cmd+Shift+I with a SnapGrid 1 folder → should start importing immediately (progress bar, then done)
4. Manual: Cmd+Shift+I → pick a folder with only images → should import them into the grid

</details>

<sub>Generated with Claude Code</sub>