### PR TITLE
Fix white trash icon in iOS context menu delete actions

### DIFF
--- a/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
+++ b/ios/SnapGrid/SnapGrid/Views/Main/MainView.swift
@@ -242,7 +242,7 @@ struct MainView: View {
             }
             .tabBarMinimizeBehavior(.onScrollDown)
             .tabViewSearchActivation(.searchTabSelection)
-            .tint(.white)
+            .toolbarColorScheme(.dark, for: .tabBar)
         } else {
             TabView(selection: $appState.selectedTab) {
                 allItemsContent(gridWidth: gridWidth)
@@ -252,7 +252,7 @@ struct MainView: View {
                     .tabItem { Label("Spaces", systemImage: "folder") }
                     .tag(AppTab.spaces)
             }
-            .tint(.white)
+            .toolbarColorScheme(.dark, for: .tabBar)
         }
     }
 


### PR DESCRIPTION
### Why?

In the iOS app, context menu delete actions show a white trash icon next to red "Delete" text. The icon should also be red, matching the standard destructive button appearance.

### How?

Replaced `.tint(.white)` on the TabView with `.toolbarColorScheme(.dark, for: .tabBar)`, which scopes the white appearance to just the tab bar without cascading into context menus and overriding the destructive role's red icon color.

<sub>Generated with Claude Code</sub>