### PR TITLE
Fix iOS settings: persist API key indicator and improve defaults

### DIFF
--- a/ios/SnapGrid/SnapGrid/App/SnapGridApp.swift
+++ b/ios/SnapGrid/SnapGrid/App/SnapGridApp.swift
@@ -9,11 +9,19 @@ struct SnapGridApp: App {
     private static let multiSpaceStoreResetKey = "multiSpaceStoreReset_v1"
 
     init() {
-        UserDefaults.standard.register(defaults: [
-            "settings_provider": "anthropic",
+        let defaults = UserDefaults.standard
+        defaults.register(defaults: [
+            "settings_provider": "none",
             "settings_apiKey": "",
-            "settings_model": ""
+            "settings_model": "auto"
         ])
+
+        if !defaults.bool(forKey: "settings_defaults_v2") {
+            if (defaults.string(forKey: "settings_model") ?? "").isEmpty {
+                defaults.set("auto", forKey: "settings_model")
+            }
+            defaults.set(true, forKey: "settings_defaults_v2")
+        }
 
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         let snapGridDir = appSupport.appendingPathComponent("SnapGrid", isDirectory: true)

--- a/ios/SnapGrid/SnapGrid/Resources/Settings.bundle/Root.plist
+++ b/ios/SnapGrid/SnapGrid/Resources/Settings.bundle/Root.plist
@@ -22,7 +22,7 @@
 			<key>Key</key>
 			<string>settings_provider</string>
 			<key>DefaultValue</key>
-			<string>anthropic</string>
+			<string>none</string>
 			<key>Titles</key>
 			<array>
 				<string>None</string>
@@ -66,7 +66,7 @@
 			<key>Key</key>
 			<string>settings_model</string>
 			<key>DefaultValue</key>
-			<string></string>
+			<string>auto</string>
 			<key>KeyboardType</key>
 			<string>Alphabet</string>
 			<key>AutocapitalizationType</key>
@@ -78,7 +78,7 @@
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 			<key>FooterText</key>
-			<string>Leave Model empty to use the default for your provider. Changes sync to the Mac app via iCloud.</string>
+			<string>"auto" uses the recommended model for your provider. You can specify a model name to override. Changes sync via iCloud.</string>
 		</dict>
 	</array>
 </dict>

--- a/ios/SnapGrid/SnapGrid/Services/KeySyncService.swift
+++ b/ios/SnapGrid/SnapGrid/Services/KeySyncService.swift
@@ -14,6 +14,7 @@ enum KeySource: String {
 final class KeySyncService: ObservableObject {
 
     static let shared = KeySyncService()
+    private static let maskedPlaceholder = String(repeating: "•", count: 48)
 
     @Published private(set) var isUnlocked = false
     @Published private(set) var activeProvider: String?
@@ -31,7 +32,7 @@ final class KeySyncService: ObservableObject {
         let defaults = UserDefaults.standard
 
         let sbApiKey = readAndClearSettingsBundleKey(defaults: defaults)
-        let sbProvider = defaults.string(forKey: "settings_provider") ?? "anthropic"
+        let sbProvider = defaults.string(forKey: "settings_provider") ?? "none"
         let sbModel = (defaults.string(forKey: "settings_model") ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let lastSyncedHash = defaults.string(forKey: "settings_lastSyncedKeyHash") ?? ""
 
@@ -90,6 +91,7 @@ final class KeySyncService: ObservableObject {
                 defaults.set(iCloudHash, forKey: "settings_lastSyncedKeyHash")
                 defaults.set(payload.provider, forKey: "settings_provider")
                 defaults.set(payload.model, forKey: "settings_model")
+                defaults.set(Self.maskedPlaceholder, forKey: "settings_apiKey")
                 return
             }
 
@@ -116,7 +118,7 @@ final class KeySyncService: ObservableObject {
     func checkForSettingsKeys() {
         let defaults = UserDefaults.standard
         let sbApiKey = readAndClearSettingsBundleKey(defaults: defaults)
-        let sbProvider = defaults.string(forKey: "settings_provider") ?? "anthropic"
+        let sbProvider = defaults.string(forKey: "settings_provider") ?? "none"
         let sbModel = (defaults.string(forKey: "settings_model") ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard !sbApiKey.isEmpty, sbProvider != "none", AIProvider(rawValue: sbProvider) != nil else {
@@ -144,9 +146,10 @@ final class KeySyncService: ObservableObject {
 
     private func readAndClearSettingsBundleKey(defaults: UserDefaults) -> String {
         let key = (defaults.string(forKey: "settings_apiKey") ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        if !key.isEmpty {
-            defaults.set("", forKey: "settings_apiKey")
+        if key == Self.maskedPlaceholder || key.isEmpty {
+            return ""
         }
+        defaults.set(Self.maskedPlaceholder, forKey: "settings_apiKey")
         return key
     }
 

--- a/ios/SnapGrid/SnapGridTests/KeySyncServiceTests.swift
+++ b/ios/SnapGrid/SnapGridTests/KeySyncServiceTests.swift
@@ -141,6 +141,7 @@ struct KeySyncServiceTests {
         defaults.removeObject(forKey: "settings_provider")
         defaults.removeObject(forKey: "settings_model")
         defaults.removeObject(forKey: "settings_lastSyncedKeyHash")
+        defaults.removeObject(forKey: "settings_defaults_v2")
     }
 
     private func cleanupKeychain() {
@@ -242,5 +243,57 @@ struct KeySyncServiceTests {
 
         #expect(service.isUnlocked == false)
         #expect(service.keySource == .none)
+    }
+
+    @Test("Settings.bundle key is replaced with masked placeholder after read")
+    @MainActor func settingsBundleWritesPlaceholder() async {
+        let defaults = UserDefaults.standard
+        defer { cleanupDefaults(defaults); cleanupKeychain() }
+
+        defaults.set("test-key-xyz", forKey: "settings_apiKey")
+        defaults.set("anthropic", forKey: "settings_provider")
+
+        let service = KeySyncService.shared
+        service.checkForSettingsKeys()
+
+        let remaining = defaults.string(forKey: "settings_apiKey") ?? ""
+        #expect(remaining == String(repeating: "•", count: 48))
+    }
+
+    @Test("Settings.bundle masked placeholder is ignored on subsequent reads")
+    @MainActor func settingsBundlePlaceholderIgnored() async {
+        let defaults = UserDefaults.standard
+        defer { cleanupDefaults(defaults); cleanupKeychain() }
+
+        defaults.set("test-key-abc", forKey: "settings_apiKey")
+        defaults.set("openai", forKey: "settings_provider")
+
+        let service = KeySyncService.shared
+        service.checkForSettingsKeys()
+
+        #expect(service.isUnlocked == true)
+        #expect(service.activeAPIKey() == "test-key-abc")
+
+        let placeholderValue = defaults.string(forKey: "settings_apiKey") ?? ""
+        #expect(placeholderValue == String(repeating: "•", count: 48))
+
+        service.checkForSettingsKeys()
+        #expect(service.isUnlocked == true)
+    }
+
+    @Test("Settings.bundle model 'auto' sets activeModel to auto")
+    @MainActor func settingsBundleAutoModel() async {
+        let defaults = UserDefaults.standard
+        defer { cleanupDefaults(defaults); cleanupKeychain() }
+
+        defaults.set("test-key-123", forKey: "settings_apiKey")
+        defaults.set("anthropic", forKey: "settings_provider")
+        defaults.set("auto", forKey: "settings_model")
+
+        let service = KeySyncService.shared
+        service.checkForSettingsKeys()
+
+        #expect(service.isUnlocked == true)
+        #expect(service.activeModel == "auto")
     }
 }


### PR DESCRIPTION
### Why?

When an API key is set in the iOS Settings.bundle screen, returning to settings shows a blank field — making it look like nothing was saved. The provider defaulted to "Anthropic Claude" even before any key was entered, and the model field was blank with no indication of what would be used.

### How?

After moving the API key to Keychain, write a masked bullet-character placeholder back to UserDefaults so the Settings UI shows a key is configured. Default provider to "None" and model to "auto" for new installs, with a one-time migration for existing users.

<details>
<summary>Implementation Plan</summary>

# Plan: Fix iOS Settings Showing Blank API Key & Default Model to "auto"

## Context

When a user sets an API key in the iOS Settings.bundle screen, then navigates away and comes back, the API key field appears blank — making it seem like nothing was saved. This is because `KeySyncService.readAndClearSettingsBundleKey()` intentionally clears `settings_apiKey` from UserDefaults after reading (for security, moving the real key to Keychain). But the Settings.bundle UI reads from UserDefaults, so it shows empty.

Additionally, the Model field defaults to empty string, giving no indication of what model will be used. The code already supports `"auto"` as a special value that resolves to the provider's default model.

## Changes

### 1. Show masked placeholder after API key is saved

**File:** `ios/SnapGrid/SnapGrid/Services/KeySyncService.swift`

- Add a constant: `private static let maskedPlaceholder = String(repeating: "•", count: 48)`
- Modify `readAndClearSettingsBundleKey()`:
  - If value equals the placeholder → return `""` (no new key to process; placeholder stays in UserDefaults)
  - If value is a real key → write placeholder back to UserDefaults instead of clearing to `""`, then return the real key
  - If value is empty → return `""` as before
- After iCloud sync applies keys, also write the placeholder to `settings_apiKey` so the Settings UI shows a key is configured regardless of source

### 2. Default provider to "none" and model to "auto"

**File:** `ios/SnapGrid/SnapGrid/App/SnapGridApp.swift`

- Change `"settings_provider": "anthropic"` → `"settings_provider": "none"` in `register(defaults:)`
- Change `"settings_model": ""` → `"settings_model": "auto"` in `register(defaults:)`
- Add one-time migration for existing users with empty model field

**File:** `ios/SnapGrid/SnapGrid/Resources/Settings.bundle/Root.plist`

- Change Provider `DefaultValue` from `"anthropic"` to `"none"`
- Change Model `DefaultValue` from `""` to `"auto"`
- Update footer text to explain "auto" uses the recommended model for your provider

**File:** `ios/SnapGrid/SnapGrid/Services/KeySyncService.swift`

- Provider fallback `?? "anthropic"` → `?? "none"` to match new default

### 3. Tests

**File:** `ios/SnapGrid/SnapGridTests/KeySyncServiceTests.swift`
- Add test: placeholder is written back after key read (not empty string)
- Add test: placeholder value is ignored on subsequent reads
- Add test: `"auto"` model sets `activeModel` to `"auto"`
- All 12 existing tests pass unchanged

</details>

<sub>Generated with Claude Code</sub>