### PR TITLE
Fix iOS retry button padding and tap handling

### DIFF
--- a/ios/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift
@@ -107,27 +107,6 @@ struct GridItemView: View {
                         removal: .opacity
                     )
                 )
-            } else if !item.isAnalyzing && item.analysisError != nil {
-                Button {
-                    onRetryAnalysis?()
-                } label: {
-                    HStack(spacing: 4) {
-                        Image(systemName: "arrow.clockwise")
-                            .font(.caption2)
-                        Text("Retry")
-                            .font(.caption2.weight(.medium))
-                    }
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(.red.opacity(0.7))
-                    .clipShape(RoundedRectangle(cornerRadius: 6))
-                    .frame(minWidth: 44, minHeight: 44)
-                    .contentShape(Rectangle())
-                }
-                .padding(8)
-                .frame(width: width, height: height, alignment: .bottomLeading)
-                .transition(.opacity.combined(with: .scale(scale: 0.8)))
             }
         }
         .frame(width: width, height: height)
@@ -150,6 +129,29 @@ struct GridItemView: View {
                     )
             }
         )
+        .overlay(alignment: .bottomLeading) {
+            if !item.isAnalyzing && item.analysisError != nil {
+                Button {
+                    onRetryAnalysis?()
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.caption2)
+                        Text("Retry")
+                            .font(.caption2.weight(.medium))
+                    }
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(.red.opacity(0.7))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                    .frame(minWidth: 44, minHeight: 44, alignment: .bottomLeading)
+                    .contentShape(Rectangle())
+                }
+                .padding(8)
+                .transition(.opacity.combined(with: .scale(scale: 0.8)))
+            }
+        }
         .contextMenu {
             Button {
                 onShare?()


### PR DESCRIPTION
### Why?

The retry button on iOS grid items had two bugs: the bottom padding was visibly larger than the side padding, and tapping the button opened the image instead of triggering retry.

### How?

Moved the retry button from the inner ZStack to a separate `.overlay` placed above the tap gesture overlay in the view hierarchy, so it receives taps. Added `alignment: .bottomLeading` to the 44pt accessibility frame so the visual button sits flush with the padding edges.

<details>
<summary>Implementation Plan</summary>

## Root causes

### Padding: centered content in min-size frame
`.frame(minWidth: 44, minHeight: 44)` centers the ~19pt-tall visual button in a 44pt frame, adding ~12.5pt of invisible space below it.

### Tap: overlay intercepts all touches
A `Color.clear.contentShape(Rectangle()).onTapGesture` overlay covers the entire grid item and sits **above** the retry button in the view hierarchy. It captures all taps and calls `onSelect` (image open), so the retry `Button` never receives the tap.

## Fix

**File:** `ios/SnapGrid/SnapGrid/Views/Grid/GridItemView.swift`

### Change 1: Move retry button above the tap overlay
Move the retry button out of the ZStack and into a separate `.overlay(alignment: .bottomLeading)` placed **after** the tap gesture overlay. This way the retry button sits on top of the tap overlay and captures taps in its area, while taps elsewhere still open the image.

### Change 2: Fix padding alignment
Change `.frame(minWidth: 44, minHeight: 44)` to `.frame(minWidth: 44, minHeight: 44, alignment: .bottomLeading)` so the visual button aligns to the corner of the accessibility tap target.

</details>

<sub>Generated with Claude Code</sub>